### PR TITLE
Accept extra heartbeats with string value for int property

### DIFF
--- a/cmd/legacy/heartbeat/params_test.go
+++ b/cmd/legacy/heartbeat/params_test.go
@@ -386,6 +386,64 @@ func TestLoadParams_ExtraHeartbeats(t *testing.T) {
 	}, params.ExtraHeartbeats)
 }
 
+func TestLoadParams_ExtraHeartbeats_WithStringValues(t *testing.T) {
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+
+	defer func() {
+		r.Close()
+		w.Close()
+	}()
+
+	origStdin := os.Stdin
+
+	defer func() { os.Stdin = origStdin }()
+
+	os.Stdin = r
+
+	data, err := ioutil.ReadFile("testdata/extra_heartbeats_with_string_values.json")
+	require.NoError(t, err)
+
+	go func() {
+		_, err := w.Write(data)
+		require.NoError(t, err)
+
+		w.Close()
+	}()
+
+	v := viper.New()
+	v.Set("key", "00000000-0000-4000-8000-000000000000")
+	v.Set("entity", "/path/to/file")
+	v.Set("extra-heartbeats", true)
+
+	params, err := cmd.LoadParams(v)
+	require.NoError(t, err)
+
+	assert.Len(t, params.ExtraHeartbeats, 2)
+	assert.Equal(t, []heartbeat.Heartbeat{
+		{
+			Category:       heartbeat.CodingCategory,
+			CursorPosition: heartbeat.Int(12),
+			Entity:         "testdata/main.go",
+			EntityType:     heartbeat.FileType,
+			IsWrite:        heartbeat.Bool(true),
+			LineNumber:     heartbeat.Int(42),
+			Time:           1585598059,
+			UserAgent:      "wakatime/13.0.6",
+		},
+		{
+			Category:       heartbeat.CodingCategory,
+			CursorPosition: heartbeat.Int(13),
+			Entity:         "testdata/main.go",
+			EntityType:     heartbeat.FileType,
+			IsWrite:        heartbeat.Bool(true),
+			LineNumber:     heartbeat.Int(43),
+			Time:           1585598060,
+			UserAgent:      "wakatime/13.0.7",
+		},
+	}, params.ExtraHeartbeats)
+}
+
 func TestLoadParams_Hostname_FlagTakesPrecedence(t *testing.T) {
 	v := viper.New()
 	v.Set("key", "00000000-0000-4000-8000-000000000000")

--- a/cmd/legacy/heartbeat/testdata/extra_heartbeats_with_string_values.json
+++ b/cmd/legacy/heartbeat/testdata/extra_heartbeats_with_string_values.json
@@ -1,0 +1,22 @@
+[
+	{
+		"category": "coding",
+		"cursorpos": "12",
+		"entity": "testdata/main.go",
+		"is_write": true,
+		"lineno": "42",
+		"type": "file",
+		"time": 1585598059,
+		"user_agent": "wakatime/13.0.6"
+	},
+	{
+		"category": "coding",
+		"cursorpos": "13",
+		"entity": "testdata/main.go",
+		"is_write": true,
+		"lineno": "43",
+		"type": "file",
+		"time": 1585598060,
+		"user_agent": "wakatime/13.0.7"
+	}
+]


### PR DESCRIPTION
This PR changes extra heartbeats parsing to try again accepting string values for int properties `cursorpos` and `lineno`.

Fixes: https://github.com/wakatime/wakatime-cli/issues/108 