### PR TITLE
Fix command handling

### DIFF
--- a/cmd/legacy/run.go
+++ b/cmd/legacy/run.go
@@ -39,21 +39,25 @@ func Run(v *viper.Viper) {
 		os.Exit(exitcode.ErrDefault)
 	}
 
-	if v.GetString("config-read") != "" {
+	if v.IsSet("config-read") {
 		jww.DEBUG.Println("command: config-read")
 
 		configread.Run(v)
 	}
 
-	if v.GetStringMapString("config-write") != nil {
+	if v.IsSet("config-write") {
 		jww.DEBUG.Println("command: config-write")
 
 		configwrite.Run(v)
 	}
 
 	if v.GetBool("today") {
+		jww.DEBUG.Println("command: today")
+
 		today.Run(v)
 	}
+
+	jww.DEBUG.Println("command: heartbeat")
 
 	heartbeat.Run(v)
 }


### PR DESCRIPTION
This PR fixes the main command handling. Instead of comparing against empty string, we should to check if flags are set. Before the script was always executing `config-write` command and never reached `today` or `heartbeat`

 