### PR TITLE
Add java dependency parser

### DIFF
--- a/pkg/deps/deps.go
+++ b/pkg/deps/deps.go
@@ -87,6 +87,8 @@ func Detect(filepath string, language heartbeat.Language) ([]string, error) {
 		parser = &ParserGo{}
 	case heartbeat.LanguageHaxe:
 		parser = &ParserHaxe{}
+	case heartbeat.LanguageJava:
+		parser = &ParserJava{}
 	case heartbeat.LanguagePHP:
 		parser = &ParserPHP{}
 	case heartbeat.LanguagePython:

--- a/pkg/deps/deps_test.go
+++ b/pkg/deps/deps_test.go
@@ -164,6 +164,11 @@ func TestDetect(t *testing.T) {
 			Language:     heartbeat.LanguageElm,
 			Dependencies: []string{"Html"},
 		},
+		"java": {
+			Filepath:     "testdata/java_minimal.java",
+			Language:     heartbeat.LanguageJava,
+			Dependencies: []string{"foobar"},
+		},
 		"golang": {
 			Filepath: "testdata/golang_minimal.go",
 			Language: heartbeat.LanguageGo,

--- a/pkg/deps/java.go
+++ b/pkg/deps/java.go
@@ -1,0 +1,167 @@
+package deps
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"regexp"
+	"strings"
+
+	"github.com/alecthomas/chroma"
+)
+
+var javaExcludeRegex = regexp.MustCompile(`(?i)^(java\..*|javax\..*)`)
+
+// StateJava is a token parsing state.
+type StateJava int
+
+const (
+	// StateJavaUnknown represents a unknown token parsing state.
+	StateJavaUnknown StateJava = iota
+	// StateJavaImport means we are in import section during token parsing.
+	StateJavaImport
+	// StateJavaImportFinished means we finished import section during token parsing.
+	StateJavaImportFinished
+)
+
+// ParserJava is a dependency parser for the java programming language.
+// It is not thread safe.
+type ParserJava struct {
+	Buffer string
+	State  StateJava
+	Output []string
+}
+
+// Parse parses dependencies from java file content via ReadCloser using the chroma java lexer.
+func (p *ParserJava) Parse(reader io.ReadCloser, lexer chroma.Lexer) ([]string, error) {
+	defer reader.Close()
+
+	p.init()
+	defer p.init()
+
+	data, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read from reader: %s", err)
+	}
+
+	iter, err := lexer.Tokenise(nil, string(data))
+	if err != nil {
+		return nil, fmt.Errorf("failed to tokenize file content: %s", err)
+	}
+
+	for _, token := range iter.Tokens() {
+		p.processToken(token)
+	}
+
+	return p.Output, nil
+}
+
+func (p *ParserJava) append(dep string) {
+	if javaExcludeRegex.MatchString(dep) {
+		return
+	}
+
+	if len(strings.TrimSpace(dep)) == 0 {
+		return
+	}
+
+	p.Output = append(p.Output, dep)
+}
+
+func (p *ParserJava) init() {
+	p.State = StateJavaUnknown
+	p.Output = nil
+}
+
+func (p *ParserJava) processToken(token chroma.Token) {
+	switch token.Type {
+	case chroma.KeywordNamespace:
+		p.processKeywordNamespace(token.Value)
+	case chroma.Name:
+		p.processName(token.Value)
+	case chroma.NameAttribute:
+		p.processNameAttribute(token.Value)
+	case chroma.NameNamespace:
+		p.processNameNamespace(token.Value)
+	case chroma.Operator:
+		p.processOperator(token.Value)
+	}
+}
+
+func (p *ParserJava) processKeywordNamespace(value string) {
+	splitted := strings.Fields(value)
+	if len(splitted) > 0 && splitted[0] == "import" {
+		p.State = StateJavaImport
+		return
+	}
+
+	if p.State != StateJavaImportFinished {
+		return
+	}
+
+	splitted = strings.Split(value, ".")
+	if len(splitted) == 1 {
+		p.append(splitted[0])
+		p.State = StateJavaUnknown
+
+		return
+	}
+
+	if len(splitted) == 0 {
+		p.State = StateJavaUnknown
+		return
+	}
+
+	// remove leading top-level domain
+	if len(splitted[0]) == 3 {
+		splitted = splitted[1:]
+	}
+
+	// remove trailing asterisk
+	if splitted[len(splitted)-1] == "*" {
+		splitted = splitted[:len(splitted)-1]
+	}
+
+	switch {
+	case len(splitted) == 1:
+		p.append(splitted[0])
+	case len(splitted) > 1:
+		// use first 2 elements
+		p.append(strings.Join(splitted[:2], "."))
+	}
+
+	p.State = StateJavaUnknown
+}
+
+func (p *ParserJava) processName(value string) {
+	if p.State == StateJavaImport {
+		p.Buffer += value
+	}
+}
+
+func (p *ParserJava) processNameAttribute(value string) {
+	if p.State == StateJavaImport {
+		p.Buffer += value
+	}
+}
+
+func (p *ParserJava) processNameNamespace(value string) {
+	if p.State == StateJavaImport && value != "package" && value != "namespace" && value != "static" {
+		p.Buffer += value
+	}
+}
+
+func (p *ParserJava) processOperator(value string) {
+	if value == ";" {
+		p.State = StateJavaImportFinished
+		p.processKeywordNamespace(p.Buffer)
+		p.State = StateJavaUnknown
+		p.Buffer = ""
+
+		return
+	}
+
+	if p.State == StateJavaImport {
+		p.Buffer += value
+	}
+}

--- a/pkg/deps/java_test.go
+++ b/pkg/deps/java_test.go
@@ -1,0 +1,33 @@
+package deps_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/wakatime/wakatime-cli/pkg/deps"
+	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
+
+	"github.com/alecthomas/chroma/lexers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParserJava_Parse(t *testing.T) {
+	lexer := lexers.Get(heartbeat.LanguageJava.StringChroma())
+
+	f, err := os.Open("testdata/java.java")
+	require.NoError(t, err)
+
+	parser := deps.ParserJava{}
+
+	dependencies, err := parser.Parse(f, lexer)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{
+		"googlecode.javacv",
+		"colorfulwolf.webcamapplet",
+		"foobar",
+		"apackage.something",
+		"anamespace.other",
+	}, dependencies)
+}

--- a/pkg/deps/testdata/java.java
+++ b/pkg/deps/testdata/java.java
@@ -1,0 +1,22 @@
+// Hello.java
+import java.io.*;
+import static java.lang.Math.*;
+import static com.googlecode.javacv.jna.highgui.cvReleaseCapture;
+import javax.servlet.*;
+import com.colorfulwolf.webcamapplet.gui.ImagePanel;
+import com.foobar.*;
+import package com.apackage.something;
+import namespace com.anamespace.other;
+
+public class Hello extends GenericServlet {
+    public void service(final ServletRequest request, final ServletResponse response)
+    throws ServletException, IOException {
+        response.setContentType("text/html");
+        final PrintWriter pw = response.getWriter();
+        try {
+            pw.println("Hello, world!");
+        } finally {
+            pw.close();
+        }
+    }
+}

--- a/pkg/deps/testdata/java_minimal.java
+++ b/pkg/deps/testdata/java_minimal.java
@@ -1,0 +1,7 @@
+import com.foobar.*;
+
+class HelloWorld {
+    public static void main(String []args) {
+        System.out.println("Hello World!");
+    }
+}


### PR DESCRIPTION
This PR adds a dependency parser for the Java programming language to `deps` package. The original implementation in wakatime python cli can be found at: https://github.com/wakatime/wakatime/blob/master/wakatime/dependencies/jvm.py#L16. Test case taken from: https://github.com/wakatime/wakatime/blob/master/tests/test_dependencies.py#L276

- The exclude regex was a little bit changed by removing the keywords `import`, `package`, `namespace` and `static` since them is already filtered out and not interpreted as the name of an imported  package.
- `chroma.NameNamespace` type calls `processKeywordNamespace()`.
- `lexer.Tokenise()` does not need the options passed since it uses a default when not set which is the same as we were passing. https://github.com/wakatime/chroma/blob/master/regexp.go#L429
- Parsing Punctuation has been not ported because in Chroma it has been merged to Operator token as seen [here](https://github.com/wakatime/chroma/blob/master/lexers/j/java.go#L41) and [here](https://github.com/pygments/pygments/blob/master/pygments/lexers/jvm.py#L87).

Closes #144 

