### PR TITLE
Reset parser state in `init()` method of all existing dependency parsers

### DIFF
--- a/pkg/deps/elm.go
+++ b/pkg/deps/elm.go
@@ -58,6 +58,7 @@ func (p *ParserElm) append(dep string) {
 }
 
 func (p *ParserElm) init() {
+	p.State = StateElmUnknown
 	p.Output = []string{}
 }
 

--- a/pkg/deps/golang.go
+++ b/pkg/deps/golang.go
@@ -66,8 +66,9 @@ func (p *ParserGo) append(dep string) {
 }
 
 func (p *ParserGo) init() {
-	p.Output = nil
 	p.Parenthesis = 0
+	p.State = StateGoUnknown
+	p.Output = nil
 }
 
 func (p *ParserGo) processToken(token chroma.Token) {

--- a/pkg/deps/python.go
+++ b/pkg/deps/python.go
@@ -82,6 +82,7 @@ func (p *ParserPython) append(dep string) {
 
 func (p *ParserPython) init() {
 	p.Parenthesis = 0
+	p.State = StatePythonUnknown
 	p.Output = []string{}
 }
 

--- a/pkg/deps/rust.go
+++ b/pkg/deps/rust.go
@@ -56,6 +56,7 @@ func (p *ParserRust) Parse(reader io.ReadCloser, lexer chroma.Lexer) ([]string, 
 }
 
 func (p *ParserRust) init() {
+	p.State = StateRustUnknown
 	p.Output = []string{}
 }
 


### PR DESCRIPTION
This PR adds reset of the parser state to `init()` method for all existing dependency parsers.