### PR TITLE
Package structure draft

### DIFF
--- a/draft/structure.md
+++ b/draft/structure.md
@@ -14,27 +14,74 @@ wakatime-cli/
                 type Client struct {}
                 func NewClient(baseURL string, client *http.Client, opts ...Option)
                 func (c *Client) Send(hh []heartbeat.Heartbeat, hostName, userAgent string) ([]heartbeat.SendResult, error)
-                func (c *Client) SummaryToday(userAgent string) ([]heartbeat.Summary, error)
-        arguemnts/
-            arguemnts.go
+                func (c *Client) Summaries(start, end time.Time, userAgent string) ([]heartbeat.Summary, error)
+        arguments/
+            arguments.go
                 type Args struct {}
         config/
             config.go
                 type Config struct {}
-        file/
-            file.go
-                type Stats struct {}
-                func Info(filepath string) (Stats, error)
+        deps/
+            deps.go
+                type Config stuct {
+                    LocalFile string
+                }
+                Detect(c Config) heartbeat.SenderOption
+                func detect(filepath, language string) (deps []string, err error)
+                type sender struct {}
+                func (d *sender) Send(hh []heartbeat.Heartbeat, hostName, userAgent string) ([]heartbeat.SendResult, error)
+        filestats/
+            filestats.go
+                type Config stuct {
+                    LocalFile string
+                }
+                Detect(c Config) heartbeat.SenderOption
+                func detect(filepath string) (lines int, err error)
+                type sender struct {}
+                func (d *sender) Send(hh []heartbeat.Heartbeat, hostName, userAgent string) ([]heartbeat.SendResult, error)
         heartbeat/
             heartbeat.go
                 type Heartbeat struct {}
-                type Summary struct {}
                 type SendResult struct {}
+                type Summary struct {}
                 type Sender interface {
                     Send(hh []Heartbeat, hostName, userAgent string) ([]SendResult, error)
                 }
+                SenderOption func(Sender) Sender
+                func NewSender(sender, ...[]SenderOption) Sender
             sanitize.go
-                func Sanitize(h Heartbeat, obfuscate Obfuscate) Heartbeat
+                type SanitizeConfig stuct {
+                    HideBranchNames []*regexp.Regexp
+                    HideFileNames []*regexp.Regexp
+                    HideProjectNames []*regexp.Regexp
+                }
+                Sanitize(c SanitizeConfig) heartbeat.SenderOption
+                func sanitize(h Heartbeat, obfuscate Obfuscate) Heartbeat
+                type sanitizeSender struct {}
+                func (s *sanitizeSender) Send(hh []heartbeat.Heartbeat, hostName, userAgent string) ([]heartbeat.SendResult, error)
+            validate.go
+                type ValidateConfig stuct {
+                    Exclude []*regexp.Regexp
+                    ExcludeUnknownProject bool
+                    Include []*regexp.Regexp
+                    IncludeOnlyWithProjectFile bool
+                }
+                Validate(c ValidateConfig) heartbeat.SenderOption
+                func validateByPattern(entity string, include, exclude []*regexp.Regexp) error
+                func validateFile(filepath string, includeOnlyWithProjectFile bool) error
+                type validateSender struct {}
+                func (v *validateSender) Send(hh []heartbeat.Heartbeat, hostName, userAgent string) ([]heartbeat.SendResult, error)
+        language/
+            language.go
+                type Config stuct {
+                    Alternative string
+                    Overwrite string
+                    LocalFile string
+                }
+                Detect(c Config) heartbeat.SenderOption
+                func detect(filepath string) (language string, err error)
+                type sender struct {}
+                func (d *sender) Send(hh []heartbeat.Heartbeat, hostName, userAgent string) ([]heartbeat.SendResult, error)
         log/
             log.go
                 type LogLevel int32
@@ -43,17 +90,21 @@ wakatime-cli/
                 func Fatalf(msg string, args ...interface{})
         offline/
             offline.go
-                type Queue struct {}
-                func (q *Queue) Send(hh []heartbeat.Heartbeat, hostName, userAgent string) ([]heartbeat.SendResult, error) 
-                func WithQueue(s heartbeat.Sender, c Config) *Queue
+                func Queue(filepath, table string) heartbeat.SenderOption
+                type sender struct {}
+                func (q *sender) Send(hh []heartbeat.Heartbeat, hostName, userAgent string) ([]heartbeat.SendResult, error)
         project/
             project.go
-                func Info(filepath string) (project, branch string, err error)
-                func InfoWithPlugin(filepath string, plugin Plugin) (project, branch string, err error)
-        validate/
-            validate.go
-                func ByPattern(entity string, include, exclude []*regexp.Regexp) error
-                func File(filepath string, includeOnlyWithProjectFile bool) error
+                type Config stuct {
+                    Alternative string
+                    Overwrite string
+                    LocalFile string
+                }
+                Detect(c Config) heartbeat.SenderOption
+                func detect(filepath string) (project, branch string, err error)
+                func detectWithPlugin(filepath string, plugin Plugin) (project, branch string, err error)
+                type sender struct {}
+                func (s *sender) Send(hh []heartbeat.Heartbeat, hostName, userAgent string) ([]heartbeat.SendResult, error)
     go.mod
     go.sum
     main.go


### PR DESCRIPTION
**Description:**

This PR defines a package structure for the wakatime-cli repo and it's main data structures/interfaces/functions. The additional `main.go` example demonstrates how these packages will be used together.

**Motivation**

The motivation is to reach rough consensus on the repo layout. If we agree on this beforehand, parallel work on the repo by mulitple developers will be easier to coordinate. Problems (e.g. import cycles) when plugging the different packages  together later, will be less likely.

**WIP**

There are some blank spots still (e.g. `/cmd` folder) and  packages like `file`, `config` and `args` could be defined more detailed. But this can be added later and we can also keep this PR open and extend it along the progressing development process. 

Filenames are secondary and code can also be separated in multiple files within one repo. The package layout and the data structures/interfaces/functions are most important here.
 
**List of Changes:**

- Add repo structure file
- Add main example

