### PR TITLE
Add basic heartbeat struct

### DIFF
--- a/lib/heartbeat/heatbeat.go
+++ b/lib/heartbeat/heatbeat.go
@@ -1,0 +1,34 @@
+package heartbeat
+
+import (
+	"fmt"
+)
+
+// Heartbeat is a structure representing activity for a user on a some entity
+type Heartbeat struct {
+	Branch         string     `json:"branch"`
+	Category       Category   `json:"category"`
+	CursorPosition int        `json:"cursorpos"`
+	Dependencies   []string   `json:"dependencies"`
+	Entity         string     `json:"entity"`
+	EntityType     EntityType `json:"type"`
+	IsWrite        bool       `json:"is_write"`
+	Language       string     `json:"language"`
+	LineNumber     int        `json:"lineno"`
+	Lines          int        `json:"lines"`
+	Project        string     `json:"project"`
+	Time           int64      `json:"time"`
+	UserAgent      string     `json:"user_agent"`
+}
+
+func (h Heartbeat) ID() string {
+	return fmt.Sprintf("%d-%s-%s-%s-%s-%s-%t",
+		h.Time,
+		h.EntityType,
+		h.Category,
+		h.Project,
+		h.Branch,
+		h.Entity,
+		h.IsWrite,
+	)
+}

--- a/lib/heartbeat/heatbeat_test.go
+++ b/lib/heartbeat/heatbeat_test.go
@@ -1,0 +1,56 @@
+package heartbeat_test
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/alanhamlett/wakatime-cli/lib/heartbeat"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHeartbeat_ID(t *testing.T) {
+	h := heartbeat.Heartbeat{
+		Branch:     "heartbeat",
+		Category:   heartbeat.CodingCategory,
+		Entity:     "/tmp/main.go",
+		EntityType: heartbeat.FileType,
+		IsWrite:    true,
+		Project:    "wakatime",
+		Time:       1585598060,
+	}
+	assert.Equal(t, "1585598060-file-coding-wakatime-heartbeat-/tmp/main.go-true", h.ID())
+}
+
+func TestHeartbeat_JSON(t *testing.T) {
+	h := heartbeat.Heartbeat{
+		Branch:         "heartbeat",
+		Category:       heartbeat.CodingCategory,
+		CursorPosition: 12,
+		Dependencies:   []string{"dep1", "dep2"},
+		Entity:         "/tmp/main.go",
+		EntityType:     heartbeat.FileType,
+		IsWrite:        true,
+		Language:       "golang",
+		LineNumber:     42,
+		Lines:          100,
+		Project:        "wakatime",
+		Time:           1585598060,
+		UserAgent:      "wakatime/13.0.7",
+	}
+
+	jsonEncoded, err := json.Marshal(h)
+	require.NoError(t, err)
+
+	f, err := os.Open("./testdata/heartbeat.json")
+	require.NoError(t, err)
+	defer f.Close()
+
+	expected, err := ioutil.ReadAll(f)
+	require.NoError(t, err)
+
+	assert.JSONEq(t, string(expected), string(jsonEncoded))
+}

--- a/lib/heartbeat/testdata/heartbeat.json
+++ b/lib/heartbeat/testdata/heartbeat.json
@@ -1,0 +1,15 @@
+{
+	"branch": "heartbeat",
+	"category": "coding",
+	"cursorpos": 12,
+	"dependencies": ["dep1", "dep2"],
+	"entity": "/tmp/main.go",
+	"is_write": true,
+	"language": "golang",
+	"lineno": 42,
+	"lines": 100,
+	"project": "wakatime",
+	"type": "file",
+	"time": 1585598060,
+	"user_agent": "wakatime/13.0.7"
+}


### PR DESCRIPTION
This PR adds a basic heartbeat struct. It includes the most important data, which will be send to API and/or stored in offline queue DB. The struct will be extended by the other logic of the legacy python implementation in subsequent PRs.

_The PR builds on changes in #12, but is ready for review. Base branch will be changed to `master`, once #12 is merged_

Issue: #3 