### PR TITLE
Parse editor from plugin

### DIFF
--- a/cmd/legacy/heartbeat/params_internal_test.go
+++ b/cmd/legacy/heartbeat/params_internal_test.go
@@ -1,0 +1,45 @@
+package heartbeat
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseEditorFromPlugin(t *testing.T) {
+	tests := map[string]struct {
+		Plugin   string
+		Expected string
+	}{
+		"editor/version plugin/version": {
+			Plugin:   "vscode/1.51.1 vscode-wakatime/4.0.9",
+			Expected: "vscode",
+		},
+		"plugin/version (no dash)": {
+			Plugin:   "emacs-wakatime/1.0.2",
+			Expected: "emacs",
+		},
+		"plugin/version (multiple dashes)": {
+			Plugin:   "camunda-modeler-wakatime/0.4.3",
+			Expected: "camunda-modeler",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			editor, err := parseEditorFromPlugin(test.Plugin)
+			require.NoError(t, err)
+
+			assert.Equal(t, test.Expected, editor)
+		})
+	}
+}
+
+func TestParseEditorFromPluginErr(t *testing.T) {
+	editor, err := parseEditorFromPlugin("editor-wakatime")
+	require.Error(t, err)
+
+	assert.Empty(t, editor)
+	assert.Equal(t, "plugin malformed: editor-wakatime", err.Error())
+}


### PR DESCRIPTION
This PR adds a parser to get editor name from plugin argument. There are different ways to pass `plugin` argument to the cli. As far as I could research three ways are common and covered in this PR. It also replaces the [old logic](https://github.com/wakatime/wakatime/blob/2e636d389bf5da4e998e05d5285a96ce2c181e3d/wakatime/stats.py#L237) to a smarter regex.

1. The most common `editor/version plugin/version`. [Example 1](https://github.com/wakatime/vscode-wakatime/blob/master/src/wakatime.ts#L347) [Example 2](https://github.com/wakatime/vim-wakatime/blob/master/plugin/wakatime.vim#L345)
2. `plugin/version (no dash)`. [Example](https://github.com/wakatime/wakatime-mode/blob/master/wakatime-mode.el#L37).
3. `plugin/version (multiple dashes)`. [Example](https://github.com/wakatime/camunda-modeler-wakatime-plugin/blob/master/helper/index.js#L42).