### PR TITLE
Fix local import paths to consider move between github accounts

### DIFF
--- a/cmd/commands/commands.go
+++ b/cmd/commands/commands.go
@@ -1,10 +1,11 @@
 package commands
 
 import (
+	"github.com/alanhamlett/wakatime-cli/cmd/config"
+	"github.com/alanhamlett/wakatime-cli/cmd/heartbeat"
+	"github.com/alanhamlett/wakatime-cli/cmd/version"
+
 	"github.com/spf13/cobra"
-	"github.com/wakatime/wakatime-cli/cmd/config"
-	"github.com/wakatime/wakatime-cli/cmd/heartbeat"
-	"github.com/wakatime/wakatime-cli/cmd/version"
 )
 
 // AddCommands adds all the commands to the root command

--- a/cmd/config/read.go
+++ b/cmd/config/read.go
@@ -3,8 +3,9 @@ package config
 import (
 	"fmt"
 
+	"github.com/alanhamlett/wakatime-cli/lib/configs"
+
 	"github.com/spf13/cobra"
-	"github.com/wakatime/wakatime-cli/lib/configs"
 )
 
 type readOptions struct {

--- a/cmd/config/write.go
+++ b/cmd/config/write.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/alanhamlett/wakatime-cli/lib/configs"
+
 	"github.com/spf13/cobra"
-	"github.com/wakatime/wakatime-cli/lib/configs"
 )
 
 type writeOptions struct {

--- a/cmd/heartbeat/cmd.go
+++ b/cmd/heartbeat/cmd.go
@@ -11,11 +11,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/alanhamlett/wakatime-cli/constants"
+	"github.com/alanhamlett/wakatime-cli/lib/arguments"
+	"github.com/alanhamlett/wakatime-cli/lib/configs"
+
 	"github.com/beevik/guid"
 	"github.com/spf13/cobra"
-	"github.com/wakatime/wakatime-cli/constants"
-	"github.com/wakatime/wakatime-cli/lib/arguments"
-	"github.com/wakatime/wakatime-cli/lib/configs"
 )
 
 // NewHeartbeatCommand returns a cobra command for `heartbeat` subcommands

--- a/cmd/heartbeat/heatbeat.go
+++ b/cmd/heartbeat/heatbeat.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/wakatime/wakatime-cli/lib/utils"
+	"github.com/alanhamlett/wakatime-cli/lib/utils"
 )
 
 // Heartbeat Heartbeat structure

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/wakatime/wakatime-cli/cmd/commands"
+	"github.com/alanhamlett/wakatime-cli/cmd/commands"
 
 	"github.com/spf13/cobra"
 )

--- a/cmd/version/cmd.go
+++ b/cmd/version/cmd.go
@@ -3,8 +3,9 @@ package version
 import (
 	"fmt"
 
+	"github.com/alanhamlett/wakatime-cli/constants"
+
 	"github.com/spf13/cobra"
-	"github.com/wakatime/wakatime-cli/constants"
 )
 
 // NewVersionCommand returns a cobra command for `version` subcommands

--- a/lib/arguments/arguments.go
+++ b/lib/arguments/arguments.go
@@ -4,7 +4,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/wakatime/wakatime-cli/lib/configs"
+	"github.com/alanhamlett/wakatime-cli/lib/configs"
 )
 
 // GetBooleanOrList Get a boolean or list of regexes from args and configs

--- a/lib/configs/configs.go
+++ b/lib/configs/configs.go
@@ -5,10 +5,11 @@ import (
 	"os"
 	"path"
 
+	"github.com/alanhamlett/wakatime-cli/constants"
+	"github.com/alanhamlett/wakatime-cli/lib/system"
+
 	"github.com/go-ini/ini"
 	"github.com/mitchellh/go-homedir"
-	"github.com/wakatime/wakatime-cli/constants"
-	"github.com/wakatime/wakatime-cli/lib/system"
 )
 
 // ConfigFile ConfigFile

--- a/lib/project/project.go
+++ b/lib/project/project.go
@@ -3,9 +3,9 @@ package project
 import (
 	"strings"
 
-	"github.com/wakatime/wakatime-cli/lib/configs"
-	"github.com/wakatime/wakatime-cli/lib/scm"
-	"github.com/wakatime/wakatime-cli/lib/utils"
+	"github.com/alanhamlett/wakatime-cli/lib/configs"
+	"github.com/alanhamlett/wakatime-cli/lib/scm"
+	"github.com/alanhamlett/wakatime-cli/lib/utils"
 )
 
 // Project Project interface

--- a/lib/project/project_file.go
+++ b/lib/project/project_file.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"strings"
 
-	"github.com/wakatime/wakatime-cli/lib/utils"
+	"github.com/alanhamlett/wakatime-cli/lib/utils"
 )
 
 // ProjectFile Information from a .wakatime-project file about the project for

--- a/lib/scm/git.go
+++ b/lib/scm/git.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/wakatime/wakatime-cli/lib/utils"
+	"github.com/alanhamlett/wakatime-cli/lib/utils"
 )
 
 // Git Information about the git project for a given file.

--- a/lib/utils/utils.go
+++ b/lib/utils/utils.go
@@ -7,8 +7,8 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/wakatime/wakatime-cli/constants"
-	"github.com/wakatime/wakatime-cli/lib/system"
+	"github.com/alanhamlett/wakatime-cli/constants"
+	"github.com/alanhamlett/wakatime-cli/lib/system"
 )
 
 // GetUserAgent Get user agent

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/wakatime/wakatime-cli/cmd"
+	"github.com/alanhamlett/wakatime-cli/cmd"
 )
 
 func main() {


### PR DESCRIPTION
Description:


Go imports of packages from within the repo always contain the full path including github account. As the repo was moved from `wakatime` to `alanhamlett` account, all local import paths have to be adjusted.
 
List of Changes:

- Adjust all local import paths to include `alanhamlett` account.

