### PR TITLE
Add JSON dependency parser

### DIFF
--- a/pkg/deps/deps.go
+++ b/pkg/deps/deps.go
@@ -86,6 +86,8 @@ func Detect(filepath string, language heartbeat.Language) ([]string, error) {
 		parser = &ParserJava{}
 	case heartbeat.LanguageJavaScript, heartbeat.LanguageTypeScript:
 		parser = &ParserJavaScript{}
+	case heartbeat.LanguageJSON:
+		parser = &ParserJSON{}
 	case heartbeat.LanguageKotlin:
 		parser = &ParserKotlin{}
 	case heartbeat.LanguageObjectiveC:

--- a/pkg/deps/deps_test.go
+++ b/pkg/deps/deps_test.go
@@ -202,6 +202,11 @@ func TestDetect(t *testing.T) {
 			Language:     heartbeat.LanguageJavaScript,
 			Dependencies: []string{"bravo"},
 		},
+		"json": {
+			Filepath:     "testdata/bower_minimal.json",
+			Language:     heartbeat.LanguageJSON,
+			Dependencies: []string{"bootstrap"},
+		},
 		"kotlin": {
 			Filepath:     "testdata/kotlin_minimal.kt",
 			Language:     heartbeat.LanguageKotlin,

--- a/pkg/deps/json.go
+++ b/pkg/deps/json.go
@@ -1,0 +1,131 @@
+package deps
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/j"
+)
+
+// nolint: gochecknoglobals
+var filesJSON = map[string]struct {
+	exact      bool
+	dependency string
+}{
+	"bower.json":     {true, "bower"},
+	"component.json": {true, "bower"},
+	"package.json":   {true, "npm"},
+}
+
+// StateJSON is a token parsing state.
+type StateJSON int
+
+const (
+	// StateJSONUnknown represents a unknown token parsing state.
+	StateJSONUnknown StateJSON = iota
+	// StateJSONDependencies means we are in dependencies section during token parsing.
+	StateJSONDependencies
+)
+
+// ParserJSON is a dependency parser for JSON parser.
+// It is not thread safe.
+type ParserJSON struct {
+	Level  int
+	Output []string
+	State  StateJSON
+}
+
+// Parse parses dependencies from JSON file content using the chroma JSON lexer.
+func (p *ParserJSON) Parse(filepath string) ([]string, error) {
+	reader, err := os.Open(filepath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
+	}
+
+	defer reader.Close()
+
+	p.init()
+	defer p.init()
+
+	// detect dependencies via filename
+	p.processFilename(filepath)
+
+	data, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read from reader: %s", err)
+	}
+
+	iter, err := j.JSON.Tokenise(nil, string(data))
+	if err != nil {
+		return nil, fmt.Errorf("failed to tokenize file content: %s", err)
+	}
+
+	for _, token := range iter.Tokens() {
+		p.processToken(token)
+	}
+
+	return p.Output, nil
+}
+
+func (p *ParserJSON) append(dep string) {
+	p.Output = append(p.Output, strings.Trim(dep, `"' `))
+}
+
+func (p *ParserJSON) init() {
+	p.Level = 0
+	p.Output = nil
+	p.State = StateJSONUnknown
+}
+
+func (p *ParserJSON) processToken(token chroma.Token) {
+	switch token.Type {
+	case chroma.NameTag:
+		p.processNameTag(token.Value)
+	case chroma.Punctuation:
+		p.processPunctuation(token.Value)
+	}
+}
+
+func (p *ParserJSON) processFilename(fp string) {
+	filename := filepath.Base(fp)
+
+	for k, f := range filesJSON {
+		if f.exact && k == filename {
+			p.Output = append(p.Output, f.dependency)
+			continue
+		}
+
+		if !f.exact && strings.Contains(strings.ToLower(filename), k) {
+			p.Output = append(p.Output, f.dependency)
+		}
+	}
+}
+
+func (p *ParserJSON) processNameTag(value string) {
+	trimmed := strings.Trim(value, `"'`)
+
+	if trimmed == "dependencies" || trimmed == "devDependencies" {
+		p.State = StateJSONDependencies
+		return
+	}
+
+	if p.State == StateJSONDependencies && p.Level == 2 {
+		p.append(value)
+	}
+}
+
+func (p *ParserJSON) processPunctuation(value string) {
+	switch value {
+	case "{":
+		p.Level++
+	case "}":
+		p.Level--
+		if p.State == StateJSONDependencies && p.Level <= 1 {
+			p.State = StateJSONUnknown
+		}
+	}
+}

--- a/pkg/deps/json_test.go
+++ b/pkg/deps/json_test.go
@@ -1,0 +1,58 @@
+package deps_test
+
+import (
+	"testing"
+
+	"github.com/wakatime/wakatime-cli/pkg/deps"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParserJSON_Parse(t *testing.T) {
+	tests := map[string]struct {
+		Filepath string
+		Expected []string
+	}{
+		"bower": {
+			Filepath: "testdata/bower.json",
+			Expected: []string{
+				"bower",
+				"animate.css",
+				"bootstrap",
+				"bootstrap-daterangepicker",
+				"moment",
+				"moment-timezone",
+			},
+		},
+		"component": {
+			Filepath: "testdata/component.json",
+			Expected: []string{
+				"bower",
+				"component/emitter",
+				"component/jquery",
+			},
+		},
+		"package": {
+			Filepath: "testdata/package.json",
+			Expected: []string{
+				"npm",
+				"wakatime",
+				"another_dep",
+				"test_framework",
+				"another_dev_dep",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			parser := deps.ParserJSON{}
+
+			dependencies, err := parser.Parse(test.Filepath)
+			require.NoError(t, err)
+
+			assert.Equal(t, test.Expected, dependencies)
+		})
+	}
+}

--- a/pkg/deps/testdata/bower.json
+++ b/pkg/deps/testdata/bower.json
@@ -1,0 +1,11 @@
+{
+    "name": "wakatime",
+    "version": "1.0.0",
+    "dependencies": {
+      "animate.css": "latest",
+      "bootstrap": "latest",
+      "bootstrap-daterangepicker": "latest",
+      "moment": "latest",
+      "moment-timezone": "latest"
+    }
+}

--- a/pkg/deps/testdata/bower_minimal.json
+++ b/pkg/deps/testdata/bower_minimal.json
@@ -1,0 +1,7 @@
+{
+    "name": "wakatime",
+    "version": "1.0.0",
+    "dependencies": {
+      "bootstrap": "latest"
+    }
+}

--- a/pkg/deps/testdata/component.json
+++ b/pkg/deps/testdata/component.json
@@ -1,0 +1,10 @@
+{
+    "name": "wakatime",
+    "repository": "wakatime/wakatime-cli",
+    "description": "WakaTime Cli",
+    "version": "1.0.0",
+    "dependencies": {
+      "component/emitter": "*",
+      "component/jquery": "*"
+    }
+}

--- a/pkg/deps/testdata/package.json
+++ b/pkg/deps/testdata/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "wakatime",
+    "version": "1.0.0",
+    "dependencies": {
+        "wakatime": "^1.0.0",
+        "another_dep": "~2.2.0"
+    },
+    "devDependencies" : {
+        "test_framework": "^3.1.0",
+        "another_dev_dep": "1.0.0 - 1.2.0"
+    }
+}


### PR DESCRIPTION
This PR adds a dependency parser for JSON programming language to deps package. The original implementation in wakatime python cli can be found at: https://github.com/wakatime/wakatime/blob/master/wakatime/dependencies/data.py#L25. Test case taken from: https://github.com/wakatime/wakatime/blob/2e636d389bf5da4e998e05d5285a96ce2c181e3d/tests%2Ftest_dependencies.py#L251

Closes #153 