### PR TITLE
Add vipertools package

### DIFF
--- a/pkg/vipertools/vipertools.go
+++ b/pkg/vipertools/vipertools.go
@@ -1,0 +1,39 @@
+package vipertools
+
+import (
+	"github.com/spf13/viper"
+)
+
+// FirstNonEmptyInt accepts multiple keys and returns the first non empty int value
+// from viper.Viper via these keys. Non-empty meaning 0 value will not be accepted.
+// Will return false as second parameter, if non-empty int value could not be retrieved.
+func FirstNonEmptyInt(v *viper.Viper, keys ...string) (int, bool) {
+	if v == nil {
+		return 0, false
+	}
+
+	for _, key := range keys {
+		if value := v.GetInt(key); value != 0 {
+			return value, true
+		}
+	}
+
+	return 0, false
+}
+
+// FirstNonEmptyString accepts multiple keys and returns the first non empty string value
+// from viper.Viper via these keys. Non-empty meaning "" value will not be accepted.
+// Will return false as second parameter, if non-empty string value could not be retrieved.
+func FirstNonEmptyString(v *viper.Viper, keys ...string) (string, bool) {
+	if v == nil {
+		return "", false
+	}
+
+	for _, key := range keys {
+		if value := v.GetString(key); value != "" {
+			return value, true
+		}
+	}
+
+	return "", false
+}

--- a/pkg/vipertools/vipertools_test.go
+++ b/pkg/vipertools/vipertools_test.go
@@ -1,0 +1,78 @@
+package vipertools_test
+
+import (
+	"testing"
+
+	"github.com/wakatime/wakatime-cli/pkg/vipertools"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFirstNonEmptyInt(t *testing.T) {
+	v := viper.New()
+	v.Set("second", 42)
+	v.Set("third", 99)
+
+	value, ok := vipertools.FirstNonEmptyInt(v, "first", "second", "third")
+	require.True(t, ok)
+
+	assert.Equal(t, 42, value)
+}
+
+func TestFirstNonEmptyInt_NilPointer(t *testing.T) {
+	_, ok := vipertools.FirstNonEmptyInt(nil, "first")
+	assert.False(t, ok)
+}
+
+func TestFirstNonEmptyInt_EmptyKeys(t *testing.T) {
+	v := viper.New()
+	_, ok := vipertools.FirstNonEmptyInt(v)
+	assert.False(t, ok)
+}
+
+func TestFirstNonEmptyInt_NotFound(t *testing.T) {
+	_, ok := vipertools.FirstNonEmptyInt(viper.New(), "key")
+	assert.False(t, ok)
+}
+
+func TestFirstNonEmptyInt_EmptyInt(t *testing.T) {
+	v := viper.New()
+	v.Set("first", 0)
+	_, ok := vipertools.FirstNonEmptyInt(v, "first")
+	assert.False(t, ok)
+}
+
+func TestFirstNonEmptyInt_StringValue(t *testing.T) {
+	v := viper.New()
+	v.Set("first", "stringvalue")
+	_, ok := vipertools.FirstNonEmptyInt(v, "first")
+	assert.False(t, ok)
+}
+
+func TestFirstNonEmptyString(t *testing.T) {
+	v := viper.New()
+	v.Set("second", "secret")
+	v.Set("third", "ignored")
+
+	value, ok := vipertools.FirstNonEmptyString(v, "first", "second", "third")
+	require.True(t, ok)
+	assert.Equal(t, "secret", value)
+}
+
+func TestFirstNonEmptyString_NilPointer(t *testing.T) {
+	_, ok := vipertools.FirstNonEmptyString(nil, "first")
+	assert.False(t, ok)
+}
+
+func TestFirstNonEmptyString_EmptyKeys(t *testing.T) {
+	v := viper.New()
+	_, ok := vipertools.FirstNonEmptyString(v)
+	assert.False(t, ok)
+}
+
+func TestFirstNonEmptyString_NotFound(t *testing.T) {
+	_, ok := vipertools.FirstNonEmptyString(viper.New(), "key")
+	assert.False(t, ok)
+}


### PR DESCRIPTION
This PR moves functions `firstNonEmptyInt` and `firstNonEmptyString` to a distinct package `vipertools`, as these will be used in multiple other places (e.g. `cmd/legacy/today`, `cmd/legacy/heartbeat`.

- This is a preparation for `cmd/legacy/heartbeat` implementation.
- Includes minor cleanup in `cmd/legacy/today`, where functions were used so far.