### PR TITLE
Reliable order of dependencies

### DIFF
--- a/pkg/deps/deps.go
+++ b/pkg/deps/deps.go
@@ -92,19 +92,19 @@ func Detect(filepath string, language heartbeat.Language) ([]string, error) {
 }
 
 func filterDependencies(deps []string) []string {
-	filtered := make(map[string]struct{})
+	var (
+		results []string
+		unique  = make(map[string]struct{})
+	)
 
 	for _, d := range deps {
-		if _, ok := filtered[d]; ok {
+		if _, ok := unique[d]; ok {
 			continue
 		}
 
-		filtered[d] = struct{}{}
-	}
+		unique[d] = struct{}{}
 
-	var results []string
-	for k := range filtered {
-		results = append(results, k)
+		results = append(results, d)
 	}
 
 	return results


### PR DESCRIPTION
This PR prevents change of order of dependencies in duplicated filtering. The problem was the usage of a map to filter our dependencies, which does not guarantee the order of elements. This lead to `Test_Detect` being flaky and failing on some occasions.

The problem is solved by using the map alongside the results slice in one for loop. This way, the order is preserved.
 