### PR TITLE
keep golangci-lint always up to date

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,30 @@
 .DEFAULT_GOAL := build-all
 
-# Basic Go commands
+# Binary name
+BINARY_NAME=wakatime-cli
+
+# basic Go commands
 GOCMD=go
 GOBUILD=$(GOCMD) build
 GOCLEAN=$(GOCMD) clean
 GOTEST=$(GOCMD) test
 GOGET=$(GOCMD) get
 
+# linting
+define get_latest_lint_release
+	curl -s "https://api.github.com/repos/golangci/golangci-lint/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'
+endef
+LATEST_LINT_VERSION=$(shell $(call get_latest_lint_release))
+INSTALLED_LINT_VERSION=$(shell golangci-lint --version 2>/dev/null | awk '{print "v"$$4}')
+
+# get GOPATH according to OS
 ifeq ($(OS),Windows_NT) # is Windows_NT on XP, 2000, 7, Vista, 10...
     GOPATH=$(go env GOPATH)
 else
     GOPATH=$(shell go env GOPATH)
 endif
 
-# Binary name
-BINARY_NAME=wakatime-cli
-
+# targets
 build-all: build-darwin build-linux build-windows
 
 build-darwin:
@@ -27,12 +36,15 @@ build-linux:
 build-windows:
 	CGO_ENABLED=1 GOOS=windows GOARCH=amd64 $(GOBUILD) -o ./build/windows/amd64/$(BINARY_NAME).exe -v
 
-# Install linter
+# install linter
 .PHONY: install-linter
 install-linter:
-	hash golangci-lint 2>/dev/null || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin v1.32.2
+ifneq "$(INSTALLED_LINT_VERSION)" "$(LATEST_LINT_VERSION)"
+	@echo "new golangci-lint version found:" $(LATEST_LINT_VERSION)
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin latest
+endif
 
-# Run static analysis tools, configuration in ./.golangci.yml file
+# run static analysis tools, configuration in ./.golangci.yml file
 .PHONY: lint
 lint: install-linter
 	golangci-lint run ./...


### PR DESCRIPTION
This PR changes `Makefile` to always check if `golangci-lint` is up to date and get the latest features from the latest release. It avoids keeping an old binary installed.