### PR TITLE
bump go to 1.15 for windows ci

### DIFF
--- a/.github/workflows/on_push_windows.yaml
+++ b/.github/workflows/on_push_windows.yaml
@@ -2,14 +2,14 @@ on: push
 
 jobs:
   test:
-    name: Test windows
+    name: Test Windows
     runs-on: windows-latest
     steps:
       - name: "Checkout"
         uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.14"
+          go-version: "1.15"
       - name: "Pull dependencies"
         run: go mod vendor
       - name: "Unit tests"


### PR DESCRIPTION
This PR simply bumps go to `1.15` for windows CI.