### PR TITLE
add missing test case for logfile

### DIFF
--- a/cmd/legacy/logfile/logfile_test.go
+++ b/cmd/legacy/logfile/logfile_test.go
@@ -27,6 +27,9 @@ func TestLoadParams(t *testing.T) {
 
 	defer os.Remove(filepath.Join(dir, ".wakatime.log"))
 
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+
 	tests := map[string]struct {
 		ViperLogFile       string
 		ViperLogFileConfig string
@@ -59,6 +62,11 @@ func TestLoadParams(t *testing.T) {
 			EnvVar: dir,
 			Expected: logfile.Params{
 				File: filepath.Join(dir, ".wakatime.log"),
+			},
+		},
+		"log file from home dir": {
+			Expected: logfile.Params{
+				File: filepath.Join(home, ".wakatime.log"),
 			},
 		},
 	}


### PR DESCRIPTION
This PR adds a missing test case for `logfile package`. It also tests the default path for `.wakatime.log`.