### PR TITLE
add ignore case to golang parser exclude regex

### DIFF
--- a/pkg/deps/golang.go
+++ b/pkg/deps/golang.go
@@ -10,7 +10,7 @@ import (
 	"github.com/alecthomas/chroma"
 )
 
-var parserGoFmtRegex = regexp.MustCompile(`^"fmt"$`)
+var goExcludeRegex = regexp.MustCompile(`(?i)^"fmt"$`)
 
 // StateGo is a token parsing state.
 type StateGo int
@@ -58,7 +58,7 @@ func (p *ParserGo) Parse(reader io.ReadCloser, lexer chroma.Lexer) ([]string, er
 }
 
 func (p *ParserGo) append(dep string) {
-	if parserGoFmtRegex.MatchString(dep) {
+	if goExcludeRegex.MatchString(dep) {
 		return
 	}
 


### PR DESCRIPTION
This PR adds missing ignore case to the exclude regex. https://github.com/wakatime/wakatime/blob/16b00ff4a63a8d72d5de733ed39180298de26969/wakatime%2Fdependencies%2F__init__.py#L35