### PR TITLE
Add C# dependency parser

### DIFF
--- a/pkg/deps/csharp.go
+++ b/pkg/deps/csharp.go
@@ -1,0 +1,121 @@
+package deps
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"regexp"
+	"strings"
+
+	"github.com/alecthomas/chroma"
+)
+
+var csharpExcludeRegex = regexp.MustCompile(`(?i)^(system|microsoft)$`)
+
+// StateCSharp is a token parsing state.
+type StateCSharp int
+
+const (
+	// StateCSharpUnknown represents a unknown token parsing state.
+	StateCSharpUnknown StateCSharp = iota
+	// StateCSharpImport means we are in import section during token parsing.
+	StateCSharpImport
+)
+
+// ParserCSharp is a dependency parser for the c# programming language.
+// It is not thread safe.
+type ParserCSharp struct {
+	State  StateCSharp
+	Buffer string
+	Output []string
+}
+
+// Parse parses dependencies from c# file content via ReadCloser using the chroma c# lexer.
+func (p *ParserCSharp) Parse(reader io.ReadCloser, lexer chroma.Lexer) ([]string, error) {
+	defer reader.Close()
+
+	p.init()
+	defer p.init()
+
+	data, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read from reader: %s", err)
+	}
+
+	iter, err := lexer.Tokenise(nil, string(data))
+	if err != nil {
+		return nil, fmt.Errorf("failed to tokenize file content: %s", err)
+	}
+
+	for _, token := range iter.Tokens() {
+		p.processToken(token)
+	}
+
+	return p.Output, nil
+}
+
+func (p *ParserCSharp) append(dep string) {
+	dep = strings.TrimSpace(strings.Split(dep, ".")[0])
+
+	if len(dep) == 0 {
+		return
+	}
+
+	if csharpExcludeRegex.MatchString(dep) {
+		return
+	}
+
+	p.Output = append(p.Output, dep)
+}
+
+func (p *ParserCSharp) init() {
+	p.State = StateCSharpUnknown
+	p.Output = nil
+}
+
+func (p *ParserCSharp) processToken(token chroma.Token) {
+	switch token.Type {
+	case chroma.Keyword:
+		p.processKeyword(token.Value)
+	case chroma.Name, chroma.NameNamespace:
+		p.processName(token.Value)
+	case chroma.Punctuation:
+		p.processPunctuation(token.Value)
+	}
+}
+
+func (p *ParserCSharp) processKeyword(value string) {
+	if value == "using" {
+		p.State = StateCSharpImport
+		p.Buffer = ""
+	}
+}
+
+func (p *ParserCSharp) processName(value string) {
+	if p.State != StateCSharpImport {
+		return
+	}
+
+	switch value {
+	case "import", "package", "namespace", "static":
+	default:
+		p.Buffer += value
+	}
+}
+
+func (p *ParserCSharp) processPunctuation(value string) {
+	if p.State != StateCSharpImport {
+		return
+	}
+
+	switch value {
+	case ";":
+		p.append(p.Buffer)
+		p.Buffer = ""
+		p.State = StateCSharpUnknown
+	case "=":
+		p.Buffer = ""
+	default:
+		p.Buffer += value
+	}
+}

--- a/pkg/deps/csharp_test.go
+++ b/pkg/deps/csharp_test.go
@@ -1,0 +1,32 @@
+package deps_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/wakatime/wakatime-cli/pkg/deps"
+	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
+
+	"github.com/alecthomas/chroma/lexers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParserCSharp_Parse(t *testing.T) {
+	lexer := lexers.Get(heartbeat.LanguageCSharp.StringChroma())
+
+	f, err := os.Open("testdata/csharp.cs")
+	require.NoError(t, err)
+
+	parser := deps.ParserCSharp{}
+
+	dependencies, err := parser.Parse(f, lexer)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{
+		"WakaTime",
+		"Math",
+		"Fart",
+		"Proper",
+	}, dependencies)
+}

--- a/pkg/deps/deps.go
+++ b/pkg/deps/deps.go
@@ -81,6 +81,8 @@ func Detect(filepath string, language heartbeat.Language) ([]string, error) {
 	switch language {
 	case heartbeat.LanguageC:
 		parser = &ParserC{}
+	case heartbeat.LanguageCSharp:
+		parser = &ParserCSharp{}
 	case heartbeat.LanguageElm:
 		parser = &ParserElm{}
 	case heartbeat.LanguageGo:

--- a/pkg/deps/deps_test.go
+++ b/pkg/deps/deps_test.go
@@ -159,6 +159,11 @@ func TestDetect(t *testing.T) {
 			Language:     heartbeat.LanguageC,
 			Dependencies: []string{"openssl"},
 		},
+		"csharp": {
+			Filepath:     "testdata/csharp_minimal.cs",
+			Language:     heartbeat.LanguageCSharp,
+			Dependencies: []string{"WakaTime"},
+		},
 		"elm": {
 			Filepath:     "testdata/elm_minimal.elm",
 			Language:     heartbeat.LanguageElm,

--- a/pkg/deps/testdata/csharp.cs
+++ b/pkg/deps/testdata/csharp.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Net;
+using Microsoft.Win32;
+using WakaTime.Forms;
+using static Math.Foo;
+using Task = Fart.Threading.Tasks.Task;
+using static Proper.Bar;
+
+public class Hello4
+{
+   public static int Main(string[] args)
+   {
+      Console.WriteLine("Hello, World!");
+      return 0;
+   }
+}

--- a/pkg/deps/testdata/csharp_minimal.cs
+++ b/pkg/deps/testdata/csharp_minimal.cs
@@ -1,0 +1,11 @@
+using System;
+using WakaTime.Forms;
+
+public class Hello4
+{
+   public static int Main(string[] args)
+   {
+      Console.WriteLine("Hello, World!");
+      return 0;
+   }
+}


### PR DESCRIPTION
This PR adds a dependency parser for the C# programming language to deps package. The original implementation in wakatime python cli can be found at: https://github.com/wakatime/wakatime/blob/master/wakatime/dependencies/dotnet.py#L16. Test case taken from: https://github.com/wakatime/wakatime/blob/master/tests/test_dependencies.py#L310

Closes #152 