### PR TITLE
Simplify dependency parser interface

### DIFF
--- a/pkg/deps/c.go
+++ b/pkg/deps/c.go
@@ -2,12 +2,13 @@ package deps
 
 import (
 	"fmt"
-	"io"
 	"io/ioutil"
+	"os"
 	"regexp"
 	"strings"
 
 	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/c"
 )
 
 var cExcludeRegex = regexp.MustCompile(`(?i)^(stdio\.h|stdlib\.h|string\.h|time\.h)$`)
@@ -29,8 +30,13 @@ type ParserC struct {
 	Output []string
 }
 
-// Parse parses dependencies from c file content via ReadCloser using the c golang lexer.
-func (p *ParserC) Parse(reader io.ReadCloser, lexer chroma.Lexer) ([]string, error) {
+// Parse parses dependencies from C file content using the C lexer.
+func (p *ParserC) Parse(filepath string) ([]string, error) {
+	reader, err := os.Open(filepath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
+	}
+
 	defer reader.Close()
 
 	p.init()
@@ -41,7 +47,7 @@ func (p *ParserC) Parse(reader io.ReadCloser, lexer chroma.Lexer) ([]string, err
 		return nil, fmt.Errorf("failed to read from reader: %s", err)
 	}
 
-	iter, err := lexer.Tokenise(nil, string(data))
+	iter, err := c.C.Tokenise(nil, string(data))
 	if err != nil {
 		return nil, fmt.Errorf("failed to tokenize file content: %s", err)
 	}

--- a/pkg/deps/c_test.go
+++ b/pkg/deps/c_test.go
@@ -1,26 +1,18 @@
 package deps_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/wakatime/wakatime-cli/pkg/deps"
-	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 
-	"github.com/alecthomas/chroma/lexers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestParserC_Parse(t *testing.T) {
-	lexer := lexers.Get(heartbeat.LanguageC.StringChroma())
-
-	f, err := os.Open("testdata/c.c")
-	require.NoError(t, err)
-
 	parser := deps.ParserC{}
 
-	dependencies, err := parser.Parse(f, lexer)
+	dependencies, err := parser.Parse("testdata/c.c")
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{

--- a/pkg/deps/csharp.go
+++ b/pkg/deps/csharp.go
@@ -2,12 +2,13 @@ package deps
 
 import (
 	"fmt"
-	"io"
 	"io/ioutil"
+	"os"
 	"regexp"
 	"strings"
 
 	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/c"
 )
 
 var csharpExcludeRegex = regexp.MustCompile(`(?i)^(system|microsoft)$`)
@@ -30,8 +31,13 @@ type ParserCSharp struct {
 	Output []string
 }
 
-// Parse parses dependencies from c# file content via ReadCloser using the chroma c# lexer.
-func (p *ParserCSharp) Parse(reader io.ReadCloser, lexer chroma.Lexer) ([]string, error) {
+// Parse parses dependencies from C# file content using the chroma C# lexer.
+func (p *ParserCSharp) Parse(filepath string) ([]string, error) {
+	reader, err := os.Open(filepath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
+	}
+
 	defer reader.Close()
 
 	p.init()
@@ -42,7 +48,7 @@ func (p *ParserCSharp) Parse(reader io.ReadCloser, lexer chroma.Lexer) ([]string
 		return nil, fmt.Errorf("failed to read from reader: %s", err)
 	}
 
-	iter, err := lexer.Tokenise(nil, string(data))
+	iter, err := c.CSharp.Tokenise(nil, string(data))
 	if err != nil {
 		return nil, fmt.Errorf("failed to tokenize file content: %s", err)
 	}

--- a/pkg/deps/csharp_test.go
+++ b/pkg/deps/csharp_test.go
@@ -1,26 +1,18 @@
 package deps_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/wakatime/wakatime-cli/pkg/deps"
-	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 
-	"github.com/alecthomas/chroma/lexers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestParserCSharp_Parse(t *testing.T) {
-	lexer := lexers.Get(heartbeat.LanguageCSharp.StringChroma())
-
-	f, err := os.Open("testdata/csharp.cs")
-	require.NoError(t, err)
-
 	parser := deps.ParserCSharp{}
 
-	dependencies, err := parser.Parse(f, lexer)
+	dependencies, err := parser.Parse("testdata/csharp.cs")
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{

--- a/pkg/deps/deps.go
+++ b/pkg/deps/deps.go
@@ -2,14 +2,10 @@ package deps
 
 import (
 	"fmt"
-	"io"
-	"os"
 
 	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 	"github.com/wakatime/wakatime-cli/pkg/regex"
 
-	"github.com/alecthomas/chroma"
-	"github.com/alecthomas/chroma/lexers"
 	jww "github.com/spf13/jwalterweatherman"
 )
 
@@ -26,7 +22,7 @@ type Config struct {
 
 // DependencyParser is a dependency parser for a programming language.
 type DependencyParser interface {
-	Parse(reader io.ReadCloser, lexer chroma.Lexer) ([]string, error)
+	Parse(filepath string) ([]string, error)
 }
 
 // WithDetection initializes and returns a heartbeat handle option, which
@@ -71,11 +67,6 @@ func WithDetection(c Config) heartbeat.HandleOption {
 
 // Detect parses the dependencies from a heartbeat file of a specific language.
 func Detect(filepath string, language heartbeat.Language) ([]string, error) {
-	lexer := lexers.Get(language.StringChroma())
-	if lexer == nil {
-		return nil, fmt.Errorf("unable to detect lexer for language %q", language)
-	}
-
 	var parser DependencyParser
 
 	switch language {
@@ -114,12 +105,7 @@ func Detect(filepath string, language heartbeat.Language) ([]string, error) {
 		return nil, nil
 	}
 
-	f, err := os.Open(filepath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
-	}
-
-	deps, err := parser.Parse(f, lexer)
+	deps, err := parser.Parse(filepath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse dependencies: %s", err)
 	}

--- a/pkg/deps/elm.go
+++ b/pkg/deps/elm.go
@@ -2,11 +2,12 @@ package deps
 
 import (
 	"fmt"
-	"io"
 	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/e"
 )
 
 // StateElm is a token parsing state.
@@ -26,8 +27,13 @@ type ParserElm struct {
 	Output []string
 }
 
-// Parse parses dependencies from elm file content via ReadCloser using the chroma elm lexer.
-func (p *ParserElm) Parse(reader io.ReadCloser, lexer chroma.Lexer) ([]string, error) {
+// Parse parses dependencies from Elm file content using the chroma Elm lexer.
+func (p *ParserElm) Parse(filepath string) ([]string, error) {
+	reader, err := os.Open(filepath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
+	}
+
 	defer reader.Close()
 
 	p.init()
@@ -38,10 +44,7 @@ func (p *ParserElm) Parse(reader io.ReadCloser, lexer chroma.Lexer) ([]string, e
 		return nil, fmt.Errorf("failed to read from reader: %s", err)
 	}
 
-	iter, err := lexer.Tokenise(&chroma.TokeniseOptions{
-		State:    "root",
-		EnsureLF: true,
-	}, string(data))
+	iter, err := e.Elm.Tokenise(nil, string(data))
 	if err != nil {
 		return nil, fmt.Errorf("failed to tokenize file content: %s", err)
 	}

--- a/pkg/deps/elm_test.go
+++ b/pkg/deps/elm_test.go
@@ -1,25 +1,17 @@
 package deps_test
 
 import (
-	"os"
 	"testing"
 
-	"github.com/alecthomas/chroma/lexers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/wakatime/wakatime-cli/pkg/deps"
-	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 )
 
 func TestParserElm_Parse(t *testing.T) {
-	lexer := lexers.Get(heartbeat.LanguageElm.StringChroma())
-
-	f, err := os.Open("testdata/elm.elm")
-	require.NoError(t, err)
-
 	parser := deps.ParserElm{}
 
-	dependencies, err := parser.Parse(f, lexer)
+	dependencies, err := parser.Parse("testdata/elm.elm")
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{

--- a/pkg/deps/golang_test.go
+++ b/pkg/deps/golang_test.go
@@ -1,26 +1,18 @@
 package deps_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/wakatime/wakatime-cli/pkg/deps"
-	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 
-	"github.com/alecthomas/chroma/lexers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestParserGo_Parse(t *testing.T) {
-	lexer := lexers.Get(heartbeat.LanguageGo.StringChroma())
-
-	f, err := os.Open("testdata/golang.go")
-	require.NoError(t, err)
-
 	parser := deps.ParserGo{}
 
-	dependencies, err := parser.Parse(f, lexer)
+	dependencies, err := parser.Parse("testdata/golang.go")
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{

--- a/pkg/deps/haskell.go
+++ b/pkg/deps/haskell.go
@@ -2,11 +2,12 @@ package deps
 
 import (
 	"fmt"
-	"io"
 	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/h"
 )
 
 // StateHaskell is a token parsing state.
@@ -26,8 +27,13 @@ type ParserHaskell struct {
 	Output []string
 }
 
-// Parse parses dependencies from Haskell file content via ReadCloser using the chroma Haskell lexer.
-func (p *ParserHaskell) Parse(reader io.ReadCloser, lexer chroma.Lexer) ([]string, error) {
+// Parse parses dependencies from Haskell file content using the chroma Haskell lexer.
+func (p *ParserHaskell) Parse(filepath string) ([]string, error) {
+	reader, err := os.Open(filepath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
+	}
+
 	defer reader.Close()
 
 	p.init()
@@ -38,7 +44,7 @@ func (p *ParserHaskell) Parse(reader io.ReadCloser, lexer chroma.Lexer) ([]strin
 		return nil, fmt.Errorf("failed to read from reader: %s", err)
 	}
 
-	iter, err := lexer.Tokenise(nil, string(data))
+	iter, err := h.Haskell.Tokenise(nil, string(data))
 	if err != nil {
 		return nil, fmt.Errorf("failed to tokenize file content: %s", err)
 	}

--- a/pkg/deps/haskell_test.go
+++ b/pkg/deps/haskell_test.go
@@ -1,26 +1,18 @@
 package deps_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/wakatime/wakatime-cli/pkg/deps"
-	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 
-	"github.com/alecthomas/chroma/lexers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestParserHaskell_Parse(t *testing.T) {
-	lexer := lexers.Get(heartbeat.LanguageHaskell.StringChroma())
-
-	f, err := os.Open("testdata/haskell.hs")
-	require.NoError(t, err)
-
 	parser := deps.ParserHaskell{}
 
-	dependencies, err := parser.Parse(f, lexer)
+	dependencies, err := parser.Parse("testdata/haskell.hs")
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{

--- a/pkg/deps/haxe.go
+++ b/pkg/deps/haxe.go
@@ -2,12 +2,13 @@ package deps
 
 import (
 	"fmt"
-	"io"
 	"io/ioutil"
+	"os"
 	"regexp"
 	"strings"
 
 	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/h"
 )
 
 // nolint:noglobal
@@ -30,8 +31,13 @@ type ParserHaxe struct {
 	Output []string
 }
 
-// Parse parses dependencies from Haxe file content via ReadCloser using the chroma Haxe lexer.
-func (p *ParserHaxe) Parse(reader io.ReadCloser, lexer chroma.Lexer) ([]string, error) {
+// Parse parses dependencies from Haxe file content using the chroma Haxe lexer.
+func (p *ParserHaxe) Parse(filepath string) ([]string, error) {
+	reader, err := os.Open(filepath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
+	}
+
 	defer reader.Close()
 
 	p.init()
@@ -42,7 +48,7 @@ func (p *ParserHaxe) Parse(reader io.ReadCloser, lexer chroma.Lexer) ([]string, 
 		return nil, fmt.Errorf("failed to read from reader: %s", err)
 	}
 
-	iter, err := lexer.Tokenise(nil, string(data))
+	iter, err := h.Haxe.Tokenise(nil, string(data))
 	if err != nil {
 		return nil, fmt.Errorf("failed to tokenize file content: %s", err)
 	}

--- a/pkg/deps/haxe_test.go
+++ b/pkg/deps/haxe_test.go
@@ -1,26 +1,18 @@
 package deps_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/wakatime/wakatime-cli/pkg/deps"
-	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 
-	"github.com/alecthomas/chroma/lexers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestParserHaxe_Parse(t *testing.T) {
-	lexer := lexers.Get(heartbeat.LanguageHaxe.StringChroma())
-
-	f, err := os.Open("testdata/haxe.hx")
-	require.NoError(t, err)
-
 	parser := deps.ParserHaxe{}
 
-	dependencies, err := parser.Parse(f, lexer)
+	dependencies, err := parser.Parse("testdata/haxe.hx")
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{

--- a/pkg/deps/java.go
+++ b/pkg/deps/java.go
@@ -2,12 +2,13 @@ package deps
 
 import (
 	"fmt"
-	"io"
 	"io/ioutil"
+	"os"
 	"regexp"
 	"strings"
 
 	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/j"
 )
 
 var javaExcludeRegex = regexp.MustCompile(`(?i)^(java\..*|javax\..*)`)
@@ -32,8 +33,13 @@ type ParserJava struct {
 	Output []string
 }
 
-// Parse parses dependencies from java file content via ReadCloser using the chroma java lexer.
-func (p *ParserJava) Parse(reader io.ReadCloser, lexer chroma.Lexer) ([]string, error) {
+// Parse parses dependencies from Java file content using the chroma Java lexer.
+func (p *ParserJava) Parse(filepath string) ([]string, error) {
+	reader, err := os.Open(filepath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
+	}
+
 	defer reader.Close()
 
 	p.init()
@@ -44,7 +50,7 @@ func (p *ParserJava) Parse(reader io.ReadCloser, lexer chroma.Lexer) ([]string, 
 		return nil, fmt.Errorf("failed to read from reader: %s", err)
 	}
 
-	iter, err := lexer.Tokenise(nil, string(data))
+	iter, err := j.Java.Tokenise(nil, string(data))
 	if err != nil {
 		return nil, fmt.Errorf("failed to tokenize file content: %s", err)
 	}

--- a/pkg/deps/java_test.go
+++ b/pkg/deps/java_test.go
@@ -1,26 +1,18 @@
 package deps_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/wakatime/wakatime-cli/pkg/deps"
-	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 
-	"github.com/alecthomas/chroma/lexers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestParserJava_Parse(t *testing.T) {
-	lexer := lexers.Get(heartbeat.LanguageJava.StringChroma())
-
-	f, err := os.Open("testdata/java.java")
-	require.NoError(t, err)
-
 	parser := deps.ParserJava{}
 
-	dependencies, err := parser.Parse(f, lexer)
+	dependencies, err := parser.Parse("testdata/java.java")
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{

--- a/pkg/deps/javascript.go
+++ b/pkg/deps/javascript.go
@@ -2,12 +2,13 @@ package deps
 
 import (
 	"fmt"
-	"io"
 	"io/ioutil"
+	"os"
 	"regexp"
 	"strings"
 
 	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/j"
 )
 
 // nolint:noglobal
@@ -30,8 +31,13 @@ type ParserJavaScript struct {
 	Output []string
 }
 
-// Parse parses dependencies from JavaScript file content via ReadCloser using the chroma JavaScript lexer.
-func (p *ParserJavaScript) Parse(reader io.ReadCloser, lexer chroma.Lexer) ([]string, error) {
+// Parse parses dependencies from JavaScript file content using the chroma JavaScript lexer.
+func (p *ParserJavaScript) Parse(filepath string) ([]string, error) {
+	reader, err := os.Open(filepath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
+	}
+
 	defer reader.Close()
 
 	p.init()
@@ -42,7 +48,7 @@ func (p *ParserJavaScript) Parse(reader io.ReadCloser, lexer chroma.Lexer) ([]st
 		return nil, fmt.Errorf("failed to read from reader: %s", err)
 	}
 
-	iter, err := lexer.Tokenise(nil, string(data))
+	iter, err := j.Javascript.Tokenise(nil, string(data))
 	if err != nil {
 		return nil, fmt.Errorf("failed to tokenize file content: %s", err)
 	}

--- a/pkg/deps/javascript_test.go
+++ b/pkg/deps/javascript_test.go
@@ -1,26 +1,18 @@
 package deps_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/wakatime/wakatime-cli/pkg/deps"
-	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 
-	"github.com/alecthomas/chroma/lexers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestParserJavaScript_Parse(t *testing.T) {
-	lexer := lexers.Get(heartbeat.LanguageJavaScript.StringChroma())
-
-	f, err := os.Open("testdata/es6.js")
-	require.NoError(t, err)
-
 	parser := deps.ParserJavaScript{}
 
-	dependencies, err := parser.Parse(f, lexer)
+	dependencies, err := parser.Parse("testdata/es6.js")
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{

--- a/pkg/deps/kotlin.go
+++ b/pkg/deps/kotlin.go
@@ -2,12 +2,13 @@ package deps
 
 import (
 	"fmt"
-	"io"
 	"io/ioutil"
+	"os"
 	"regexp"
 	"strings"
 
 	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/k"
 )
 
 var kotlinExcludeRegex = regexp.MustCompile(`(?i)^java\.`)
@@ -29,8 +30,13 @@ type ParserKotlin struct {
 	Output []string
 }
 
-// Parse parses dependencies from Kotlin file content via ReadCloser using the chroma Kotlin lexer.
-func (p *ParserKotlin) Parse(reader io.ReadCloser, lexer chroma.Lexer) ([]string, error) {
+// Parse parses dependencies from Kotlin file content using the chroma Kotlin lexer.
+func (p *ParserKotlin) Parse(filepath string) ([]string, error) {
+	reader, err := os.Open(filepath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
+	}
+
 	defer reader.Close()
 
 	p.init()
@@ -41,7 +47,7 @@ func (p *ParserKotlin) Parse(reader io.ReadCloser, lexer chroma.Lexer) ([]string
 		return nil, fmt.Errorf("failed to read from reader: %s", err)
 	}
 
-	iter, err := lexer.Tokenise(nil, string(data))
+	iter, err := k.Kotlin.Tokenise(nil, string(data))
 	if err != nil {
 		return nil, fmt.Errorf("failed to tokenize file content: %s", err)
 	}

--- a/pkg/deps/kotlin_test.go
+++ b/pkg/deps/kotlin_test.go
@@ -1,26 +1,18 @@
 package deps_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/wakatime/wakatime-cli/pkg/deps"
-	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 
-	"github.com/alecthomas/chroma/lexers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestParserKotlin_Parse(t *testing.T) {
-	lexer := lexers.Get(heartbeat.LanguageKotlin.StringChroma())
-
-	f, err := os.Open("testdata/kotlin.kt")
-	require.NoError(t, err)
-
 	parser := deps.ParserKotlin{}
 
-	dependencies, err := parser.Parse(f, lexer)
+	dependencies, err := parser.Parse("testdata/kotlin.kt")
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{

--- a/pkg/deps/objectivec.go
+++ b/pkg/deps/objectivec.go
@@ -2,11 +2,12 @@ package deps
 
 import (
 	"fmt"
-	"io"
 	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/o"
 )
 
 // StateObjectiveC is a token parsing state.
@@ -26,8 +27,13 @@ type ParserObjectiveC struct {
 	Output []string
 }
 
-// Parse parses dependencies from objective-c file content via ReadCloser using the chroma objective-c lexer.
-func (p *ParserObjectiveC) Parse(reader io.ReadCloser, lexer chroma.Lexer) ([]string, error) {
+// Parse parses dependencies from Objective-C file content using the chroma Objective-C lexer.
+func (p *ParserObjectiveC) Parse(filepath string) ([]string, error) {
+	reader, err := os.Open(filepath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
+	}
+
 	defer reader.Close()
 
 	p.init()
@@ -38,7 +44,7 @@ func (p *ParserObjectiveC) Parse(reader io.ReadCloser, lexer chroma.Lexer) ([]st
 		return nil, fmt.Errorf("failed to read from reader: %s", err)
 	}
 
-	iter, err := lexer.Tokenise(nil, string(data))
+	iter, err := o.ObjectiveC.Tokenise(nil, string(data))
 	if err != nil {
 		return nil, fmt.Errorf("failed to tokenize file content: %s", err)
 	}

--- a/pkg/deps/objectivec_test.go
+++ b/pkg/deps/objectivec_test.go
@@ -1,26 +1,18 @@
 package deps_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/wakatime/wakatime-cli/pkg/deps"
-	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 
-	"github.com/alecthomas/chroma/lexers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestParserObjectiveC_Parse(t *testing.T) {
-	lexer := lexers.Get(heartbeat.LanguageObjectiveC.StringChroma())
-
-	f, err := os.Open("testdata/objective_c.m")
-	require.NoError(t, err)
-
 	parser := deps.ParserObjectiveC{}
 
-	dependencies, err := parser.Parse(f, lexer)
+	dependencies, err := parser.Parse("testdata/objective_c.m")
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{

--- a/pkg/deps/php.go
+++ b/pkg/deps/php.go
@@ -2,12 +2,13 @@ package deps
 
 import (
 	"fmt"
-	"io"
 	"io/ioutil"
+	"os"
 	"regexp"
 	"strings"
 
 	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/circular"
 )
 
 // nolint:noglobals
@@ -36,8 +37,13 @@ type ParserPHP struct {
 	Output []string
 }
 
-// Parse parses dependencies from php file content via ReadCloser using the chroma php lexer.
-func (p *ParserPHP) Parse(reader io.ReadCloser, lexer chroma.Lexer) ([]string, error) {
+// Parse parses dependencies from PHP file content using the chroma PHP lexer.
+func (p *ParserPHP) Parse(filepath string) ([]string, error) {
+	reader, err := os.Open(filepath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
+	}
+
 	defer reader.Close()
 
 	p.init()
@@ -48,10 +54,7 @@ func (p *ParserPHP) Parse(reader io.ReadCloser, lexer chroma.Lexer) ([]string, e
 		return nil, fmt.Errorf("failed to read from reader: %s", err)
 	}
 
-	iter, err := lexer.Tokenise(&chroma.TokeniseOptions{
-		State:    "root",
-		EnsureLF: true,
-	}, string(data))
+	iter, err := circular.PHP.Tokenise(nil, string(data))
 	if err != nil {
 		return nil, fmt.Errorf("failed to tokenize file content: %s", err)
 	}

--- a/pkg/deps/php_test.go
+++ b/pkg/deps/php_test.go
@@ -1,26 +1,18 @@
 package deps_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/wakatime/wakatime-cli/pkg/deps"
-	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 
-	"github.com/alecthomas/chroma/lexers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestParserPHP_Parse(t *testing.T) {
-	lexer := lexers.Get(heartbeat.LanguagePHP.StringChroma())
-
-	f, err := os.Open("testdata/php.php")
-	require.NoError(t, err)
-
 	parser := deps.ParserPHP{}
 
-	dependencies, err := parser.Parse(f, lexer)
+	dependencies, err := parser.Parse("testdata/php.php")
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{

--- a/pkg/deps/python.go
+++ b/pkg/deps/python.go
@@ -2,12 +2,13 @@ package deps
 
 import (
 	"fmt"
-	"io"
 	"io/ioutil"
+	"os"
 	"regexp"
 	"strings"
 
 	"github.com/alecthomas/chroma"
+	lp "github.com/alecthomas/chroma/lexers/p"
 )
 
 // nolint:noglobal
@@ -33,8 +34,13 @@ type ParserPython struct {
 	Output      []string
 }
 
-// Parse parses dependencies from python file content via ReadCloser using the chroma python lexer.
-func (p *ParserPython) Parse(reader io.ReadCloser, lexer chroma.Lexer) ([]string, error) {
+// Parse parses dependencies from Python file content using the chroma Python lexer.
+func (p *ParserPython) Parse(filepath string) ([]string, error) {
+	reader, err := os.Open(filepath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
+	}
+
 	defer reader.Close()
 
 	p.init()
@@ -45,10 +51,7 @@ func (p *ParserPython) Parse(reader io.ReadCloser, lexer chroma.Lexer) ([]string
 		return nil, fmt.Errorf("failed to read from reader: %s", err)
 	}
 
-	iter, err := lexer.Tokenise(&chroma.TokeniseOptions{
-		State:    "root",
-		EnsureLF: true,
-	}, string(data))
+	iter, err := lp.Python.Tokenise(nil, string(data))
 	if err != nil {
 		return nil, fmt.Errorf("failed to tokenize file content: %s", err)
 	}

--- a/pkg/deps/python_test.go
+++ b/pkg/deps/python_test.go
@@ -1,26 +1,18 @@
 package deps_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/wakatime/wakatime-cli/pkg/deps"
-	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 
-	"github.com/alecthomas/chroma/lexers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestParserPython_Parse(t *testing.T) {
-	lexer := lexers.Get(heartbeat.LanguagePython.StringChroma())
-
-	f, err := os.Open("testdata/python.py")
-	require.NoError(t, err)
-
 	parser := deps.ParserPython{}
 
-	dependencies, err := parser.Parse(f, lexer)
+	dependencies, err := parser.Parse("testdata/python.py")
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{

--- a/pkg/deps/rust.go
+++ b/pkg/deps/rust.go
@@ -2,11 +2,12 @@ package deps
 
 import (
 	"fmt"
-	"io"
 	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/r"
 )
 
 // StateRust is a token parsing state.
@@ -28,8 +29,13 @@ type ParserRust struct {
 	Output []string
 }
 
-// Parse parses dependencies from rust file content via ReadCloser using the chroma rust lexer.
-func (p *ParserRust) Parse(reader io.ReadCloser, lexer chroma.Lexer) ([]string, error) {
+// Parse parses dependencies from Rust file content using the chroma Rust lexer.
+func (p *ParserRust) Parse(filepath string) ([]string, error) {
+	reader, err := os.Open(filepath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
+	}
+
 	defer reader.Close()
 
 	p.init()
@@ -40,10 +46,7 @@ func (p *ParserRust) Parse(reader io.ReadCloser, lexer chroma.Lexer) ([]string, 
 		return nil, fmt.Errorf("failed to read from reader: %s", err)
 	}
 
-	iter, err := lexer.Tokenise(&chroma.TokeniseOptions{
-		State:    "root",
-		EnsureLF: true,
-	}, string(data))
+	iter, err := r.Rust.Tokenise(nil, string(data))
 	if err != nil {
 		return nil, fmt.Errorf("failed to tokenize file content: %s", err)
 	}

--- a/pkg/deps/rust_test.go
+++ b/pkg/deps/rust_test.go
@@ -1,26 +1,18 @@
 package deps_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/wakatime/wakatime-cli/pkg/deps"
-	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 
-	"github.com/alecthomas/chroma/lexers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestParserRust_Parse(t *testing.T) {
-	lexer := lexers.Get(heartbeat.LanguageRust.StringChroma())
-
-	f, err := os.Open("testdata/rust.rs")
-	require.NoError(t, err)
-
 	parser := deps.ParserRust{}
 
-	dependencies, err := parser.Parse(f, lexer)
+	dependencies, err := parser.Parse("testdata/rust.rs")
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{

--- a/pkg/deps/scala.go
+++ b/pkg/deps/scala.go
@@ -2,11 +2,12 @@ package deps
 
 import (
 	"fmt"
-	"io"
 	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/s"
 )
 
 // StateScala is a token parsing state.
@@ -26,8 +27,13 @@ type ParserScala struct {
 	Output []string
 }
 
-// Parse parses dependencies from Scala file content via ReadCloser using the chroma Scala lexer.
-func (p *ParserScala) Parse(reader io.ReadCloser, lexer chroma.Lexer) ([]string, error) {
+// Parse parses dependencies from Scala file content using the chroma Scala lexer.
+func (p *ParserScala) Parse(filepath string) ([]string, error) {
+	reader, err := os.Open(filepath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
+	}
+
 	defer reader.Close()
 
 	p.init()
@@ -38,7 +44,7 @@ func (p *ParserScala) Parse(reader io.ReadCloser, lexer chroma.Lexer) ([]string,
 		return nil, fmt.Errorf("failed to read from reader: %s", err)
 	}
 
-	iter, err := lexer.Tokenise(nil, string(data))
+	iter, err := s.Scala.Tokenise(nil, string(data))
 	if err != nil {
 		return nil, fmt.Errorf("failed to tokenize file content: %s", err)
 	}

--- a/pkg/deps/scala_test.go
+++ b/pkg/deps/scala_test.go
@@ -1,26 +1,18 @@
 package deps_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/wakatime/wakatime-cli/pkg/deps"
-	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 
-	"github.com/alecthomas/chroma/lexers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestParserScala_Parse(t *testing.T) {
-	lexer := lexers.Get(heartbeat.LanguageScala.StringChroma())
-
-	f, err := os.Open("testdata/scala.scala")
-	require.NoError(t, err)
-
 	parser := deps.ParserScala{}
 
-	dependencies, err := parser.Parse(f, lexer)
+	dependencies, err := parser.Parse("testdata/scala.scala")
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{

--- a/pkg/deps/swift.go
+++ b/pkg/deps/swift.go
@@ -2,12 +2,13 @@ package deps
 
 import (
 	"fmt"
-	"io"
 	"io/ioutil"
+	"os"
 	"regexp"
 	"strings"
 
 	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/s"
 )
 
 // nolint:noglobals
@@ -30,8 +31,13 @@ type ParserSwift struct {
 	Output []string
 }
 
-// Parse parses dependencies from swift file content via ReadCloser using the chroma swift lexer.
-func (p *ParserSwift) Parse(reader io.ReadCloser, lexer chroma.Lexer) ([]string, error) {
+// Parse parses dependencies from Swift file content using the chroma Swift lexer.
+func (p *ParserSwift) Parse(filepath string) ([]string, error) {
+	reader, err := os.Open(filepath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
+	}
+
 	defer reader.Close()
 
 	p.init()
@@ -42,7 +48,7 @@ func (p *ParserSwift) Parse(reader io.ReadCloser, lexer chroma.Lexer) ([]string,
 		return nil, fmt.Errorf("failed to read from reader: %s", err)
 	}
 
-	iter, err := lexer.Tokenise(nil, string(data))
+	iter, err := s.Swift.Tokenise(nil, string(data))
 	if err != nil {
 		return nil, fmt.Errorf("failed to tokenize file content: %s", err)
 	}

--- a/pkg/deps/swift_test.go
+++ b/pkg/deps/swift_test.go
@@ -1,26 +1,18 @@
 package deps_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/wakatime/wakatime-cli/pkg/deps"
-	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 
-	"github.com/alecthomas/chroma/lexers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestParserSwift_Parse(t *testing.T) {
-	lexer := lexers.Get(heartbeat.LanguageSwift.StringChroma())
-
-	f, err := os.Open("testdata/swift.swift")
-	require.NoError(t, err)
-
 	parser := deps.ParserSwift{}
 
-	dependencies, err := parser.Parse(f, lexer)
+	dependencies, err := parser.Parse("testdata/swift.swift")
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{


### PR DESCRIPTION
As we discussed @dron22 this PR simplifies the dependency parser interface as a preparation for `JSON` parser.