### PR TITLE
Feature/integrate offline queue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,13 +14,13 @@ BINARY_NAME=wakatime-cli
 build-all: build-darwin build-linux build-windows
 
 build-darwin:
-	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 $(GOBUILD) -o ./build/darwin/amd64/$(BINARY_NAME) -v
+	CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 $(GOBUILD) -o ./build/darwin/amd64/$(BINARY_NAME) -v
 
 build-linux:
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GOBUILD) -o ./build/linux/amd64/$(BINARY_NAME) -v
+	CGO_ENABLED=1 GOOS=linux GOARCH=amd64 $(GOBUILD) -o ./build/linux/amd64/$(BINARY_NAME) -v
 
 build-windows:
-	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 $(GOBUILD) -o ./build/windows/amd64/$(BINARY_NAME).exe -v
+	CGO_ENABLED=1 GOOS=windows GOARCH=amd64 $(GOBUILD) -o ./build/windows/amd64/$(BINARY_NAME).exe -v
 
 # Install linter
 .PHONY: install-linter

--- a/cmd/legacy/heartbeat/heartbeat.go
+++ b/cmd/legacy/heartbeat/heartbeat.go
@@ -10,14 +10,16 @@ import (
 	"github.com/wakatime/wakatime-cli/pkg/exitcode"
 	"github.com/wakatime/wakatime-cli/pkg/filter"
 	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
+	"github.com/wakatime/wakatime-cli/pkg/offline"
 
+	_ "github.com/mattn/go-sqlite3" // not used directly
 	jww "github.com/spf13/jwalterweatherman"
 	"github.com/spf13/viper"
 )
 
 // Run executes the heartbeat command.
 func Run(v *viper.Viper) {
-	err := SendHeartbeat(v)
+	err := SendHeartbeats(v)
 	if err != nil {
 		var errauth api.ErrAuth
 		if errors.As(err, &errauth) {
@@ -30,19 +32,22 @@ func Run(v *viper.Viper) {
 
 		var errapi api.Err
 		if errors.As(err, &errapi) {
-			jww.CRITICAL.Printf("failed to send heartbeat: %s", err)
+			jww.CRITICAL.Printf("failed to send heartbeat(s): %s", err)
 			os.Exit(exitcode.ErrAPI)
 		}
 
-		jww.CRITICAL.Printf("failed to send heartbeat: %s", err)
+		jww.CRITICAL.Printf("failed to send heartbeat(s): %s", err)
 		os.Exit(exitcode.ErrDefault)
 	}
 
+	jww.DEBUG.Println("successfully handled heartbeat(s)")
 	os.Exit(exitcode.Success)
 }
 
-// SendHeartbeat sends a heartbeat to the wakatime api.
-func SendHeartbeat(v *viper.Viper) error {
+// SendHeartbeats sends a heartbeat to the wakatime api and includes additional
+// heartbeats from the offline queue, if available and offline sync is not
+// explicitly disabled.
+func SendHeartbeats(v *viper.Viper) error {
 	params, err := LoadParams(v)
 	if err != nil {
 		return fmt.Errorf("failed to load command parameters: %w", err)
@@ -114,6 +119,20 @@ func SendHeartbeat(v *viper.Viper) error {
 			FilePatterns:    params.Sanitize.HideFileNames,
 			ProjectPatterns: params.Sanitize.HideProjectNames,
 		}),
+	}
+
+	if !params.OfflineDisabled {
+		filepath, err := offline.QueueFilepath()
+		if err != nil {
+			return fmt.Errorf("failed to load offline queue filepath: %w", err)
+		}
+
+		offlineHandleOpt, err := offline.WithQueue(filepath, params.OfflineSyncMax)
+		if err != nil {
+			return fmt.Errorf("failed to initialize offline queue handle option: %w", err)
+		}
+
+		handleOpts = append(handleOpts, offlineHandleOpt)
 	}
 
 	handle := heartbeat.NewHandle(c, handleOpts...)

--- a/cmd/legacy/heartbeat/heartbeat_test.go
+++ b/cmd/legacy/heartbeat/heartbeat_test.go
@@ -14,12 +14,13 @@ import (
 	cmd "github.com/wakatime/wakatime-cli/cmd/legacy/heartbeat"
 	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 
+	_ "github.com/mattn/go-sqlite3" // not used directly
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestSendHeartbeat(t *testing.T) {
+func TestSendHeartbeats(t *testing.T) {
 	testServerURL, router, tearDown := setupTestServer()
 	defer tearDown()
 
@@ -72,13 +73,13 @@ func TestSendHeartbeat(t *testing.T) {
 	v.Set("timeout", 5)
 	v.Set("write", true)
 
-	err := cmd.SendHeartbeat(v)
+	err := cmd.SendHeartbeats(v)
 	require.NoError(t, err)
 
 	assert.Eventually(t, func() bool { return numCalls == 1 }, time.Second, 50*time.Millisecond)
 }
 
-func TestSendHeartbeat_WithFiltering_Exclude(t *testing.T) {
+func TestSendHeartbeats_WithFiltering_Exclude(t *testing.T) {
 	testServerURL, router, tearDown := setupTestServer()
 	defer tearDown()
 
@@ -102,7 +103,7 @@ func TestSendHeartbeat_WithFiltering_Exclude(t *testing.T) {
 	v.Set("timeout", 5)
 	v.Set("write", true)
 
-	err := cmd.SendHeartbeat(v)
+	err := cmd.SendHeartbeats(v)
 	require.NoError(t, err)
 
 	assert.Equal(t, 0, numCalls)

--- a/cmd/legacy/heartbeat/params.go
+++ b/cmd/legacy/heartbeat/params.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -27,19 +28,21 @@ var (
 
 // Params contains heartbeat command parameters.
 type Params struct {
-	APIKey     string
-	APIUrl     string
-	Category   heartbeat.Category
-	Entity     string
-	EntityType heartbeat.EntityType
-	Hostname   string
-	IsWrite    *bool
-	Plugin     string
-	Time       float64
-	Timeout    time.Duration
-	Filter     FilterParams
-	Network    NetworkParams
-	Sanitize   SanitizeParams
+	APIKey          string
+	APIUrl          string
+	Category        heartbeat.Category
+	Entity          string
+	EntityType      heartbeat.EntityType
+	Hostname        string
+	IsWrite         *bool
+	OfflineDisabled bool
+	OfflineSyncMax  int
+	Plugin          string
+	Time            float64
+	Timeout         time.Duration
+	Filter          FilterParams
+	Network         NetworkParams
+	Sanitize        SanitizeParams
 }
 
 // FilterParams contains heartbeat filtering related command parameters.
@@ -93,7 +96,7 @@ func LoadParams(v *viper.Viper) (Params, error) {
 	}
 
 	entity, ok := vipertools.FirstNonEmptyString(v, "entity", "file")
-	if !ok {
+	if !ok && !v.IsSet("sync-offline-activity") {
 		return Params{}, errors.New("failed to retrieve entity")
 	}
 
@@ -123,6 +126,30 @@ func LoadParams(v *viper.Viper) (Params, error) {
 		isWrite = heartbeat.Bool(b)
 	}
 
+	offlineDisabled := vipertools.FirstNonEmptyBool(v, "disableoffline", "disable-offline")
+	if b := v.GetBool("settings.offline"); v.IsSet("settings.offline") {
+		offlineDisabled = !b
+	}
+
+	var offlineSyncMax int
+
+	switch {
+	case !v.IsSet("sync-offline-activity"):
+		// use default
+		offlineSyncMax = v.GetInt("sync-offline-activity")
+	case v.GetString("sync-offline-activity") == "none":
+		break
+	default:
+		offlineSyncMax, err = strconv.Atoi(v.GetString("sync-offline-activity"))
+		if err != nil {
+			return Params{}, errors.New("argument --sync-offline-activity must be \"none\" or a positive integer number: %s")
+		}
+	}
+
+	if offlineSyncMax < 0 {
+		return Params{}, errors.New("argument --sync-offline-activity must be \"none\" or a positive integer number")
+	}
+
 	timeSecs := v.GetFloat64("time")
 	if timeSecs == 0 {
 		timeSecs = float64(time.Now().UnixNano()) / 1000000000
@@ -146,19 +173,21 @@ func LoadParams(v *viper.Viper) (Params, error) {
 	}
 
 	return Params{
-		APIKey:     apiKey,
-		APIUrl:     apiURL,
-		Category:   category,
-		Entity:     entity,
-		EntityType: entityType,
-		Hostname:   hostname,
-		IsWrite:    isWrite,
-		Plugin:     v.GetString("plugin"),
-		Time:       timeSecs,
-		Timeout:    timeout,
-		Network:    networkParams,
-		Sanitize:   sanitizeParams,
-		Filter:     loadFilterParams(v),
+		APIKey:          apiKey,
+		APIUrl:          apiURL,
+		Category:        category,
+		Entity:          entity,
+		EntityType:      entityType,
+		Hostname:        hostname,
+		IsWrite:         isWrite,
+		OfflineDisabled: offlineDisabled,
+		OfflineSyncMax:  offlineSyncMax,
+		Plugin:          v.GetString("plugin"),
+		Time:            timeSecs,
+		Timeout:         timeout,
+		Filter:          loadFilterParams(v),
+		Network:         networkParams,
+		Sanitize:        sanitizeParams,
 	}, nil
 }
 

--- a/cmd/legacy/heartbeat/params_test.go
+++ b/cmd/legacy/heartbeat/params_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/wakatime/wakatime-cli/pkg/api"
 	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -324,6 +325,138 @@ func TestLoadParams_IsWrite_Unset(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Nil(t, params.IsWrite)
+}
+
+func TestLoadParams_OfflineDisabled_ConfigTakesPrecedence(t *testing.T) {
+	v := viper.New()
+	v.Set("key", "00000000-0000-4000-8000-000000000000")
+	v.Set("entity", "/path/to/file")
+	v.Set("disable-offline", false)
+	v.Set("disableoffline", false)
+	v.Set("settings.offline", false)
+
+	params, err := cmd.LoadParams(v)
+	require.NoError(t, err)
+
+	assert.True(t, params.OfflineDisabled)
+}
+
+func TestLoadParams_OfflineDisabled_FlagDeprecatedTakesPrecedence(t *testing.T) {
+	v := viper.New()
+	v.Set("key", "00000000-0000-4000-8000-000000000000")
+	v.Set("entity", "/path/to/file")
+	v.Set("disable-offline", false)
+	v.Set("disableoffline", true)
+
+	params, err := cmd.LoadParams(v)
+	require.NoError(t, err)
+
+	assert.True(t, params.OfflineDisabled)
+}
+
+func TestLoadParams_OfflineDisabled_FromFlag(t *testing.T) {
+	v := viper.New()
+	v.Set("key", "00000000-0000-4000-8000-000000000000")
+	v.Set("entity", "/path/to/file")
+	v.Set("disable-offline", true)
+
+	params, err := cmd.LoadParams(v)
+	require.NoError(t, err)
+
+	assert.True(t, params.OfflineDisabled)
+}
+
+func TestLoadParams_OfflineSyncMax(t *testing.T) {
+	v := viper.New()
+	v.Set("key", "00000000-0000-4000-8000-000000000000")
+	v.Set("entity", "/path/to/file")
+	v.Set("sync-offline-activity", 42)
+	v.SetDefault("sync-offline-activity", 100)
+
+	params, err := cmd.LoadParams(v)
+	require.NoError(t, err)
+
+	assert.Equal(t, 42, params.OfflineSyncMax)
+}
+
+func TestLoadParams_OfflineSyncMax_NoEntity(t *testing.T) {
+	v := viper.New()
+	v.Set("key", "00000000-0000-4000-8000-000000000000")
+	v.Set("sync-offline-activity", 42)
+	v.SetDefault("sync-offline-activity", 100)
+
+	params, err := cmd.LoadParams(v)
+	require.NoError(t, err)
+
+	assert.Equal(t, 42, params.OfflineSyncMax)
+}
+
+func TestLoadParams_OfflineSyncMax_NoEntity_DefaultNotAccepted(t *testing.T) {
+	v := viper.New()
+
+	flags := pflag.FlagSet{}
+	flags.String("sync-offline-activity", "100", "")
+
+	err := v.BindPFlags(&flags)
+	require.NoError(t, err)
+
+	v.Set("key", "00000000-0000-4000-8000-000000000000")
+
+	_, err = cmd.LoadParams(v)
+	require.Error(t, err)
+
+	assert.Equal(t, "failed to retrieve entity", err.Error())
+}
+
+func TestLoadParams_OfflineSyncMax_None(t *testing.T) {
+	v := viper.New()
+	v.Set("key", "00000000-0000-4000-8000-000000000000")
+	v.Set("entity", "/path/to/file")
+	v.Set("sync-offline-activity", "none")
+	v.SetDefault("sync-offline-activity", 100)
+
+	params, err := cmd.LoadParams(v)
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, params.OfflineSyncMax)
+}
+
+func TestLoadParams_OfflineSyncMax_Default(t *testing.T) {
+	v := viper.New()
+	v.Set("key", "00000000-0000-4000-8000-000000000000")
+	v.Set("entity", "/path/to/file")
+	v.SetDefault("sync-offline-activity", 100)
+
+	params, err := cmd.LoadParams(v)
+	require.NoError(t, err)
+
+	assert.Equal(t, 100, params.OfflineSyncMax)
+}
+
+func TestLoadParams_OfflineSyncMax_NegativeNumber(t *testing.T) {
+	v := viper.New()
+	v.Set("key", "00000000-0000-4000-8000-000000000000")
+	v.Set("entity", "/path/to/file")
+	v.Set("sync-offline-activity", -1)
+	v.SetDefault("sync-offline-activity", 100)
+
+	_, err := cmd.LoadParams(v)
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "--sync-offline-activity")
+}
+
+func TestLoadParams_OfflineSyncMax_NonIntegerValue(t *testing.T) {
+	v := viper.New()
+	v.Set("key", "00000000-0000-4000-8000-000000000000")
+	v.Set("entity", "/path/to/file")
+	v.Set("sync-offline-activity", "invalid")
+	v.SetDefault("sync-offline-activity", 100)
+
+	_, err := cmd.LoadParams(v)
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "--sync-offline-activity")
 }
 
 func TestLoadParams_Plugin(t *testing.T) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,6 +17,9 @@ const (
 	defaultConfigSection = "settings"
 	// defaultTimeoutSecs is the default timeout used for requests to the wakatime api
 	defaultTimeoutSecs = 60
+	// defaultOfflineSync is the default maximum number of heartbeats from the
+	// offline queue, which will be synced upon sending heartbeats to the API.
+	defaultOfflineSync = "100"
 )
 
 // NewRootCMD creates a rootCmd, which represents the base command when called without any subcommands.
@@ -59,6 +62,8 @@ func setFlags(cmd *cobra.Command, v *viper.Viper) {
 		nil,
 		"Writes value to a config key, then exits. Expects two arguments, key and value.",
 	)
+	flags.Bool("disable-offline", false, "Disables offline time logging instead of queuing logged time.")
+	flags.Bool("disableoffline", false, "(deprecated) Disables offline time logging instead of queuing logged time.")
 	flags.String(
 		"entity",
 		"",
@@ -127,6 +132,15 @@ func setFlags(cmd *cobra.Command, v *viper.Viper) {
 		"",
 		"Override the bundled Python Requests CA certs file. By default, uses"+
 			"system ca certs.",
+	)
+	flags.String(
+		"sync-offline-activity",
+		defaultOfflineSync,
+		"Amount of offline activity to sync from your local ~/.wakatime.db sqlite3"+
+			" file to your WakaTime Dashboard before exiting. Can be \"none\" or"+
+			" a positive integer. Defaults to 100, meaning for every heartbeat sent"+
+			" while online, 100 offline heartbeats are synced. Can be used without"+
+			" --entity to only sync offline activity without generating new heartbeats.",
 	)
 	flags.Int(
 		"timeout",

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/slongfield/pyfmt v0.0.0-20180124071345-020a7cb18bca
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/jwalterweatherman v1.1.0
+	github.com/spf13/pflag v1.0.3
 	github.com/spf13/viper v1.7.0
 	github.com/stretchr/testify v1.6.1
 	github.com/yookoala/realpath v1.0.0

--- a/pkg/api/heartbeat.go
+++ b/pkg/api/heartbeat.go
@@ -10,11 +10,15 @@ import (
 	"strings"
 
 	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
+
+	jww "github.com/spf13/jwalterweatherman"
 )
 
 // Send sends a bulk of heartbeats to the wakatime api.
 func (c *Client) Send(heartbeats []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
 	url := c.baseURL + "/v1/users/current/heartbeats.bulk"
+
+	jww.DEBUG.Printf("sending %d heartbeat(s) to api at %q", len(heartbeats), url)
 
 	data, err := json.Marshal(heartbeats)
 	if err != nil {

--- a/pkg/offline/offline.go
+++ b/pkg/offline/offline.go
@@ -5,15 +5,39 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
+	"path"
 
 	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 
+	_ "github.com/mattn/go-sqlite3" // not used directly
+	"github.com/mitchellh/go-homedir"
 	jww "github.com/spf13/jwalterweatherman"
 )
 
 const (
 	tableName = "heartbeat_2"
 )
+
+// QueueFilepath returns the path to the offline queue db file.
+func QueueFilepath() (string, error) {
+	dir := os.Getenv("WAKATIME_HOME")
+
+	var err error
+	if dir == "" {
+		dir, err = os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("failed to retrieve user's home dir: %s", err)
+		}
+	}
+
+	expanded, err := homedir.Expand(dir)
+	if err != nil {
+		return "", fmt.Errorf("failed to expand offline queue folder path: %s", err)
+	}
+
+	return path.Join(expanded, ".wakatime.db"), nil
+}
 
 // WithQueue initializes and returns a heartbeat handle option, which can be
 // used in a heartbeat processing pipeline for automatic handling of failures


### PR DESCRIPTION
This PR integrates the offline queue into send heartbeats command. The following flags are added:

- `disable-offline`
- `disableoffline` (deprecated)
- `sync-offline-activity`

Alternatively `offline` boolean can be defined in `settings` section of `.wakatime.cfg` file. Default setting for number of heartbeats synced from offline queue is `100`, like in the python version.

 