### PR TITLE
Language detection from vim modeline

### DIFF
--- a/pkg/language/language.go
+++ b/pkg/language/language.go
@@ -72,11 +72,24 @@ func Detect(fp string) (heartbeat.Language, error) {
 		return language, nil
 	}
 
-	if language, ok := chromaMatchCustomized(fp); ok {
-		return language, nil
+	var language heartbeat.Language
+
+	languageChroma, weight, ok := detectChromaCustomized(fp)
+	if ok {
+		language = languageChroma
 	}
 
-	return heartbeat.LanguageUnknown, fmt.Errorf("could not detect the language of file %q", fp)
+	languageVim, weightVim, okVim := detectVimModeline(fp)
+	if okVim && weightVim > weight {
+		// use language from vim modeline, if weight is higher
+		language = languageVim
+	}
+
+	if language == heartbeat.LanguageUnknown {
+		return heartbeat.LanguageUnknown, fmt.Errorf("could not detect the language of file %q", fp)
+	}
+
+	return language, nil
 }
 
 // detectSpecialCases detects the language by file extension for some special cases.

--- a/pkg/language/vim.go
+++ b/pkg/language/vim.go
@@ -1,0 +1,38 @@
+package language
+
+import (
+	"regexp"
+
+	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
+
+	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers"
+)
+
+var modelineRegex = regexp.MustCompile(`(?m)(?:vi|vim|ex)(?:[<=>]?\d*)?:.*(?:ft|filetype|syn|syntax)=([^:\s]+)`)
+
+// detectVimModeline tries to detect the language from the vim modeline.
+func detectVimModeline(text string) (heartbeat.Language, float32, bool) {
+	matches := modelineRegex.FindStringSubmatch(text)
+
+	if matches == nil || len(matches) != 2 {
+		return heartbeat.LanguageUnknown, 0, false
+	}
+
+	lang, ok := Parse(matches[1], "vim")
+	if !ok {
+		return heartbeat.LanguageUnknown, 0, false
+	}
+
+	lexer := lexers.Get(lang.StringChroma())
+	if lexer == nil {
+		return heartbeat.LanguageUnknown, 0, false
+	}
+
+	analyser, ok := lexer.(chroma.Analyser)
+	if !ok {
+		return heartbeat.LanguageUnknown, 0, false
+	}
+
+	return lang, analyser.AnalyseText(text), true
+}

--- a/pkg/language/vim_internal_test.go
+++ b/pkg/language/vim_internal_test.go
@@ -1,0 +1,56 @@
+package language
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetectVimModeline(t *testing.T) {
+	tests := map[string]struct {
+		Text     string
+		Language heartbeat.Language
+		Error    error
+	}{
+		"ft": {
+			Text:     `/* vim: ft=python tw=60 ts=2: */`,
+			Language: heartbeat.LanguagePython,
+		},
+		"filetype": {
+			Text:     "/* vim: filetype=python tw=60 ts=2: */",
+			Language: heartbeat.LanguagePython,
+		},
+		"syn": {
+			Text:     "/* vim: syn=python tw=60 ts=2: */",
+			Language: heartbeat.LanguagePython,
+		},
+		"syntax": {
+			Text:     "/* vim: syntax=python tw=60 ts=2: */",
+			Language: heartbeat.LanguagePython,
+		},
+		"different order": {
+			Text:     "/* vim: tw=60 ft=python ts=2: */",
+			Language: heartbeat.LanguagePython,
+		},
+		"multiline": {
+			Text: `
+			/* vim: tw=60 ft=python ts=2: */
+			`,
+			Language: heartbeat.LanguagePython,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			lang, weight, ok := detectVimModeline(test.Text)
+			require.True(t, ok)
+
+			assert.Equal(t, float32(0), weight)
+			assert.Equal(t, test.Language, lang, fmt.Sprintf("Got: %q, want: %q", lang, test.Language))
+		})
+	}
+}


### PR DESCRIPTION
This PR adds language detection from vim modeline.

- This is done via vim modeline parsing function, which borrows logic from pygment's `get_filetype_from_buffer()`/`get_filetype_from_line()` (https://github.com/pygments/pygments/blob/master/pygments/modeline.py#L29) and integrate into it language detection.
- Naming is a little bit adjusted to be more consistent.