### PR TITLE
Apply label on new issues

### DIFF
--- a/.github/workflows/on_open_issue.yml
+++ b/.github/workflows/on_open_issue.yml
@@ -1,0 +1,28 @@
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  issue-triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v3
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['triage']
+            })
+      - uses: actions/github-script@v3
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '👋 Thanks for reporting!'
+            })


### PR DESCRIPTION
This PR creates a new workflow to apply a `triage` label and a message to every new issue opened. It'll be much useful when released to general public.