### PR TITLE
Add elm dependency parser

### DIFF
--- a/pkg/deps/deps.go
+++ b/pkg/deps/deps.go
@@ -75,6 +75,8 @@ func Detect(filepath string, language heartbeat.Language) ([]string, error) {
 	var parser DependencyParser
 
 	switch language {
+	case heartbeat.LanguageElm:
+		parser = &ParserElm{}
 	case heartbeat.LanguageGo:
 		parser = &ParserGo{}
 	case heartbeat.LanguageRust:

--- a/pkg/deps/deps_test.go
+++ b/pkg/deps/deps_test.go
@@ -154,6 +154,11 @@ func TestDetect(t *testing.T) {
 		Language     heartbeat.Language
 		Dependencies []string
 	}{
+		"elm": {
+			Filepath:     "testdata/elm_minimal.elm",
+			Language:     heartbeat.LanguageElm,
+			Dependencies: []string{"Html"},
+		},
 		"golang": {
 			Filepath: "testdata/golang_minimal.go",
 			Language: heartbeat.LanguageGo,

--- a/pkg/deps/elm.go
+++ b/pkg/deps/elm.go
@@ -1,0 +1,87 @@
+package deps
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"strings"
+
+	"github.com/alecthomas/chroma"
+)
+
+// StateElm is a token parsing state.
+type StateElm int
+
+const (
+	// StateElmUnknown represents a unknown token parsing state.
+	StateElmUnknown StateElm = iota
+	// StateElmImport means we are in import during token parsing.
+	StateElmImport
+)
+
+// ParserElm is a dependency parser for the elm programming language.
+// It is not thread safe.
+type ParserElm struct {
+	State  StateElm
+	Output []string
+}
+
+// Parse parses dependencies from elm file content via ReadCloser using the chroma elm lexer.
+func (p *ParserElm) Parse(reader io.ReadCloser, lexer chroma.Lexer) ([]string, error) {
+	defer reader.Close()
+
+	p.init()
+	defer p.init()
+
+	data, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read from reader: %s", err)
+	}
+
+	iter, err := lexer.Tokenise(&chroma.TokeniseOptions{
+		State:    "root",
+		EnsureLF: true,
+	}, string(data))
+	if err != nil {
+		return nil, fmt.Errorf("failed to tokenize file content: %s", err)
+	}
+
+	for _, token := range iter.Tokens() {
+		p.processToken(token)
+	}
+
+	return p.Output, nil
+}
+
+func (p *ParserElm) append(dep string) {
+	p.Output = append(p.Output, strings.TrimSpace(strings.Split(dep, ".")[0]))
+}
+
+func (p *ParserElm) init() {
+	p.Output = []string{}
+}
+
+func (p *ParserElm) processToken(token chroma.Token) {
+	switch token.Type {
+	case chroma.KeywordNamespace:
+		p.processNamespace(token.Value)
+	case chroma.NameClass:
+		p.processClass(token.Value)
+	default:
+		p.State = StateElmUnknown
+	}
+}
+
+func (p *ParserElm) processNamespace(value string) {
+	if strings.TrimSpace(value) == "import" {
+		p.State = StateElmImport
+	} else {
+		p.State = StateElmUnknown
+	}
+}
+
+func (p *ParserElm) processClass(value string) {
+	if p.State == StateElmImport {
+		p.append(value)
+	}
+}

--- a/pkg/deps/elm_test.go
+++ b/pkg/deps/elm_test.go
@@ -1,0 +1,34 @@
+package deps_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/alecthomas/chroma/lexers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wakatime/wakatime-cli/pkg/deps"
+	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
+)
+
+func TestParserElm_Parse(t *testing.T) {
+	lexer := lexers.Get(heartbeat.LanguageElm.StringChroma())
+
+	f, err := os.Open("testdata/elm.elm")
+	require.NoError(t, err)
+
+	parser := deps.ParserElm{}
+
+	dependencies, err := parser.Parse(f, lexer)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{
+		"Color",
+		"Dict",
+		"TempFontAwesome",
+		"Html",
+		"Html",
+		"Markdown",
+		"String",
+	}, dependencies)
+}

--- a/pkg/deps/testdata/elm.elm
+++ b/pkg/deps/testdata/elm.elm
@@ -1,0 +1,21 @@
+module Index exposing (..) -- where
+
+import Color exposing (Color, darkGrey)
+import Dict
+import TempFontAwesome as FA
+import Html exposing (..)
+import Html.Attributes exposing (..)
+import Markdown
+import String
+
+
+-- MAIN
+
+
+main =
+  Html.programWithFlags
+    { init = init
+    , view = view
+    , update = update
+    , subscriptions = subscriptions
+    }

--- a/pkg/deps/testdata/elm_minimal.elm
+++ b/pkg/deps/testdata/elm_minimal.elm
@@ -1,0 +1,5 @@
+import Html exposing (text)
+
+
+main =
+  text "Hello!"


### PR DESCRIPTION
This PR ports Elm dependency parser from Python. Original code can be found at: https://github.com/wakatime/wakatime/blob/master/wakatime/dependencies/elm.py#L15

The dependencies must be unique in the outputted list. In this PR I also added `append2` (open to name suggestions) to not allow duplicate entries in the list. Afterwards I'll apply the same for `Rust` and `Go`.

fixes: https://github.com/wakatime/wakatime-cli/issues/151