### PR TITLE
Accept extra heartbeats with "timestamp" property

### DIFF
--- a/cmd/legacy/heartbeat/testdata/extra_heartbeats.json
+++ b/cmd/legacy/heartbeat/testdata/extra_heartbeats.json
@@ -16,7 +16,7 @@
 		"is_write": null,
 		"lineno": null,
 		"type": "file",
-		"time": 1585598060,
+		"timestamp": 1585598060,
 		"user_agent": "wakatime/13.0.7"
 	}
 ]

--- a/cmd/legacy/heartbeat/testdata/extra_heartbeats_with_string_values.json
+++ b/cmd/legacy/heartbeat/testdata/extra_heartbeats_with_string_values.json
@@ -16,7 +16,7 @@
 		"is_write": true,
 		"lineno": "43",
 		"type": "file",
-		"time": 1585598060,
+		"timestamp": 1585598060,
 		"user_agent": "wakatime/13.0.7"
 	}
 ]


### PR DESCRIPTION
This PR changes extra heartbeats parsing to also accept property `timestamp`, which is sent by sublime plugin.

@gandarez Do all plugins use `timestamp` as a property? First, I assumed the usage of `time`, which is what the backend expects.