### PR TITLE
Package structure draft

### DIFF
--- a/draft/structure.md
+++ b/draft/structure.md
@@ -3,7 +3,7 @@ wakatime-cli/
         legacy/
             config.go
             heartbeat.go
-            legacy.go
+            run.go
             today.go
             version.go
         root.go
@@ -29,64 +29,51 @@ wakatime-cli/
                 func (c *Client) Summaries(startDate, endDate time.Time) ([]summary.Summary, error)
         deps/
             deps.go
-                type Config stuct {
-                    LocalFile string
-                }
-                Detect(c Config) heartbeat.SenderOption
+                WithDetection() heartbeat.SenderOption
+                WithDetectionOnFile(filepath string) heartbeat.SenderOption
                 func detect(filepath, language string) (deps []string, err error)
-                type sender struct {}
-                func (s *sender) Send(hh []heartbeat.Heartbeat) ([]heartbeat.SendResult, error)
         filestats/
             filestats.go
-                type Config stuct {
-                    LocalFile string
-                }
-                Detect(c Config) heartbeat.SenderOption
+                WithDetection() heartbeat.HandleOption
+                WithDetectionOnFile(filepath string) heartbeat.SenderOption
                 func detect(filepath string) (lines int, err error)
-                type sender struct {}
-                func (s *sender) Send(hh []heartbeat.Heartbeat) ([]heartbeat.SendResult, error)
         heartbeat/
             heartbeat.go
                 type Heartbeat struct {}
-                type SendResult struct {}
+                type Result struct {}
                 type Sender interface {
-                    Send(hh []Heartbeat) ([]SendResult, error)
+                    Send(hh []Heartbeat) ([]Result, error)
                 }
-                SenderOption func(Sender) Sender
-                func NewSender(sender, ...SenderOption) Sender
+                type Handle func(hh []Heartbeat) ([]Result, error)
+                HandleOption func(Handle) Handle
+                func NewHandle(Sender, ...HandleOption) Handle
             sanitize.go
-                type SanitizeConfig stuct {
+                type SanitizeConfig struct {
                     HideBranchNames []*regexp.Regexp
                     HideFileNames []*regexp.Regexp
                     HideProjectNames []*regexp.Regexp
                 }
-                Sanitize(c SanitizeConfig) heartbeat.SenderOption
+                WithSanitization(c SanitizeConfig) heartbeat.SenderOption
                 func sanitize(h Heartbeat, obfuscate Obfuscate) Heartbeat
-                type sanitizeSender struct {}
-                func (s *sanitizeSender) Send(hh []heartbeat.Heartbeat) ([]heartbeat.SendResult, error)
             validate.go
-                type ValidateConfig stuct {
+                type ValidateConfig struct {
                     Exclude []*regexp.Regexp
                     ExcludeUnknownProject bool
                     Include []*regexp.Regexp
                     IncludeOnlyWithProjectFile bool
                 }
-                Validate(c ValidateConfig) heartbeat.SenderOption
+                WithValidation(c ValidateConfig) heartbeat.SenderOption
                 func validateByPattern(entity string, include, exclude []*regexp.Regexp) error
                 func validateFile(filepath string, includeOnlyWithProjectFile bool) error
-                type validateSender struct {}
-                func (s *validateSender) Send(hh []heartbeat.Heartbeat) ([]heartbeat.SendResult, error)
         language/
             language.go
-                type Config stuct {
+                type Config struct {
                     Alternative string
                     Overwrite string
                     LocalFile string
                 }
-                Detect(c Config) heartbeat.SenderOption
+                WithDetection(c Config) heartbeat.SenderOption
                 func detect(filepath string) (language string, err error)
-                type sender struct {}
-                func (s *sender) Send(hh []heartbeat.Heartbeat) ([]heartbeat.SendResult, error)
         log/
             log.go
                 type LogLevel int32
@@ -95,21 +82,17 @@ wakatime-cli/
                 func Fatalf(msg string, args ...interface{})
         offline/
             offline.go
-                func Queue(filepath, table string) heartbeat.SenderOption
-                type sender struct {}
-                func (s *sender) Send(hh []heartbeat.Heartbeat) ([]heartbeat.SendResult, error)
+                func WithQueue(filepath, table string) heartbeat.SenderOption
         project/
             project.go
-                type Config stuct {
+                type Config struct {
                     Alternative string
                     Overwrite string
                     LocalFile string
                 }
-                Detect(c Config) heartbeat.SenderOption
+                WithDetection(c Config) heartbeat.SenderOption
                 func detect(filepath string) (project, branch string, err error)
                 func detectWithPlugin(filepath string, plugin Plugin) (project, branch string, err error)
-                type sender struct {}
-                func (s *sender) Send(hh []heartbeat.Heartbeat) ([]heartbeat.SendResult, error)
         summary/
             summary.go
                 type Summary struct {}


### PR DESCRIPTION
This PR is an updated version of https://github.com/alanhamlett/wakatime-cli/pull/21 on a clean master.

**Description**

This PR defines a package structure for the `wakatime-cli` repo and it's main data structures/interfaces/functions. The additional `main.go` example demonstrates how these packages will be used together. Mind that `main.go` represents an usage example for the packages and some details (e.g. `args` object for arguments) are simplified and not final.

**Motivation**

The motivation is to reach rough consensus on the repo layout. If we agree on this beforehand, parallel work on the repo by mulitple developers will be easier to coordinate. Problems (e.g. import cycles) when plugging the different packages together later, will be less likely.

@gandarez Please check structure in depth and come forward with all questions that you have. If we merge it, it will serve as a plan, guiding our work towards `wakatime-cli v1`.

List of Changes:

    Add repo structure file
    Add main example
