### PR TITLE
Send heartbeats bulk to wakatime API

### DIFF
--- a/lib/api/response.go
+++ b/lib/api/response.go
@@ -2,10 +2,14 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"net/http"
+	"strings"
 )
 
 type Result struct {
+	Errors    []string
 	Status    int
 	Heartbeat Heartbeat
 }
@@ -22,23 +26,85 @@ func parseResults(data []byte) ([]Result, error) {
 
 	var results []Result
 	for _, r := range responseBody.Responses {
-		type heartbeatData struct {
-			Data *Heartbeat `json:"data"`
-		}
-
-		var result Result
-		err := json.Unmarshal(r[0], &heartbeatData{Data: &result.Heartbeat})
+		result, err := parseResult(r)
 		if err != nil {
-			return nil, fmt.Errorf("failed json unmarshal heartbeat: %s", err)
-		}
-
-		err = json.Unmarshal(r[1], &result.Status)
-		if err != nil {
-			return nil, fmt.Errorf("failed json unmarshal status: %s", err)
+			return nil, fmt.Errorf("failed parsing result: %s", err)
 		}
 
 		results = append(results, result)
 	}
 
 	return results, nil
+}
+
+// response is used to parse heartbeat responses from the send heartbeats bulk response body
+// response body examples:
+//   - ./testdata/api_heartbeats_response.json
+//   - ./testdata/api_heartbeats_response_error.json
+type response struct {
+	Error  *string              `json:"error"`
+	Errors *map[string][]string `json:"errors"`
+	Data   *Heartbeat           `json:"data"`
+}
+
+func parseResult(data []json.RawMessage) (Result, error) {
+	var result Result
+	err := json.Unmarshal(data[1], &result.Status)
+	if err != nil {
+		return Result{}, fmt.Errorf("failed json unmarshal status: %s", err)
+	}
+
+	if result.Status == http.StatusBadRequest {
+		resultErrors, err := parseResultErrors(data[0])
+		if err != nil {
+			return Result{}, fmt.Errorf("failed parsing result errors: %s", err)
+		}
+
+		result.Errors = resultErrors
+		return result, nil
+	}
+
+	err = json.Unmarshal(data[0], &response{Data: &result.Heartbeat})
+	if err != nil {
+		return Result{}, fmt.Errorf("failed json unmarshal heartbeat: %s", err)
+	}
+
+	return result, nil
+}
+
+func parseResultErrors(data json.RawMessage) ([]string, error) {
+	var errs []string
+
+	// 1. try "error" key
+	var resultError string
+	err := json.Unmarshal(data, &response{Error: &resultError})
+	if err != nil {
+		return nil, fmt.Errorf("failed json unmarshal heartbeat error: %s", err)
+	}
+
+	if resultError != "" {
+		errs = append(errs, resultError)
+		return errs, nil
+	}
+
+	// 2. try "errors" key
+	var resultErrors map[string][]string
+	err = json.Unmarshal(data, &response{Errors: &resultErrors})
+	if err != nil {
+		return nil, fmt.Errorf("failed json unmarshal heartbeat errors: %s", err)
+	}
+
+	if resultErrors == nil {
+		return nil, errors.New("failed to detect any errors despite invalid response status")
+	}
+
+	for field, messages := range resultErrors {
+		errs = append(errs, fmt.Sprintf(
+			"%s: %s",
+			field,
+			strings.Join(messages, " "),
+		))
+	}
+
+	return errs, nil
 }

--- a/lib/api/testdata/api_heartbeats_response_error.json
+++ b/lib/api/testdata/api_heartbeats_response_error.json
@@ -1,0 +1,23 @@
+{
+    "responses": [
+        [
+            {
+                "errors": {
+                    "lineno": [
+                        "Number must be between 1 and 2147483647."
+                    ],
+                    "time": [
+                        "This field is required."
+                    ]
+                }
+            },
+            400
+        ],
+        [
+            {
+                "error": "Can not log time before user was created."
+            },
+            400
+        ]
+    ]
+}


### PR DESCRIPTION
Description:

Heartbeats have to be send to the wakatime API to track a users time. 

- `get_time_today` method from https://github.com/wakatime/wakatime/blob/master/wakatime/api.py#L165 will be added in subsequent PR
- `User agent`: Is passed into `SendHeartbeats` method via config argument. Creation of user agent string itself (from plugin arg) will happen outside of `api.Client`
- `Request timeout`: Will be set on the `http.client`, outside of the `api.Client`
- `Offline queue`: All offline queue handling will happen outside of `api.Client` and will happen based on results returned by api client.
- `SSL certs`: Will be set via `http.Transport` on `http.Client`, outside of `api.Client`
- `NTLM`: Usage of NTLM proxy and it's authentication is prepared by flexible basic auth config. (see commit `Add flexible auth config, which can be used for api key and ntlm auth`). NTLM handling will be done with:  https://github.com/Azure/go-ntlmssp
- `Logging` is done via simple `log.Printf()` statements. These do not support log levels, but I wanted to skip the logging topic for now. We should adjust later, after we agreed on a concrete logging approach.

As confirmed by @alanhamlett via slack:

- `Timezone` header: Will not be sent in first version
- `Session cache`: Will not be included into 1st version

List of Changes:

- Add client for sending heartbeats to the wakatime API.

Issue: https://github.com/alanhamlett/wakatime-cli/issues/7

