### PR TITLE
Set debug level based also on settings file

### DIFF
--- a/cmd/legacy/configread/configread.go
+++ b/cmd/legacy/configread/configread.go
@@ -58,9 +58,6 @@ func LoadParams(v *viper.Viper) (Params, error) {
 	section := strings.TrimSpace(v.GetString("config-section"))
 	key := strings.TrimSpace(v.GetString("config-read"))
 
-	jww.DEBUG.Println("section:", section)
-	jww.DEBUG.Println("key:", key)
-
 	if section == "" || key == "" {
 		return Params{},
 			ErrFileRead("failed reading wakatime config file. neither section nor key can be empty")

--- a/cmd/legacy/run.go
+++ b/cmd/legacy/run.go
@@ -19,15 +19,6 @@ import (
 // Run executes legacy commands following the interface of the old python implementation of the WakaTime script.
 func Run(v *viper.Viper) {
 	logfile.Set(v)
-	setVerbose(v)
-
-	if v.GetBool("version") {
-		jww.DEBUG.Println("command: version")
-
-		runVersion(v.GetBool("verbose"))
-
-		os.Exit(exitcode.Success)
-	}
 
 	if err := config.ReadInConfig(v, config.FilePath); err != nil {
 		jww.CRITICAL.Printf("err: %s", err)
@@ -38,6 +29,16 @@ func Run(v *viper.Viper) {
 		}
 
 		os.Exit(exitcode.ErrDefault)
+	}
+
+	setVerbose(v)
+
+	if v.GetBool("version") {
+		jww.DEBUG.Println("command: version")
+
+		runVersion(v.GetBool("verbose"))
+
+		os.Exit(exitcode.Success)
 	}
 
 	if v.IsSet("config-read") {
@@ -64,7 +65,12 @@ func Run(v *viper.Viper) {
 }
 
 func setVerbose(v *viper.Viper) {
-	if v.GetBool("verbose") {
+	var debug bool
+	if b := v.GetBool("settings.debug"); v.IsSet("settings.debug") {
+		debug = b
+	}
+
+	if v.GetBool("verbose") || debug {
 		jww.SetStdoutThreshold(jww.LevelDebug)
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -67,8 +67,6 @@ func ReadInConfig(v *viper.Viper, filepathFn func(v *viper.Viper) (string, error
 		return ErrFileParse(fmt.Sprintf("error getting filepath: %s", err))
 	}
 
-	jww.DEBUG.Println("wakatime path: ", configFilepath)
-
 	v.SetConfigType("ini")
 	v.SetConfigFile(configFilepath)
 


### PR DESCRIPTION
This PR ensures that debug level is set based on both `verbose` argument and `debug` setting.

Original code can be found [here](https://github.com/wakatime/wakatime/blob/e8deb156f1c2d26e5cf874da97f7b4354b3f5d20/wakatime/arguments.py#L368).