### PR TITLE
Handle API error response in offline queue

### DIFF
--- a/pkg/api/heartbeat.go
+++ b/pkg/api/heartbeat.go
@@ -14,7 +14,9 @@ import (
 	jww "github.com/spf13/jwalterweatherman"
 )
 
-// Send sends a bulk of heartbeats to the wakatime api.
+// Send sends a bulk of heartbeats to the wakatime api and returns the result.
+// The API does not guarantuee the setting of the Heartbeat property of the result.
+// On certain errors, like 429/too many heartbeats, this is omitted and not set.
 func (c *Client) Send(heartbeats []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
 	url := c.baseURL + "/v1/users/current/heartbeats.bulk"
 

--- a/pkg/offline/offline_test.go
+++ b/pkg/offline/offline_test.go
@@ -241,8 +241,8 @@ func TestWithQueue_InvalidResults(t *testing.T) {
 				Heartbeat: testHeartbeats()[0],
 			},
 			{
-				Status:    403,
-				Heartbeat: testHeartbeats()[1],
+				Status: 429,
+				Errors: []string{"Too many heartbeats"},
 			},
 		}, nil
 	})
@@ -256,8 +256,8 @@ func TestWithQueue_InvalidResults(t *testing.T) {
 			Heartbeat: testHeartbeats()[0],
 		},
 		{
-			Status:    403,
-			Heartbeat: testHeartbeats()[1],
+			Status: 429,
+			Errors: []string{"Too many heartbeats"},
 		},
 	}, results)
 


### PR DESCRIPTION
This PR adjusts offline queue to correctly handle API responses which do not include any heartbeat. This previously lead to a heartbeat with empty properties being added to offline queue.

The problem is solved by pushing the corresponding heartbeat from the request data to offline queue, instead of expecting a the heartbeat to be returned with the response.