### PR TITLE
Skip deps scanning if sensitive data is hidden

### DIFF
--- a/cmd/legacy/heartbeat/heartbeat.go
+++ b/cmd/legacy/heartbeat/heartbeat.go
@@ -173,7 +173,9 @@ func SendHeartbeats(v *viper.Viper) error {
 			Alternate: params.Language.Alternate,
 			Override:  params.Language.Override,
 		}),
-		deps.WithDetection(),
+		deps.WithDetection(deps.Config{
+			FilePatterns: params.Sanitize.HideFileNames,
+		}),
 		project.WithDetection(project.Config{
 			Alternate:              params.Project.Alternate,
 			Override:               params.Project.Override,

--- a/pkg/deps/deps_test.go
+++ b/pkg/deps/deps_test.go
@@ -1,17 +1,19 @@
 package deps_test
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/wakatime/wakatime-cli/pkg/deps"
 	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
+	"github.com/wakatime/wakatime-cli/pkg/regex"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestWithDetection(t *testing.T) {
-	opt := deps.WithDetection()
+	opt := deps.WithDetection(deps.Config{})
 
 	h := opt(func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
 		assert.Equal(t, []heartbeat.Heartbeat{
@@ -44,8 +46,37 @@ func TestWithDetection(t *testing.T) {
 	}, result)
 }
 
+func TestWithDetection_SkipSanitized(t *testing.T) {
+	opt := deps.WithDetection(deps.Config{
+		FilePatterns: []regex.Regex{regexp.MustCompile(".*")},
+	})
+
+	h := opt(func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+		assert.Len(t, hh[0].Dependencies, 0)
+
+		return []heartbeat.Result{
+			{
+				Status: 201,
+			},
+		}, nil
+	})
+
+	result, err := h([]heartbeat.Heartbeat{{
+		Entity:     "testdata/golang.go",
+		EntityType: heartbeat.FileType,
+		Language:   heartbeat.LanguageGo,
+	}})
+	require.NoError(t, err)
+
+	assert.Equal(t, []heartbeat.Result{
+		{
+			Status: 201,
+		},
+	}, result)
+}
+
 func TestWithDetection_LocalFile(t *testing.T) {
-	opt := deps.WithDetection()
+	opt := deps.WithDetection(deps.Config{})
 
 	h := opt(func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
 		assert.Equal(t, []heartbeat.Heartbeat{
@@ -81,7 +112,7 @@ func TestWithDetection_LocalFile(t *testing.T) {
 }
 
 func TestWithDetection_NonFileType(t *testing.T) {
-	opt := deps.WithDetection()
+	opt := deps.WithDetection(deps.Config{})
 
 	h := opt(func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
 		assert.Equal(t, []heartbeat.Heartbeat{


### PR DESCRIPTION
This PR adds a feature to deps which will skip any dependency scanning when sensitive data is hidden. It'll avoid any extra cpu usages.