### PR TITLE
Add rust dependency parser

### DIFF
--- a/pkg/deps/rust.go
+++ b/pkg/deps/rust.go
@@ -1,0 +1,85 @@
+package deps
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"strings"
+
+	"github.com/alecthomas/chroma"
+)
+
+// StateRust is a token parsing state.
+type StateRust int
+
+const (
+	// StateRustUnknown represents a unknown token parsing state.
+	StateRustUnknown StateRust = iota
+	// StateRustExtern means we are in extern section during token parsing.
+	StateRustExtern
+	// StateRustExternCrate means we are in extern crate section during token parsing.
+	StateRustExternCrate
+)
+
+// ParserRust is a dependency parser for the rust programming language.
+// It is not thread safe.
+type ParserRust struct {
+	State  StateRust
+	Output []string
+}
+
+// Parse parses dependencies from rust file content via ReadCloser using the chroma rust lexer.
+func (p *ParserRust) Parse(reader io.ReadCloser, lexer chroma.Lexer) ([]string, error) {
+	defer reader.Close()
+
+	p.init()
+	defer p.init()
+
+	data, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read from reader: %s", err)
+	}
+
+	iter, err := lexer.Tokenise(&chroma.TokeniseOptions{
+		State:    "root",
+		EnsureLF: true,
+	}, string(data))
+	if err != nil {
+		return nil, fmt.Errorf("failed to tokenize file content: %s", err)
+	}
+
+	for _, token := range iter.Tokens() {
+		p.processToken(token)
+	}
+
+	return p.Output, nil
+}
+
+func (p *ParserRust) init() {
+	p.Output = []string{}
+}
+
+func (p *ParserRust) processToken(token chroma.Token) {
+	switch token.Type {
+	case chroma.Keyword:
+		p.processKeyword(token.Value)
+	case chroma.Name:
+		p.processName(token.Value)
+	}
+}
+
+func (p *ParserRust) processKeyword(value string) {
+	if p.State == StateRustExtern && value == "crate" {
+		p.State = StateRustExternCrate
+	} else if value == "extern" {
+		p.State = StateRustExtern
+	}
+}
+
+func (p *ParserRust) processName(value string) {
+	if p.State == StateRustExternCrate {
+		p.Output = append(p.Output, strings.TrimSpace(value))
+	}
+
+	p.State = StateRustUnknown
+}

--- a/pkg/deps/rust_test.go
+++ b/pkg/deps/rust_test.go
@@ -1,0 +1,31 @@
+package deps_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/alecthomas/chroma/lexers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wakatime/wakatime-cli/pkg/deps"
+	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
+)
+
+func TestParserRust_Parse(t *testing.T) {
+	lexer := lexers.Get(heartbeat.LanguageRust.StringChroma())
+
+	f, err := os.Open("testdata/rust.rs")
+	require.NoError(t, err)
+
+	parser := deps.ParserRust{}
+
+	dependencies, err := parser.Parse(f, lexer)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{
+		`proc_macro`,
+		`phrases`,
+		`syn`,
+		`quote`,
+	}, dependencies)
+}

--- a/pkg/deps/testdata/rust.rs
+++ b/pkg/deps/testdata/rust.rs
@@ -1,0 +1,21 @@
+extern crate proc_macro;
+extern crate phrases as sayings;
+extern crate syn;
+#[macro_use]
+extern crate quote;
+
+use sayings::japanese::greetings as ja_greetings;
+use sayings::japanese::farewells::*;
+use sayings::english::{self, greetings as en_greetings, farewells as en_farewells};
+
+extern "C" {
+    fn c_callback(n: c_int);
+}
+
+fn main() {
+    println!("Hello in English; {}", en_greetings::hello());
+    println!("And in Japanese: {}", ja_greetings::hello());
+    println!("Goodbye in English: {}", english::farewells::goodbye());
+    println!("Again: {}", en_farewells::goodbye());
+    println!("And in Japanese: {}", goodbye());
+}


### PR DESCRIPTION
This PR ports Rust dependency parser from Python. Original code can be found at: https://github.com/wakatime/wakatime/blob/master/wakatime/dependencies/rust.py#L15

fixes: https://github.com/wakatime/wakatime-cli/issues/139