### PR TITLE
Skip lines counting if it's already done

### DIFF
--- a/pkg/filestats/filestats.go
+++ b/pkg/filestats/filestats.go
@@ -31,6 +31,10 @@ func WithDetection(c Config) heartbeat.HandleOption {
 					continue
 				}
 
+				if h.Lines != nil {
+					continue
+				}
+
 				filepath := h.Entity
 				if h.LocalFile != "" {
 					filepath = h.LocalFile


### PR DESCRIPTION
This PR makes `filestats.WithDetection` to skip counting line numbers if it's already done. It's a preparation for another PR which will change extra heartbeats behaviour.