### PR TITLE
Add Unknown dependency parser

### DIFF
--- a/pkg/deps/deps.go
+++ b/pkg/deps/deps.go
@@ -105,8 +105,9 @@ func Detect(filepath string, language heartbeat.Language) ([]string, error) {
 	case heartbeat.LanguageVBNet:
 		parser = &ParserVbNet{}
 	default:
-		jww.DEBUG.Printf("parsing dependencies not supported for language %q", language)
-		return nil, nil
+		jww.DEBUG.Printf("No parser has been found for language %q. Using Unknown parser to detect dependencies.", language)
+
+		parser = &ParserUnknown{}
 	}
 
 	deps, err := parser.Parse(filepath)

--- a/pkg/deps/deps_test.go
+++ b/pkg/deps/deps_test.go
@@ -247,6 +247,11 @@ func TestDetect(t *testing.T) {
 			Language:     heartbeat.LanguageTypeScript,
 			Dependencies: []string{"bravo"},
 		},
+		"unknown": {
+			Filepath:     "testdata/Gruntfile",
+			Language:     heartbeat.LanguageUnknown,
+			Dependencies: []string{"grunt"},
+		},
 		"vb.net": {
 			Filepath:     "testdata/vbnet_minimal.vb",
 			Language:     heartbeat.LanguageVBNet,

--- a/pkg/deps/testdata/Gruntfile
+++ b/pkg/deps/testdata/Gruntfile
@@ -1,0 +1,23 @@
+module.exports = function(grunt) {
+
+  grunt.initConfig({
+    jshint: {
+      files: ['Gruntfile.js', 'src/**/*.js', 'test/**/*.js'],
+      options: {
+        globals: {
+          jQuery: true
+        }
+      }
+    },
+    watch: {
+      files: ['<%= jshint.files %>'],
+      tasks: ['jshint']
+    }
+  });
+
+  grunt.loadNpmTasks('grunt-contrib-jshint');
+  grunt.loadNpmTasks('grunt-contrib-watch');
+
+  grunt.registerTask('default', ['jshint']);
+
+};

--- a/pkg/deps/unknown.go
+++ b/pkg/deps/unknown.go
@@ -1,0 +1,46 @@
+package deps
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// nolint: gochecknoglobals
+var filesUnknown = map[string]struct {
+	exact      bool
+	dependency string
+}{
+	"bower": {false, "bower"},
+	"grunt": {false, "grunt"},
+}
+
+// ParserUnknown is a dependency parser for unknown parser.
+// It is not thread safe.
+type ParserUnknown struct {
+	Output []string
+}
+
+// Parse parses dependencies from any file content via ReadCloser using the chroma golang lexer.
+func (p *ParserUnknown) Parse(fp string) ([]string, error) {
+	p.init()
+	defer p.init()
+
+	filename := filepath.Base(fp)
+
+	for k, f := range filesUnknown {
+		if f.exact && k == filename {
+			p.Output = append(p.Output, f.dependency)
+			continue
+		}
+
+		if !f.exact && strings.Contains(strings.ToLower(filename), k) {
+			p.Output = append(p.Output, f.dependency)
+		}
+	}
+
+	return p.Output, nil
+}
+
+func (p *ParserUnknown) init() {
+	p.Output = nil
+}

--- a/pkg/deps/unknown_test.go
+++ b/pkg/deps/unknown_test.go
@@ -1,0 +1,41 @@
+package deps_test
+
+import (
+	"testing"
+
+	"github.com/wakatime/wakatime-cli/pkg/deps"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParserUnkwown_Parse(t *testing.T) {
+	tests := map[string]struct {
+		Filepath string
+		Expected []string
+	}{
+		"bower": {
+			Filepath: "testdata/bower.json",
+			Expected: []string{
+				"bower",
+			},
+		},
+		"grunt": {
+			Filepath: "testdata/Gruntfile",
+			Expected: []string{
+				"grunt",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			parser := deps.ParserUnknown{}
+
+			dependencies, err := parser.Parse(test.Filepath)
+			require.NoError(t, err)
+
+			assert.Equal(t, test.Expected, dependencies)
+		})
+	}
+}


### PR DESCRIPTION
This PR adds a dependency parser when no language is detected. The original implementation in wakatime python cli can be found at: https://github.com/wakatime/wakatime/blob/master/wakatime/dependencies/unknown.py#L23. Test case taken from: https://github.com/wakatime/wakatime/blob/2e636d389bf5da4e998e05d5285a96ce2c181e3d/tests%2Ftest_dependencies.py#L266

Closes #155 