### PR TITLE
Add C dependency parser

### DIFF
--- a/pkg/deps/c_test.go
+++ b/pkg/deps/c_test.go
@@ -1,0 +1,30 @@
+package deps_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/wakatime/wakatime-cli/pkg/deps"
+	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
+
+	"github.com/alecthomas/chroma/lexers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParserC_Parse(t *testing.T) {
+	lexer := lexers.Get(heartbeat.LanguageC.StringChroma())
+
+	f, err := os.Open("testdata/c.c")
+	require.NoError(t, err)
+
+	parser := deps.ParserC{}
+
+	dependencies, err := parser.Parse(f, lexer)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{
+		"math",
+		"openssl",
+	}, dependencies)
+}

--- a/pkg/deps/deps.go
+++ b/pkg/deps/deps.go
@@ -79,6 +79,8 @@ func Detect(filepath string, language heartbeat.Language) ([]string, error) {
 	var parser DependencyParser
 
 	switch language {
+	case heartbeat.LanguageC:
+		parser = &ParserC{}
 	case heartbeat.LanguageElm:
 		parser = &ParserElm{}
 	case heartbeat.LanguageGo:

--- a/pkg/deps/deps_test.go
+++ b/pkg/deps/deps_test.go
@@ -154,6 +154,11 @@ func TestDetect(t *testing.T) {
 		Language     heartbeat.Language
 		Dependencies []string
 	}{
+		"c": {
+			Filepath:     "testdata/c_minimal.c",
+			Language:     heartbeat.LanguageC,
+			Dependencies: []string{"openssl"},
+		},
 		"elm": {
 			Filepath:     "testdata/elm_minimal.elm",
 			Language:     heartbeat.LanguageElm,

--- a/pkg/deps/testdata/c.c
+++ b/pkg/deps/testdata/c.c
@@ -1,0 +1,9 @@
+#include <stdio.h>
+#include <math.h>
+#include <openssl/rand.h>
+
+main()
+{
+    printf("Hello World\n");
+    return 0;
+}

--- a/pkg/deps/testdata/c_minimal.c
+++ b/pkg/deps/testdata/c_minimal.c
@@ -1,0 +1,7 @@
+#include <openssl/rand.h>
+
+main()
+{
+    printf("Hello World\n");
+    return 0;
+}


### PR DESCRIPTION
This PR adds a dependency parser for the C programming language to deps package. The original implementation in wakatime python cli can be found at: https://github.com/wakatime/wakatime/blob/master/wakatime/dependencies/c_cpp.py#L15. Test case taken from: https://github.com/wakatime/wakatime/blob/master/tests/test_dependencies.py#L290

- Also added test to detect single includes like `#include <math.h>`.

Closes #154 