### PR TITLE
Simplify python dependency truncate

### DIFF
--- a/pkg/deps/python.go
+++ b/pkg/deps/python.go
@@ -61,23 +61,22 @@ func (p *ParserPython) Parse(reader io.ReadCloser, lexer chroma.Lexer) ([]string
 }
 
 func (p *ParserPython) append(dep string) {
-	splitted := strings.Split(dep, ".")
+	// if dot separated import path, select first element
+	dep = strings.Split(dep, ".")[0]
 
-	if len(splitted) == 1 {
-		dep = splitted[0]
-	} else {
-		dep = strings.Join(splitted[:1], ".")
-	}
+	// trim whitespaces
+	dep = strings.TrimSpace(dep)
 
 	if len(dep) == 0 {
 		return
 	}
 
+	// filter by regex
 	if pythonExcludeRegex.MatchString(dep) {
 		return
 	}
 
-	p.Output = append(p.Output, strings.TrimSpace(dep))
+	p.Output = append(p.Output, dep)
 }
 
 func (p *ParserPython) init() {


### PR DESCRIPTION
This PR simplifies the logic, which was taken over from `_save_dependency` (https://github.com/wakatime/wakatime/blob/master/wakatime/dependencies/__init__.py#L75).

We always truncate to use the first element of a dot separated import path. `splitted[:1]`, as well as `splitted[0]` both essentially selecting the first element and we can delete the if condition and joining.