### PR TITLE
Language constants for chroma P - Q lexers

### DIFF
--- a/pkg/heartbeat/language.go
+++ b/pkg/heartbeat/language.go
@@ -695,6 +695,8 @@ const (
 	LanguagePan
 	// LanguageParaSail represents the ParaSail programming language.
 	LanguageParaSail
+	// LanguageParrot represents the Parrot programming language.
+	LanguageParrot
 	// LanguagePascal represents the Pascal programming language.
 	LanguagePascal
 	// LanguagePawn represents the Pawn programming language.
@@ -1273,6 +1275,7 @@ const (
 	languagePacmanConfStr          = "PacmanConf"
 	languagePanStr                 = "Pan"
 	languageParaSailStr            = "ParaSail"
+	languageParrotStr              = "Parrot"
 	languagePascalStr              = "Pascal"
 	languagePawnStr                = "Pawn"
 	languagePEGStr                 = "PEG"
@@ -2102,6 +2105,8 @@ func ParseLanguage(s string) (Language, bool) {
 		return LanguagePan, true
 	case normalizeString(languageParaSailStr):
 		return LanguageParaSail, true
+	case normalizeString(languageParrotStr):
+		return LanguageParrot, true
 	case normalizeString(languagePascalStr):
 		return LanguagePascal, true
 	case normalizeString(languagePawnStr):
@@ -3104,6 +3109,8 @@ func (l Language) String() string {
 		return languagePanStr
 	case LanguageParaSail:
 		return languageParaSailStr
+	case LanguageParrot:
+		return languageParrotStr
 	case LanguagePascal:
 		return languagePascalStr
 	case LanguagePawn:

--- a/pkg/heartbeat/language_test.go
+++ b/pkg/heartbeat/language_test.go
@@ -356,6 +356,7 @@ func languageTests() map[string]heartbeat.Language {
 		"PacmanConf":                    heartbeat.LanguagePacmanConf,
 		"Pan":                           heartbeat.LanguagePan,
 		"ParaSail":                      heartbeat.LanguageParaSail,
+		"Parrot":                        heartbeat.LanguageParrot,
 		"Pascal":                        heartbeat.LanguagePascal,
 		"Pawn":                          heartbeat.LanguagePawn,
 		"PEG":                           heartbeat.LanguagePEG,


### PR DESCRIPTION
This PR ensures language support for P - Q chroma lexers. This includes correct language spelling following wakatime verified languages.

Additionally language support for missing wakatime verified is added.

Closes #238 