### PR TITLE
Build bsd binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ else
 endif
 
 # targets
-build-all: build-all-darwin build-all-linux build-all-windows
+build-all: build-all-darwin build-all-freebsd build-all-linux build-all-netbsd build-all-openbsd build-all-windows
 
 build-all-darwin: build-darwin-amd64 build-darwin-arm64
 
@@ -41,6 +41,17 @@ build-darwin-amd64:
 
 build-darwin-arm64:
 	GOOS=darwin GOARCH=arm64 make build-binary
+
+build-all-freebsd: build-freebsd-386 build-freebsd-amd64 build-freebsd-arm
+
+build-freebsd-386:
+	GOOS=freebsd GOARCH=386 make build-binary
+
+build-freebsd-amd64:
+	GOOS=freebsd GOARCH=amd64 make build-binary
+
+build-freebsd-arm:
+	GOOS=freebsd GOARCH=arm make build-binary
 
 build-all-linux: build-linux-386 build-linux-amd64 build-linux-arm build-linux-arm64
 
@@ -55,6 +66,31 @@ build-linux-arm:
 
 build-linux-arm64:
 	GOOS=linux GOARCH=arm64 make build-binary
+
+build-all-netbsd: build-netbsd-386 build-netbsd-amd64 build-netbsd-arm
+
+build-netbsd-386:
+	GOOS=netbsd GOARCH=386 make build-binary
+
+build-netbsd-amd64:
+	GOOS=netbsd GOARCH=amd64 make build-binary
+
+build-netbsd-arm:
+	GOOS=netbsd GOARCH=arm make build-binary
+
+build-all-openbsd: build-openbsd-386 build-openbsd-amd64 build-openbsd-arm build-openbsd-arm64
+
+build-openbsd-386:
+	GOOS=openbsd GOARCH=386 make build-binary
+
+build-openbsd-amd64:
+	GOOS=openbsd GOARCH=amd64 make build-binary
+
+build-openbsd-arm:
+	GOOS=openbsd GOARCH=arm make build-binary
+
+build-openbsd-arm64:
+	GOOS=openbsd GOARCH=arm64 make build-binary
 
 build-all-windows: build-windows-386 build-windows-amd64
 

--- a/bin/prepare_assets.sh
+++ b/bin/prepare_assets.sh
@@ -13,18 +13,38 @@ if [ "$(which zip)" = "" ]; then
 fi
 
 # add execution permission
+chmod 750 ./build/wakatime-cli-freebsd-386
+chmod 750 ./build/wakatime-cli-freebsd-amd64
+chmod 750 ./build/wakatime-cli-freebsd-arm
 chmod 750 ./build/wakatime-cli-linux-386
 chmod 750 ./build/wakatime-cli-linux-amd64
 chmod 750 ./build/wakatime-cli-linux-arm
 chmod 750 ./build/wakatime-cli-linux-arm64
+chmod 750 ./build/wakatime-cli-netbsd-386
+chmod 750 ./build/wakatime-cli-netbsd-amd64
+chmod 750 ./build/wakatime-cli-netbsd-arm
+chmod 750 ./build/wakatime-cli-openbsd-386
+chmod 750 ./build/wakatime-cli-openbsd-amd64
+chmod 750 ./build/wakatime-cli-openbsd-arm
+chmod 750 ./build/wakatime-cli-openbsd-arm64
 chmod 750 ./build/wakatime-cli-windows-386.exe
 chmod 750 ./build/wakatime-cli-windows-amd64.exe
 
 # create archives
+tar -czf ./release/wakatime-cli-freebsd-386.tar.gz -C ./build/ wakatime-cli-freebsd-386
+tar -czf ./release/wakatime-cli-freebsd-amd64.tar.gz -C ./build/ wakatime-cli-freebsd-amd64
+tar -czf ./release/wakatime-cli-freebsd-arm.tar.gz -C ./build/ wakatime-cli-freebsd-arm
 tar -czf ./release/wakatime-cli-linux-386.tar.gz -C ./build/ wakatime-cli-linux-386
 tar -czf ./release/wakatime-cli-linux-amd64.tar.gz -C ./build/ wakatime-cli-linux-amd64
 tar -czf ./release/wakatime-cli-linux-arm.tar.gz -C ./build/ wakatime-cli-linux-arm
 tar -czf ./release/wakatime-cli-linux-arm64.tar.gz -C ./build/ wakatime-cli-linux-arm64
+tar -czf ./release/wakatime-cli-netbsd-386.tar.gz -C ./build/ wakatime-cli-netbsd-386
+tar -czf ./release/wakatime-cli-netbsd-amd64.tar.gz -C ./build/ wakatime-cli-netbsd-amd64
+tar -czf ./release/wakatime-cli-netbsd-arm.tar.gz -C ./build/ wakatime-cli-netbsd-arm
+tar -czf ./release/wakatime-cli-openbsd-386.tar.gz -C ./build/ wakatime-cli-openbsd-386
+tar -czf ./release/wakatime-cli-openbsd-amd64.tar.gz -C ./build/ wakatime-cli-openbsd-amd64
+tar -czf ./release/wakatime-cli-openbsd-arm.tar.gz -C ./build/ wakatime-cli-openbsd-arm
+tar -czf ./release/wakatime-cli-openbsd-arm64.tar.gz -C ./build/ wakatime-cli-openbsd-arm64
 zip -j ./release/wakatime-cli-windows-386.zip ./build/wakatime-cli-windows-386.exe
 zip -j ./release/wakatime-cli-windows-amd64.zip ./build/wakatime-cli-windows-amd64.exe
 

--- a/go.mod
+++ b/go.mod
@@ -26,3 +26,5 @@ require (
 replace github.com/alecthomas/chroma => github.com/wakatime/chroma v0.8.2-wakatime.3
 
 replace github.com/spf13/viper => github.com/wakatime/viper v1.7.1-0.20210127133619-3adac62bd70f
+
+replace github.com/matishsiao/goInfo => github.com/wakatime/goInfo v0.1.0-wakatime.2

--- a/go.sum
+++ b/go.sum
@@ -127,8 +127,6 @@ github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzRKO2BQ4=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
-github.com/matishsiao/goInfo v0.0.0-20200404012835-b5f882ee2288 h1:cdM7et8/VlNnSBpq3KbyQWsYLCY0WsB7tvV8Fr0DUNE=
-github.com/matishsiao/goInfo v0.0.0-20200404012835-b5f882ee2288/go.mod h1:yLZrFIhv+Z20hxHvcZpEyKVQp9HMsOJkXAxx7yDqtvg=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
@@ -211,6 +209,8 @@ github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/wakatime/chroma v0.8.2-wakatime.3 h1:J/gf6+mW7FmJ653vgU+7zxuN2qzwAU3KNtyIkfDgezI=
 github.com/wakatime/chroma v0.8.2-wakatime.3/go.mod h1:Mldbmbb8NHiOz8oC1HKR8xUQ0EPvAjZpKDyQl2nGrnQ=
+github.com/wakatime/goInfo v0.1.0-wakatime.2 h1:CaPbE4l8yv6s2Oj+yAEkYHfMY6BJ09tNjdGboUvZu4g=
+github.com/wakatime/goInfo v0.1.0-wakatime.2/go.mod h1:aEt7p9Rvh67BYApmZwNDPpgircTO2kgdmDUoF/1QmwA=
 github.com/wakatime/viper v1.7.1-0.20210127133619-3adac62bd70f h1:l7cFA661os7j0s1Ub+jJ2Y9icZhfEGXXNa3/D8CFsMg=
 github.com/wakatime/viper v1.7.1-0.20210127133619-3adac62bd70f/go.mod h1:3sfV/eQm/hLQ0tQ24YjZmGp6Jm+yPGAmxexB8s0KatU=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=


### PR DESCRIPTION
This PR adds building of bsd operating system binaries. All architectures, as listed in https://golang.org/doc/install/source#environment are supported. Check built binaries on test release https://github.com/wakatime/wakatime-cli/releases/tag/v0.0.0-test.781548702.

- Due to missing support for NetBSD and OpenBSD in https://github.com/matishsiao/goInfo, this repo was forked to wakatime organization, wher NetBSD/OpenBSD support was added.
- PR was opened to merge changes upstream: https://github.com/matishsiao/goInfo/pull/10

Closes #58 