### PR TITLE
Add offline queue implementation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/matishsiao/goInfo v0.0.0-20200404012835-b5f882ee2288
+	github.com/mattn/go-sqlite3 v1.14.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/slongfield/pyfmt v0.0.0-20180124071345-020a7cb18bca
 	github.com/spf13/cobra v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,10 @@ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/PuerkitoBio/goquery v1.5.1/go.mod h1:GsLWisAFVj4WgDibEWF4pvYnkVQBpKBKeU+7zCJoLcc=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/andybalholm/cascadia v1.1.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
@@ -121,6 +123,8 @@ github.com/matishsiao/goInfo v0.0.0-20200404012835-b5f882ee2288 h1:cdM7et8/VlNnS
 github.com/matishsiao/goInfo v0.0.0-20200404012835-b5f882ee2288/go.mod h1:yLZrFIhv+Z20hxHvcZpEyKVQp9HMsOJkXAxx7yDqtvg=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
+github.com/mattn/go-sqlite3 v1.14.0 h1:mLyGNKR8+Vv9CAU7PphKa2hkEqxxhn8i32J6FPj1/QA=
+github.com/mattn/go-sqlite3 v1.14.0/go.mod h1:JIl7NbARA7phWnGvh0LKTyg7S9BA+6gx71ShQilpsus=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
@@ -229,6 +233,7 @@ golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
 golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=
+golang.org/x/net v0.0.0-20180218175443-cbe0f9307d01/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181023162649-9b4f9f5ad519/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -244,6 +249,8 @@ golang.org/x/net v0.0.0-20190503192946-f4e77d36d62c/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190522155817-f3200d17e092/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -266,6 +273,8 @@ golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0 h1:HyfiK1WMnHj5FXFXatD+Qs1A/xC2Run6RzeW1SyHxpc=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
+golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=

--- a/pkg/heartbeat/heartbeat.go
+++ b/pkg/heartbeat/heartbeat.go
@@ -26,6 +26,34 @@ type Heartbeat struct {
 	UserAgent      string     `json:"user_agent"`
 }
 
+// ID returns an ID generated from the heartbeat data.
+func (h Heartbeat) ID() string {
+	var branch string
+	if h.Branch != nil {
+		branch = *h.Branch
+	}
+
+	var project string
+	if h.Project != nil {
+		project = *h.Project
+	}
+
+	var isWrite bool
+	if h.IsWrite != nil {
+		isWrite = *h.IsWrite
+	}
+
+	return fmt.Sprintf("%f-%s-%s-%s-%s-%s-%t",
+		h.Time,
+		h.EntityType,
+		h.Category,
+		project,
+		branch,
+		h.Entity,
+		isWrite,
+	)
+}
+
 // Result represents a response from the wakatime api.
 type Result struct {
 	Errors    []string

--- a/pkg/heartbeat/heartbeat_test.go
+++ b/pkg/heartbeat/heartbeat_test.go
@@ -12,6 +12,29 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestHeartbeat_ID(t *testing.T) {
+	h := heartbeat.Heartbeat{
+		Branch:     heartbeat.String("heartbeat"),
+		Category:   heartbeat.CodingCategory,
+		Entity:     "/tmp/main.go",
+		EntityType: heartbeat.FileType,
+		IsWrite:    heartbeat.Bool(true),
+		Project:    heartbeat.String("wakatime"),
+		Time:       1592868313.541149,
+	}
+	assert.Equal(t, "1592868313.541149-file-coding-wakatime-heartbeat-/tmp/main.go-true", h.ID())
+}
+
+func TestHeartbeat_ID_NilFields(t *testing.T) {
+	h := heartbeat.Heartbeat{
+		Category:   heartbeat.CodingCategory,
+		Entity:     "/tmp/main.go",
+		EntityType: heartbeat.FileType,
+		Time:       1592868313.541149,
+	}
+	assert.Equal(t, "1592868313.541149-file-coding---/tmp/main.go-false", h.ID())
+}
+
 func TestHeartbeat_JSON(t *testing.T) {
 	h := heartbeat.Heartbeat{
 		Branch:         heartbeat.String("heartbeat"),

--- a/pkg/offline/offline.go
+++ b/pkg/offline/offline.go
@@ -4,21 +4,112 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"net/http"
 
 	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
+
+	jww "github.com/spf13/jwalterweatherman"
 )
 
 const (
 	tableName = "heartbeat_2"
 )
 
+// WithQueue initializes and returns a heartbeat handle option, which can be
+// used in a heartbeat processing pipeline for automatic handling of failures
+// of heartbeat sending to the API. Upon inability to send due to missing or
+// failing connection to API, failed sending or errors returned by API, the
+// heartbeats will be temporarily stored in a sqlite DB and sending will be
+// retried at next usages of the wakatime cli.
+func WithQueue(filepath string, syncLimit int) (heartbeat.HandleOption, error) {
+	conn, err := sql.Open("sqlite3", filepath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open db connection: %s", err)
+	}
+
+	_, err = conn.Exec(fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (id TEXT, heartbeat TEXT)", tableName))
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize db: %s", err)
+	}
+
+	return func(next heartbeat.Handle) heartbeat.Handle {
+		return func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+			// start transaction
+			tx, err := conn.Begin()
+			if err != nil {
+				jww.ERROR.Fatalf("failed to start offline queue db transaction: %s", err)
+				return next(hh)
+			}
+			// nolint
+			defer tx.Rollback()
+
+			queue := NewQueue(tx)
+
+			queued, err := queue.PopMany(syncLimit)
+			if err != nil {
+				jww.ERROR.Fatalf("failed to pop heartbeat(s) from offline queue: %s", err)
+			}
+
+			if len(queued) > 0 {
+				jww.DEBUG.Printf("include %d heartbeat(s) from offline queue", len(queued))
+				hh = append(hh, queued...)
+			}
+
+			results, err := next(hh)
+			if err != nil {
+				jww.DEBUG.Printf("api error: %s", err)
+				jww.DEBUG.Printf("pushing %d heartbeat(s) to offline queue", len(hh))
+
+				// push to queue on any err
+				queueErr := queue.PushMany(hh)
+				if queueErr != nil {
+					jww.ERROR.Fatalf("failed to push heartbeat(s) to queue: %s", queueErr)
+				}
+
+				// commit transaction
+				if err := tx.Commit(); err != nil {
+					jww.ERROR.Fatalf("failed to commit offline queue db transaction: %s", err)
+				}
+
+				return nil, err
+			}
+
+			for _, result := range results {
+				// push to queue on invalid result status codes
+				if result.Status != http.StatusCreated &&
+					result.Status != http.StatusAccepted &&
+					result.Status != http.StatusBadRequest {
+					queueErr := queue.PushMany([]heartbeat.Heartbeat{result.Heartbeat})
+					if queueErr != nil {
+						jww.ERROR.Fatalf("failed to push invalid result heartbeat to queue: %s", queueErr)
+					}
+				}
+			}
+
+			// commit transaction
+			if err = tx.Commit(); err != nil {
+				jww.ERROR.Fatalf("failed to commit offline queue db transaction: %s", err)
+			}
+
+			return results, nil
+		}
+	}, nil
+}
+
+// DB is a minimal database connection interface satisfied by both sql.DB and sql.Tx.
+type DB interface {
+	Exec(query string, args ...interface{}) (sql.Result, error)
+	Prepare(query string) (*sql.Stmt, error)
+	Query(query string, args ...interface{}) (*sql.Rows, error)
+}
+
 // Queue is a queue to temporarily store heartbeats.
 type Queue struct {
-	conn *sql.DB
+	conn DB
 }
 
 // NewQueue creates a new Queue instance.
-func NewQueue(conn *sql.DB) *Queue {
+func NewQueue(conn DB) *Queue {
 	return &Queue{
 		conn: conn,
 	}
@@ -85,6 +176,7 @@ func (q *Queue) PopMany(limit int) ([]heartbeat.Heartbeat, error) {
 		ids = append(ids, id)
 
 		var h heartbeat.Heartbeat
+
 		err = json.Unmarshal([]byte(data), &h)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse heartbeat json data: %s", err)

--- a/pkg/offline/offline.go
+++ b/pkg/offline/offline.go
@@ -1,0 +1,57 @@
+package offline
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+
+	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
+)
+
+const (
+	tableName = "heartbeat_2"
+)
+
+// Queue is a queue to temporarily store heartbeats.
+type Queue struct {
+	conn *sql.DB
+}
+
+// NewQueue creates a new Queue instance.
+func NewQueue(conn *sql.DB) *Queue {
+	return &Queue{
+		conn: conn,
+	}
+}
+
+// PushMany adds multiple heartbeats to the queue.
+func (q *Queue) PushMany(hh []heartbeat.Heartbeat) error {
+	stmt, err := q.conn.Prepare(fmt.Sprintf("INSERT INTO %s VALUES ($1, $2);", tableName))
+	if err != nil {
+		return fmt.Errorf("failed to prepare db statement: %s", err)
+	}
+	defer stmt.Close()
+
+	for _, h := range hh {
+		data, err := json.Marshal(h)
+		if err != nil {
+			return fmt.Errorf("failed to json encode heartbeat: %s", err)
+		}
+
+		result, err := stmt.Exec(h.ID(), data)
+		if err != nil {
+			return fmt.Errorf("failed to execute db query: %s", err)
+		}
+
+		affected, err := result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("checking number of affected rows failed: %s", err)
+		}
+
+		if affected != 1 {
+			return fmt.Errorf("unexpected number of affected rows. got: %d, want: %d", affected, 1)
+		}
+	}
+
+	return nil
+}

--- a/pkg/offline/offline_test.go
+++ b/pkg/offline/offline_test.go
@@ -1,0 +1,162 @@
+package offline_test
+
+import (
+	"database/sql"
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
+	"github.com/wakatime/wakatime-cli/pkg/offline"
+
+	_ "github.com/mattn/go-sqlite3" // not used directly
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// nolint
+var conn *sql.DB
+
+func TestMain(m *testing.M) {
+	f, err := ioutil.TempFile(os.TempDir(), "")
+	if err != nil {
+		panic(err)
+	}
+
+	defer os.Remove(f.Name())
+
+	// connect to DB
+	conn, err = sql.Open("sqlite3", f.Name())
+	if err != nil {
+		panic(err)
+	}
+
+	// check DB connection
+	for i := 0; i < 10; i++ {
+		err = conn.Ping()
+		if err == nil {
+			break
+		}
+
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	if err != nil {
+		panic(err)
+	}
+
+	// run tests
+	os.Exit(m.Run())
+}
+
+func TestQueue_PushMany(t *testing.T) {
+	_, err := conn.Exec("CREATE TABLE heartbeat_2 (id TEXT, heartbeat TEXT)")
+	require.NoError(t, err)
+
+	defer func() {
+		_, err := conn.Exec(`DROP TABLE heartbeat_2;`)
+		if err != nil {
+			panic(err)
+		}
+	}()
+
+	q := offline.NewQueue(conn)
+	err = q.PushMany(testHeartbeats())
+	require.NoError(t, err)
+
+	rows, err := conn.Query("SELECT id, heartbeat FROM heartbeat_2;")
+	require.NoError(t, err)
+
+	var heartbeats []heartbeat.Heartbeat
+
+	for rows.Next() {
+		var (
+			id   string
+			data string
+		)
+
+		err := rows.Scan(
+			&id,
+			&data,
+		)
+		require.NoError(t, err)
+
+		var h heartbeat.Heartbeat
+		err = json.Unmarshal([]byte(data), &h)
+		require.NoError(t, err)
+
+		assert.Equal(t, h.ID(), id)
+
+		heartbeats = append(heartbeats, h)
+	}
+	require.NoError(t, rows.Err())
+
+	assert.Len(t, heartbeats, 2)
+	assert.Contains(t, heartbeats, heartbeat.Heartbeat{
+		Branch:         heartbeat.String("heartbeat"),
+		Category:       heartbeat.CodingCategory,
+		CursorPosition: heartbeat.Int(12),
+		Dependencies:   []string{"dep1", "dep2"},
+		Entity:         "/tmp/main.go",
+		EntityType:     heartbeat.FileType,
+		IsWrite:        heartbeat.Bool(true),
+		Language:       heartbeat.String("golang"),
+		LineNumber:     heartbeat.Int(42),
+		Lines:          heartbeat.Int(100),
+		Project:        heartbeat.String("wakatime-cli"),
+		Time:           1592868367.219124,
+		UserAgent:      "wakatime/13.0.6",
+	})
+	assert.Contains(t, heartbeats, heartbeat.Heartbeat{
+		Branch:         heartbeat.String("summary"),
+		Category:       heartbeat.DebuggingCategory,
+		CursorPosition: heartbeat.Int(13),
+		Dependencies:   []string{"dep3", "dep4"},
+		Entity:         "/tmp/main.py",
+		EntityType:     heartbeat.FileType,
+		IsWrite:        heartbeat.Bool(false),
+		Language:       heartbeat.String("python"),
+		LineNumber:     heartbeat.Int(43),
+		Lines:          heartbeat.Int(101),
+		Project:        heartbeat.String("wakatime"),
+		Time:           1592868386.079084,
+		UserAgent:      "wakatime/13.0.7",
+	})
+}
+
+func testHeartbeats() []heartbeat.Heartbeat {
+	return []heartbeat.Heartbeat{
+		{
+			Branch:         heartbeat.String("heartbeat"),
+			Category:       heartbeat.CodingCategory,
+			CursorPosition: heartbeat.Int(12),
+			Dependencies:   []string{"dep1", "dep2"},
+			Entity:         "/tmp/main.go",
+			EntityType:     heartbeat.FileType,
+			IsWrite:        heartbeat.Bool(true),
+			Language:       heartbeat.String("golang"),
+			LineNumber:     heartbeat.Int(42),
+			Lines:          heartbeat.Int(100),
+			Project:        heartbeat.String("wakatime-cli"),
+			Time:           1592868367.219124,
+			UserAgent:      "wakatime/13.0.6",
+		},
+		{
+			Branch:         heartbeat.String("summary"),
+			Category:       heartbeat.DebuggingCategory,
+			CursorPosition: heartbeat.Int(13),
+			Dependencies:   []string{"dep3", "dep4"},
+			Entity:         "/tmp/main.py",
+			EntityType:     heartbeat.FileType,
+			IsWrite:        heartbeat.Bool(false),
+			Language:       heartbeat.String("python"),
+			LineNumber:     heartbeat.Int(43),
+			Lines:          heartbeat.Int(101),
+			Project:        heartbeat.String("wakatime"),
+			Time:           1592868386.079084,
+			UserAgent:      "wakatime/13.0.7",
+		},
+	}
+}

--- a/pkg/offline/offline_test.go
+++ b/pkg/offline/offline_test.go
@@ -126,6 +126,170 @@ func TestQueue_PushMany(t *testing.T) {
 	})
 }
 
+func TestQueue_PopMany(t *testing.T) {
+	_, err := conn.Exec("CREATE TABLE heartbeat_2 (id TEXT, heartbeat TEXT)")
+	require.NoError(t, err)
+
+	defer func() {
+		_, err := conn.Exec(`DROP TABLE heartbeat_2;`)
+		if err != nil {
+			panic(err)
+		}
+	}()
+
+	data, err := ioutil.ReadFile("testdata/heartbeat_one.json")
+	require.NoError(t, err)
+
+	insertHearbeatRecords(t, []heartbeatRecord{
+		{
+			ID:        "1592868313.541149-file-coding-wakatime-cli-heartbeat-/tmp/main.go-true",
+			Heartbeat: string(data),
+		},
+	})
+
+	data, err = ioutil.ReadFile("testdata/heartbeat_two.json")
+	require.NoError(t, err)
+
+	insertHearbeatRecords(t, []heartbeatRecord{
+		{
+			ID:        "1592868386.079084-file-debugging-wakatime-summary-/tmp/main.py-false",
+			Heartbeat: string(data),
+		},
+	})
+
+	q := offline.NewQueue(conn)
+	hh, err := q.PopMany(99)
+	require.NoError(t, err)
+
+	assert.Len(t, hh, 2)
+	assert.Contains(t, hh, heartbeat.Heartbeat{
+		Branch:         heartbeat.String("heartbeat"),
+		Category:       heartbeat.CodingCategory,
+		CursorPosition: heartbeat.Int(12),
+		Dependencies:   []string{"dep1", "dep2"},
+		Entity:         "/tmp/main.go",
+		EntityType:     heartbeat.FileType,
+		IsWrite:        heartbeat.Bool(true),
+		Language:       heartbeat.String("golang"),
+		LineNumber:     heartbeat.Int(42),
+		Lines:          heartbeat.Int(100),
+		Project:        heartbeat.String("wakatime-cli"),
+		Time:           1592868367.219124,
+		UserAgent:      "wakatime/13.0.6",
+	})
+	assert.Contains(t, hh, heartbeat.Heartbeat{
+		Branch:         heartbeat.String("summary"),
+		Category:       heartbeat.DebuggingCategory,
+		CursorPosition: heartbeat.Int(13),
+		Dependencies:   []string{"dep3", "dep4"},
+		Entity:         "/tmp/main.py",
+		EntityType:     heartbeat.FileType,
+		IsWrite:        heartbeat.Bool(false),
+		Language:       heartbeat.String("python"),
+		LineNumber:     heartbeat.Int(43),
+		Lines:          heartbeat.Int(101),
+		Project:        heartbeat.String("wakatime"),
+		Time:           1592868386.079084,
+		UserAgent:      "wakatime/13.0.7",
+	})
+
+	rows, err := conn.Query("SELECT id, heartbeat FROM heartbeat_2;")
+	require.NoError(t, err)
+
+	assert.False(t, rows.Next())
+}
+
+func TestQueue_PopMany_Limit(t *testing.T) {
+	_, err := conn.Exec("CREATE TABLE heartbeat_2 (id TEXT, heartbeat TEXT)")
+	require.NoError(t, err)
+
+	defer func() {
+		_, err := conn.Exec(`DROP TABLE heartbeat_2;`)
+		if err != nil {
+			panic(err)
+		}
+	}()
+
+	data, err := ioutil.ReadFile("testdata/heartbeat_one.json")
+	require.NoError(t, err)
+
+	insertHearbeatRecords(t, []heartbeatRecord{
+		{
+			ID:        "1592868313.541149-file-coding-wakatime-cli-heartbeat-/tmp/main.go-true",
+			Heartbeat: string(data),
+		},
+	})
+
+	data, err = ioutil.ReadFile("testdata/heartbeat_two.json")
+	require.NoError(t, err)
+
+	insertHearbeatRecords(t, []heartbeatRecord{
+		{
+			ID:        "1592868386.079084-file-debugging-wakatime-summary-/tmp/main.py-false",
+			Heartbeat: string(data),
+		},
+	})
+
+	q := offline.NewQueue(conn)
+	hh, err := q.PopMany(1)
+	require.NoError(t, err)
+
+	assert.Len(t, hh, 1)
+	assert.Contains(t, testHeartbeats(), hh[0])
+
+	rows, err := conn.Query("SELECT id, heartbeat FROM heartbeat_2;")
+	require.NoError(t, err)
+
+	var (
+		ids        []string
+		heartbeats []heartbeat.Heartbeat
+	)
+
+	for rows.Next() {
+		var (
+			id   string
+			data string
+		)
+
+		err := rows.Scan(
+			&id,
+			&data,
+		)
+		require.NoError(t, err)
+
+		ids = append(ids, id)
+
+		var h heartbeat.Heartbeat
+		err = json.Unmarshal([]byte(data), &h)
+		require.NoError(t, err)
+
+		assert.Equal(t, h.ID(), id)
+
+		heartbeats = append(heartbeats, h)
+	}
+	require.NoError(t, rows.Err())
+
+	assert.Equal(t, []string{"1592868386.079084-file-debugging-wakatime-summary-/tmp/main.py-false"}, ids)
+	assert.Equal(t, []heartbeat.Heartbeat{
+		{
+
+			Branch:         heartbeat.String("summary"),
+			Category:       heartbeat.DebuggingCategory,
+			CursorPosition: heartbeat.Int(13),
+			Dependencies:   []string{"dep3", "dep4"},
+			Entity:         "/tmp/main.py",
+			EntityType:     heartbeat.FileType,
+			IsWrite:        heartbeat.Bool(false),
+			Language:       heartbeat.String("python"),
+			LineNumber:     heartbeat.Int(43),
+			Lines:          heartbeat.Int(101),
+			Project:        heartbeat.String("wakatime"),
+			Time:           1592868386.079084,
+			UserAgent:      "wakatime/13.0.7",
+		},
+	}, heartbeats)
+}
+
 func testHeartbeats() []heartbeat.Heartbeat {
 	return []heartbeat.Heartbeat{
 		{
@@ -159,4 +323,26 @@ func testHeartbeats() []heartbeat.Heartbeat {
 			UserAgent:      "wakatime/13.0.7",
 		},
 	}
+}
+
+type heartbeatRecord struct {
+	ID        string
+	Heartbeat string
+}
+
+func insertHearbeatRecords(t *testing.T, hh []heartbeatRecord) {
+	for _, h := range hh {
+		insertHearbeatRecord(t, h)
+	}
+}
+
+func insertHearbeatRecord(t *testing.T, h heartbeatRecord) {
+	t.Helper()
+
+	_, err := conn.Exec(
+		"INSERT INTO heartbeat_2 VALUES ($1, $2)",
+		h.ID,
+		h.Heartbeat,
+	)
+	require.NoError(t, err)
 }

--- a/pkg/offline/testdata/heartbeat_one.json
+++ b/pkg/offline/testdata/heartbeat_one.json
@@ -1,0 +1,15 @@
+{
+    "branch": "heartbeat",
+    "category": "coding",
+    "cursorpos": 12,
+    "dependencies": ["dep1", "dep2"],
+    "entity": "/tmp/main.go",
+    "is_write": true,
+    "language": "golang",
+    "lineno": 42,
+    "lines": 100,
+    "project": "wakatime-cli",
+    "type": "file",
+    "time": 1592868367.219124,
+    "user_agent": "wakatime/13.0.6"
+}

--- a/pkg/offline/testdata/heartbeat_two.json
+++ b/pkg/offline/testdata/heartbeat_two.json
@@ -1,0 +1,15 @@
+{
+    "branch": "summary",
+    "category": "debugging",
+    "cursorpos": 13,
+    "dependencies": ["dep3", "dep4"],
+    "entity": "/tmp/main.py",
+    "is_write": false,
+    "language": "python",
+    "lineno": 43,
+    "lines": 101,
+    "project": "wakatime",
+    "type": "file",
+    "time": 1592868386.079084,
+    "user_agent": "wakatime/13.0.7"
+}


### PR DESCRIPTION
This PR adds `offline` package, containing offline queue implementation. `offline.WithQueue` returns `heartbeat.HandleOption`, which can be used to integrate the offline queue into the heartbeat processing pipeline.

`WithQueue` logic:

1. Start transaction
2. Pop heartbeats from the queue
3. Forward original and popped heartbeats to next handle of heartbeat processing pipeline.
4. On error of next handle of heartbeat processing pipeline, push original and popped heartbeats to queue, commit transaction and return
5. On success of next handle or heartbeat processing pipeline, check heartbeat sending results and push each heartbeat with invalid result to queue, commit transaction and return



