### PR TITLE
Simplify chroma tests

### DIFF
--- a/pkg/heartbeat/language.go
+++ b/pkg/heartbeat/language.go
@@ -798,9 +798,9 @@ const (
 	languageApacheConfigChromaStr   = "ApacheConf"
 	languageAssemblyChromaStr       = "GAS"
 	languageColdfusionHTMLChromaStr = "Coldfusion HTML"
+	languageEmacsLispChromaStr      = "EmacsLisp"
 	languageFSharpChromaStr         = "FSharp"
 	languageGosuChromaStr           = "Gosu Template"
-	languageEmacsLispChromaStr      = "EmacsLisp"
 	languageJSXChromaStr            = "react"
 	languageLessChromaStr           = "LessCss"
 	languageMakefileChromaStr       = "Base Makefile"
@@ -1930,6 +1930,8 @@ func (l Language) String() string {
 // nolint:gocyclo
 func (l Language) StringChroma() string {
 	switch l {
+	case LanguageApacheConfig:
+		return languageApacheConfigChromaStr
 	case LanguageAssembly:
 		return languageAssemblyChromaStr
 	case LanguageColdfusionHTML:

--- a/pkg/heartbeat/language_test.go
+++ b/pkg/heartbeat/language_test.go
@@ -282,9 +282,9 @@ func languageTestsChroma() map[string]heartbeat.Language {
 		"ApacheConf":      heartbeat.LanguageApacheConfig,
 		"GAS":             heartbeat.LanguageAssembly,
 		"Coldfusion HTML": heartbeat.LanguageColdfusionHTML,
+		"EmacsLisp":       heartbeat.LanguageEmacsLisp,
 		"FSharp":          heartbeat.LanguageFSharp,
 		"Gosu Template":   heartbeat.LanguageGosu,
-		"EmacsLisp":       heartbeat.LanguageEmacsLisp,
 		"react":           heartbeat.LanguageJSX,
 		"LessCss":         heartbeat.LanguageLess,
 		"Base Makefile":   heartbeat.LanguageMakefile,
@@ -442,6 +442,14 @@ func TestLanguage_String(t *testing.T) {
 	for value, language := range languageTests() {
 		t.Run(value, func(t *testing.T) {
 			assert.Equal(t, value, language.String())
+		})
+	}
+}
+
+func TestLanguage_StringChroma(t *testing.T) {
+	for value, language := range languageTestsChroma() {
+		t.Run(value, func(t *testing.T) {
+			assert.Equal(t, value, language.StringChroma())
 		})
 	}
 }


### PR DESCRIPTION
This PR simplifies chroma tests:

- `TestParseLanguageFromChroma()` is reduced to cover only the special cases
- `StringChroma()` is covered by tests.

Closes #246