### PR TITLE
Add Blazor language constant

### DIFF
--- a/pkg/heartbeat/language.go
+++ b/pkg/heartbeat/language.go
@@ -105,6 +105,8 @@ const (
 	LanguageBibTeX
 	// LanguageBladeTemplate represents the BladeTemplate programming language.
 	LanguageBladeTemplate
+	// LanguageBlazor represent the Blazor programming language.
+	LanguageBlazor
 	// LanguageBlitzBasic represents the BlitzBasic programming language.
 	LanguageBlitzBasic
 	// LanguageBlitzMax represents the BlitzMax programming language.
@@ -758,6 +760,7 @@ const (
 	languageBefungeStr             = "Befunge"
 	languageBibTeXStr              = "BibTeX"
 	languageBladeTemplateStr       = "Blade Template"
+	languageBlazorStr              = "Blazor"
 	languageBlitzBasicStr          = "BlitzBasic"
 	languageBlitzMaxStr            = "BlitzMax"
 	languageBNFStr                 = "BNF"
@@ -1177,6 +1180,8 @@ func ParseLanguage(s string) (Language, bool) {
 		return LanguageBibTeX, true
 	case normalizeString(languageBladeTemplateStr):
 		return LanguageBladeTemplate, true
+	case normalizeString(languageBlazorStr):
+		return LanguageBlazor, true
 	case normalizeString(languageBlitzBasicStr):
 		return LanguageBlitzBasic, true
 	case normalizeString(languageBlitzMaxStr):
@@ -1945,6 +1950,8 @@ func (l Language) String() string {
 		return languageBibTeXStr
 	case LanguageBladeTemplate:
 		return languageBladeTemplateStr
+	case LanguageBlazor:
+		return languageBlazorStr
 	case LanguageBlitzBasic:
 		return languageBlitzBasicStr
 	case LanguageBlitzMax:

--- a/pkg/heartbeat/language_test.go
+++ b/pkg/heartbeat/language_test.go
@@ -62,6 +62,7 @@ func languageTests() map[string]heartbeat.Language {
 		"Befunge":                     heartbeat.LanguageBefunge,
 		"BibTeX":                      heartbeat.LanguageBibTeX,
 		"Blade Template":              heartbeat.LanguageBladeTemplate,
+		"Blazor":                      heartbeat.LanguageBlazor,
 		"BlitzBasic":                  heartbeat.LanguageBlitzBasic,
 		"BlitzMax":                    heartbeat.LanguageBlitzMax,
 		"BNF":                         heartbeat.LanguageBNF,


### PR DESCRIPTION
This PR adds Blazor language constant to have language support for new Blazor lexer added in: https://github.com/wakatime/chroma/pull/109

 