### PR TITLE
Add typescript dependency parser

### DIFF
--- a/pkg/deps/deps.go
+++ b/pkg/deps/deps.go
@@ -84,7 +84,7 @@ func Detect(filepath string, language heartbeat.Language) ([]string, error) {
 		parser = &ParserHaxe{}
 	case heartbeat.LanguageJava:
 		parser = &ParserJava{}
-	case heartbeat.LanguageJavaScript:
+	case heartbeat.LanguageJavaScript, heartbeat.LanguageTypeScript:
 		parser = &ParserJavaScript{}
 	case heartbeat.LanguageKotlin:
 		parser = &ParserKotlin{}

--- a/pkg/deps/deps_test.go
+++ b/pkg/deps/deps_test.go
@@ -237,6 +237,11 @@ func TestDetect(t *testing.T) {
 			Language:     heartbeat.LanguageSwift,
 			Dependencies: []string{"Swift"},
 		},
+		"typescript": {
+			Filepath:     "testdata/typescript_minimal.ts",
+			Language:     heartbeat.LanguageTypeScript,
+			Dependencies: []string{"bravo"},
+		},
 		"vb.net": {
 			Filepath:     "testdata/vbnet_minimal.vb",
 			Language:     heartbeat.LanguageVBNet,

--- a/pkg/deps/javascript.go
+++ b/pkg/deps/javascript.go
@@ -84,12 +84,12 @@ func (p *ParserJavaScript) init() {
 }
 
 func (p *ParserJavaScript) processToken(token chroma.Token) {
-	switch {
-	case token.Type == chroma.KeywordReserved:
+	switch token.Type {
+	case chroma.KeywordReserved:
 		p.processKeywordReserved(token.Value)
-	case token.Type == chroma.LiteralStringSingle:
+	case chroma.LiteralStringSingle:
 		p.processLiteralStringSingle(token.Value)
-	case token.Type == chroma.Punctuation:
+	case chroma.Punctuation:
 		p.processPunctuation(token.Value)
 	}
 }
@@ -104,12 +104,11 @@ func (p *ParserJavaScript) processKeywordReserved(value string) {
 }
 
 func (p *ParserJavaScript) processLiteralStringSingle(value string) {
-	switch p.State {
-	case StateJavaScriptImport:
+	if p.State == StateJavaScriptImport {
 		p.append(value)
-	default:
-		p.State = StateJavaScriptUnknown
 	}
+
+	p.State = StateJavaScriptUnknown
 }
 
 func (p *ParserJavaScript) processPunctuation(value string) {

--- a/pkg/deps/javascript_test.go
+++ b/pkg/deps/javascript_test.go
@@ -4,28 +4,64 @@ import (
 	"testing"
 
 	"github.com/wakatime/wakatime-cli/pkg/deps"
+	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 
+	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestParserJavaScript_Parse(t *testing.T) {
-	parser := deps.ParserJavaScript{}
+	tests := map[string]struct {
+		Lexer    chroma.Lexer
+		Filepath string
+		Expected []string
+	}{
+		"js": {
+			Lexer:    lexers.Get(heartbeat.LanguageJavaScript.StringChroma()),
+			Filepath: "testdata/es6.js",
+			Expected: []string{
+				"bravo",
+				"foxtrot",
+				"india",
+				"kilo",
+				"november",
+				"oscar",
+				"quebec",
+				"tango",
+				"uniform",
+				"victor",
+				"whiskey",
+			},
+		},
+		"typescript": {
+			Lexer:    lexers.Get(heartbeat.LanguageTypeScript.StringChroma()),
+			Filepath: "testdata/typescript.ts",
+			Expected: []string{
+				"bravo",
+				"foxtrot",
+				"india",
+				"kilo",
+				"november",
+				"oscar",
+				"quebec",
+				"tango",
+				"uniform",
+				"victor",
+				"whiskey",
+			},
+		},
+	}
 
-	dependencies, err := parser.Parse("testdata/es6.js")
-	require.NoError(t, err)
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			parser := deps.ParserJavaScript{}
 
-	assert.Equal(t, []string{
-		"bravo",
-		"foxtrot",
-		"india",
-		"kilo",
-		"november",
-		"oscar",
-		"quebec",
-		"tango",
-		"uniform",
-		"victor",
-		"whiskey",
-	}, dependencies)
+			dependencies, err := parser.Parse(test.Filepath)
+			require.NoError(t, err)
+
+			assert.Equal(t, test.Expected, dependencies)
+		})
+	}
 }

--- a/pkg/deps/testdata/typescript.ts
+++ b/pkg/deps/testdata/typescript.ts
@@ -1,0 +1,37 @@
+import Alpha from './bravo'
+import { charlie, delta } from '../../echo/foxtrot'
+import golf from './hotel/india.js'
+import juliett from 'kilo'
+import {
+  lima,
+  mike,
+} from './november'
+import * from '/modules/oscar'
+import * as papa from 'quebec'
+import {romeo as sierra} from from 'tango.jsx'
+import 'uniform.js'
+import victorDefault, * as victorModule from '/modules/victor.js'
+import whiskeyDefault, {whiskeyOne, whiskeyTwo} from 'whiskey'
+
+const propTypes = {}
+
+const defaultProps = {}
+
+class Link extends Alpha.Component {
+  static method() {
+    return true
+  }
+
+  render() {
+    return (
+      <a href={this.props.url} data-id={this.props.id}>
+        {this.props.text}
+      </a>
+    )
+  }
+}
+
+Link.propTypes = propTypes
+Link.defaultProps = defaultProps
+
+export default Link

--- a/pkg/deps/testdata/typescript_minimal.ts
+++ b/pkg/deps/testdata/typescript_minimal.ts
@@ -1,0 +1,3 @@
+import Alpha from './bravo'
+
+console.log('Hello World!')


### PR DESCRIPTION
This PR adds a dependency parser for Typescript programming language to deps package. The original implementation in wakatime python cli can be found at: https://github.com/wakatime/wakatime/blob/master/wakatime/dependencies/javascript.py#L59. Test case taken from: https://github.com/wakatime/wakatime/blob/2e636d389bf5da4e998e05d5285a96ce2c181e3d/tests%2Ftest_dependencies.py#L401

- It also fixes a bug at `processLiteralStringSingle` function where semicolon is not necessary to end a line for both languages. Original piece of code can be found [here](https://github.com/wakatime/wakatime/blob/799fe92c218abc14ec6a24f372f4ff393ef5c4f7/wakatime%2Fdependencies%2Fjavascript.py#L41).

Closes #200 