### PR TITLE
add mercurial project detection

### DIFF
--- a/pkg/project/mercurial.go
+++ b/pkg/project/mercurial.go
@@ -29,13 +29,11 @@ func (m Mercurial) Detect() (Result, bool, error) {
 		fp = path.Dir(fp)
 	}
 
-	result := Result{}
-
 	// Find for .hg folder
 	hgDirectory, ok := findHgConfigDir(fp)
 
 	if ok {
-		result.Project = path.Base(path.Join(hgDirectory, ".."))
+		project := path.Base(path.Join(hgDirectory, ".."))
 
 		branch, err := findHgBranch(hgDirectory)
 		if err != nil {
@@ -46,17 +44,19 @@ func (m Mercurial) Detect() (Result, bool, error) {
 			)
 		}
 
-		result.Branch = branch
-
-		return result, true, nil
+		return Result{
+			Project: project,
+			Branch:  branch,
+		}, true, nil
 	}
 
 	return Result{}, false, nil
 }
 
 func findHgConfigDir(fp string) (string, bool) {
-	if fileExists(path.Join(fp, ".hg")) {
-		return path.Join(fp, ".hg"), true
+	p := path.Join(fp, ".hg")
+	if fileExists(p) {
+		return p, true
 	}
 
 	dir := filepath.Clean(path.Join(fp, ".."))
@@ -68,11 +68,12 @@ func findHgConfigDir(fp string) (string, bool) {
 }
 
 func findHgBranch(fp string) (string, error) {
-	if !fileExists(path.Join(fp, "branch")) {
+	p := path.Join(fp, "branch")
+	if !fileExists(p) {
 		return "default", nil
 	}
 
-	lines, err := readFile(path.Join(fp, "branch"))
+	lines, err := readFile(p)
 	if err != nil {
 		return "", Err(fmt.Sprintf("failed while opening file %q: %s", fp, err))
 	}

--- a/pkg/project/mercurial.go
+++ b/pkg/project/mercurial.go
@@ -1,0 +1,90 @@
+package project
+
+import (
+	"fmt"
+	"path"
+	"path/filepath"
+	"strings"
+
+	jww "github.com/spf13/jwalterweatherman"
+	"github.com/yookoala/realpath"
+)
+
+// Mercurial contains mercurial data.
+type Mercurial struct {
+	// Filepath conaints the entity path.
+	Filepath string
+}
+
+// Detect gets information about the mercurial project for a given file.
+func (m Mercurial) Detect() (Result, bool, error) {
+	fp, err := realpath.Realpath(m.Filepath)
+	if err != nil {
+		return Result{}, false,
+			Err(fmt.Sprintf("failed to get the real path: %s", err))
+	}
+
+	// Take only the directory
+	if fileExists(fp) {
+		fp = path.Dir(fp)
+	}
+
+	result := Result{}
+
+	// Find for .hg folder
+	hgDirectory, ok := findHgConfigDir(fp)
+
+	if ok {
+		result.Project = path.Base(path.Join(hgDirectory, ".."))
+
+		branch, err := findHgBranch(hgDirectory)
+		if err != nil {
+			jww.ERROR.Printf(
+				"error finding for branch name from %q: %s",
+				hgDirectory,
+				err,
+			)
+		}
+
+		result.Branch = branch
+
+		return result, true, nil
+	}
+
+	return Result{}, false, nil
+}
+
+func findHgConfigDir(fp string) (string, bool) {
+	if fileExists(path.Join(fp, ".hg")) {
+		return path.Join(fp, ".hg"), true
+	}
+
+	dir := filepath.Clean(path.Join(fp, ".."))
+	if dir == "/" {
+		return "", false
+	}
+
+	return findHgConfigDir(dir)
+}
+
+func findHgBranch(fp string) (string, error) {
+	if !fileExists(path.Join(fp, "branch")) {
+		return "default", nil
+	}
+
+	lines, err := readFile(path.Join(fp, "branch"))
+	if err != nil {
+		return "", Err(fmt.Sprintf("failed while opening file %q: %s", fp, err))
+	}
+
+	if len(lines) > 0 {
+		return strings.TrimSpace(lines[0]), nil
+	}
+
+	return "default", nil
+}
+
+// String returns its name.
+func (m Mercurial) String() string {
+	return "hg-detector"
+}

--- a/pkg/project/mercurial_test.go
+++ b/pkg/project/mercurial_test.go
@@ -1,0 +1,105 @@
+package project_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/wakatime/wakatime-cli/pkg/project"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMercurial_Detect(t *testing.T) {
+	fp, tearDown := setupTestMercurial(t)
+	defer tearDown()
+
+	m := project.Mercurial{
+		Filepath: path.Join(fp, "wakatime-cli/src/pkg/file.go"),
+	}
+
+	result, detected, err := m.Detect()
+	require.NoError(t, err)
+
+	assert.True(t, detected)
+	assert.Equal(t, project.Result{
+		Project: "wakatime-cli",
+		Branch:  "billing",
+	}, result)
+}
+
+func TestMercurial_Detect_BranchWithSlash(t *testing.T) {
+	fp, tearDown := setupTestMercurial(t)
+	defer tearDown()
+
+	m := project.Mercurial{
+		Filepath: path.Join(fp, "wakatime-cli/src/pkg/file.go"),
+	}
+
+	result, detected, err := m.Detect()
+	require.NoError(t, err)
+
+	assert.True(t, detected)
+	assert.Equal(t, project.Result{
+		Project: "wakatime-cli",
+		Branch:  "billing",
+	}, result)
+}
+
+func TestMercurial_Detect_NoBranch(t *testing.T) {
+	fp, tearDown := setupTestMercurialNoBranch(t)
+	defer tearDown()
+
+	m := project.Mercurial{
+		Filepath: path.Join(fp, "wakatime-cli/src/pkg/file.go"),
+	}
+
+	result, detected, err := m.Detect()
+	require.NoError(t, err)
+
+	assert.True(t, detected)
+	assert.Equal(t, project.Result{
+		Project: "wakatime-cli",
+		Branch:  "default",
+	}, result)
+}
+
+func setupTestMercurial(t *testing.T) (fp string, tearDown func()) {
+	tmpDir, err := ioutil.TempDir(os.TempDir(), "wakatime-hg")
+	require.NoError(t, err)
+
+	err = os.MkdirAll(path.Join(tmpDir, "wakatime-cli/src/pkg"), os.FileMode(int(0700)))
+	require.NoError(t, err)
+
+	tmpFile, err := os.Create(path.Join(tmpDir, "wakatime-cli/src/pkg/file.go"))
+	require.NoError(t, err)
+
+	tmpFile.Close()
+
+	err = os.Mkdir(path.Join(tmpDir, "wakatime-cli/.hg"), os.FileMode(int(0700)))
+	require.NoError(t, err)
+
+	copyFile(t, "testdata/hg/branch", path.Join(tmpDir, "wakatime-cli/.hg/branch"))
+
+	return tmpDir, func() { os.RemoveAll(tmpDir) }
+}
+
+func setupTestMercurialNoBranch(t *testing.T) (fp string, tearDown func()) {
+	tmpDir, err := ioutil.TempDir(os.TempDir(), "wakatime-hg")
+	require.NoError(t, err)
+
+	err = os.MkdirAll(path.Join(tmpDir, "wakatime-cli/src/pkg"), os.FileMode(int(0700)))
+	require.NoError(t, err)
+
+	tmpFile, err := os.Create(path.Join(tmpDir, "wakatime-cli/src/pkg/file.go"))
+	require.NoError(t, err)
+
+	tmpFile.Close()
+
+	err = os.Mkdir(path.Join(tmpDir, "wakatime-cli/.hg"), os.FileMode(int(0700)))
+	require.NoError(t, err)
+
+	return tmpDir, func() { os.RemoveAll(tmpDir) }
+}

--- a/pkg/project/mercurial_test.go
+++ b/pkg/project/mercurial_test.go
@@ -31,7 +31,7 @@ func TestMercurial_Detect(t *testing.T) {
 }
 
 func TestMercurial_Detect_BranchWithSlash(t *testing.T) {
-	fp, tearDown := setupTestMercurial(t)
+	fp, tearDown := setupTestMercurialBranchWithSlash(t)
 	defer tearDown()
 
 	m := project.Mercurial{
@@ -44,7 +44,7 @@ func TestMercurial_Detect_BranchWithSlash(t *testing.T) {
 	assert.True(t, detected)
 	assert.Equal(t, project.Result{
 		Project: "wakatime-cli",
-		Branch:  "billing",
+		Branch:  "feature/billing",
 	}, result)
 }
 
@@ -82,6 +82,26 @@ func setupTestMercurial(t *testing.T) (fp string, tearDown func()) {
 	require.NoError(t, err)
 
 	copyFile(t, "testdata/hg/branch", path.Join(tmpDir, "wakatime-cli/.hg/branch"))
+
+	return tmpDir, func() { os.RemoveAll(tmpDir) }
+}
+
+func setupTestMercurialBranchWithSlash(t *testing.T) (fp string, tearDown func()) {
+	tmpDir, err := ioutil.TempDir(os.TempDir(), "wakatime-hg")
+	require.NoError(t, err)
+
+	err = os.MkdirAll(path.Join(tmpDir, "wakatime-cli/src/pkg"), os.FileMode(int(0700)))
+	require.NoError(t, err)
+
+	tmpFile, err := os.Create(path.Join(tmpDir, "wakatime-cli/src/pkg/file.go"))
+	require.NoError(t, err)
+
+	tmpFile.Close()
+
+	err = os.Mkdir(path.Join(tmpDir, "wakatime-cli/.hg"), os.FileMode(int(0700)))
+	require.NoError(t, err)
+
+	copyFile(t, "testdata/hg/branch_with_slash", path.Join(tmpDir, "wakatime-cli/.hg/branch"))
 
 	return tmpDir, func() { os.RemoveAll(tmpDir) }
 }

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -112,6 +112,9 @@ func DetectWithRevControl(entity string, submodulePatterns []*regexp.Regexp,
 			Filepath:          entity,
 			SubmodulePatterns: submodulePatterns,
 		},
+		Mercurial{
+			Filepath: entity,
+		},
 	}
 
 	for _, p := range revControlPlugins {

--- a/pkg/project/testdata/hg/branch
+++ b/pkg/project/testdata/hg/branch
@@ -1,0 +1,1 @@
+billing

--- a/pkg/project/testdata/hg/branch_with_slash
+++ b/pkg/project/testdata/hg/branch_with_slash
@@ -1,0 +1,1 @@
+feature/billing


### PR DESCRIPTION
This PR adds mercurial project detection. The detection is much simpler than `git` and the detection only looks for `.hg` folder to get the informations.