### PR TITLE
Add lines-in-file argument

### DIFF
--- a/cmd/legacy/heartbeat/heartbeat.go
+++ b/cmd/legacy/heartbeat/heartbeat.go
@@ -165,7 +165,9 @@ func SendHeartbeats(v *viper.Viper) error {
 			Include:                    params.Filter.Include,
 			IncludeOnlyWithProjectFile: params.Filter.IncludeOnlyWithProjectFile,
 		}),
-		filestats.WithDetection(),
+		filestats.WithDetection(filestats.Config{
+			LinesInFile: params.LinesInFile,
+		}),
 		language.WithDetection(language.Config{
 			Alternate: params.Language.Alternate,
 			Override:  params.Language.Override,

--- a/cmd/legacy/heartbeat/params.go
+++ b/cmd/legacy/heartbeat/params.go
@@ -44,6 +44,7 @@ type Params struct {
 	Hostname        string
 	IsWrite         *bool
 	LineNumber      *int
+	LinesInFile     *int
 	LocalFile       string
 	OfflineDisabled bool
 	OfflineSyncMax  int
@@ -73,11 +74,16 @@ func (p Params) String() string {
 		lineNumber = strconv.Itoa(*p.LineNumber)
 	}
 
+	var linesInFile string
+	if p.LinesInFile != nil {
+		linesInFile = strconv.Itoa(*p.LinesInFile)
+	}
+
 	return fmt.Sprintf(
 		"api key: %q, api url: %q, category: %q, cursor position: %q, entity: %q,"+
 			" entity type: %q, num extra heartbeats: %d, hostname: %q, is write: %t,"+
-			" line number: %q, offline disabled: %t, offline sync max: %d, plugin: %q,"+
-			" time: %.5f, timeout: %s, filter params: (%s), language params: (%s)"+
+			" line number: %q, lines in file: %q, offline disabled: %t, offline sync max: %d, "+
+			" plugin: %q, time: %.5f, timeout: %s, filter params: (%s), language params: (%s)"+
 			" network params: (%s), project params: (%s), sanitize params: (%s)",
 		p.APIKey[:4]+"...",
 		p.APIUrl,
@@ -89,6 +95,7 @@ func (p Params) String() string {
 		p.Hostname,
 		isWrite,
 		lineNumber,
+		linesInFile,
 		p.OfflineDisabled,
 		p.OfflineSyncMax,
 		p.Plugin,
@@ -263,6 +270,11 @@ func LoadParams(v *viper.Viper) (Params, error) {
 		lineNumber = heartbeat.Int(num)
 	}
 
+	var linesInFile *int
+	if num := v.GetInt("lines-in-file"); v.IsSet("lines-in-file") {
+		linesInFile = heartbeat.Int(num)
+	}
+
 	offlineDisabled := vipertools.FirstNonEmptyBool(v, "disableoffline", "disable-offline")
 	if b := v.GetBool("settings.offline"); v.IsSet("settings.offline") {
 		offlineDisabled = !b
@@ -330,6 +342,7 @@ func LoadParams(v *viper.Viper) (Params, error) {
 		Hostname:        hostname,
 		IsWrite:         isWrite,
 		LineNumber:      lineNumber,
+		LinesInFile:     linesInFile,
 		LocalFile:       v.GetString("local-file"),
 		OfflineDisabled: offlineDisabled,
 		OfflineSyncMax:  offlineSyncMax,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -117,6 +117,11 @@ func setFlags(cmd *cobra.Command, v *viper.Viper) {
 	flags.String("key", "", "Your wakatime api key; uses api_key from ~/.wakatime.cfg by default.")
 	flags.String("language", "", "Optional language name. If valid, takes priority over auto-detected language.")
 	flags.Int("lineno", 0, "Optional line number. This is the current line being edited.")
+	flags.Int(
+		"lines-in-file",
+		0,
+		"Optional lines in the file. Normally, this is detected automatically but"+
+			" can be provided manually for performance, accuracy, or when using --local-file.")
 	flags.String(
 		"local-file",
 		"",

--- a/pkg/filestats/filestats.go
+++ b/pkg/filestats/filestats.go
@@ -15,43 +15,56 @@ import (
 // bytes will not have a line count stat for performance. Default is 2MB (2*1024*1014).
 const maxFileSizeSupported = 2097152
 
+// Config contains configurations for file stats.
+type Config struct {
+	LinesInFile *int
+}
+
 // WithDetection initializes and returns a heartbeat handle option, which
 // can be used in a heartbeat processing pipeline to detect filestats. At the
 // moment only the total number of lines in a file is detected.
-func WithDetection() heartbeat.HandleOption {
+func WithDetection(c Config) heartbeat.HandleOption {
 	return func(next heartbeat.Handle) heartbeat.Handle {
 		return func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
 			for n, h := range hh {
-				if h.EntityType == heartbeat.FileType {
-					filepath := h.Entity
-					if h.LocalFile != "" {
-						filepath = h.LocalFile
-					}
-
-					fileInfo, err := os.Stat(filepath)
-					if err != nil {
-						jww.WARN.Printf("failed to retrieve file stats of file %q: %s", filepath, err)
-						continue
-					}
-
-					if fileInfo.Size() > maxFileSizeSupported {
-						jww.DEBUG.Printf(
-							"file %q exceeds max file size of %d bytes. Lines won't be counted",
-							h.Entity,
-							maxFileSizeSupported,
-						)
-
-						continue
-					}
-
-					lines, err := countLineNumbers(filepath)
-					if err != nil {
-						jww.WARN.Printf("failed to detect the total number of lines in file %q: %s", filepath, err)
-						continue
-					}
-
-					hh[n].Lines = heartbeat.Int(lines)
+				if h.EntityType != heartbeat.FileType {
+					continue
 				}
+
+				filepath := h.Entity
+				if h.LocalFile != "" {
+					filepath = h.LocalFile
+				}
+
+				if c.LinesInFile != nil {
+					hh[n].Lines = heartbeat.Int(*c.LinesInFile)
+
+					continue
+				}
+
+				fileInfo, err := os.Stat(filepath)
+				if err != nil {
+					jww.WARN.Printf("failed to retrieve file stats of file %q: %s", filepath, err)
+					continue
+				}
+
+				if fileInfo.Size() > maxFileSizeSupported {
+					jww.DEBUG.Printf(
+						"file %q exceeds max file size of %d bytes. Lines won't be counted",
+						h.Entity,
+						maxFileSizeSupported,
+					)
+
+					continue
+				}
+
+				lines, err := countLineNumbers(filepath)
+				if err != nil {
+					jww.WARN.Printf("failed to detect the total number of lines in file %q: %s", filepath, err)
+					continue
+				}
+
+				hh[n].Lines = heartbeat.Int(lines)
 			}
 
 			return next(hh)


### PR DESCRIPTION
This PR adds a new argument `--lines-in-file` to be used when local file contain only the head of the file and the count of total lines might be wrong.

fixes: https://github.com/wakatime/wakatime-cli/issues/126