### PR TITLE
Add `--useragent` flag

### DIFF
--- a/cmd/legacy/run.go
+++ b/cmd/legacy/run.go
@@ -2,16 +2,18 @@ package legacy
 
 import (
 	"errors"
+	"fmt"
 	"os"
 
 	"github.com/wakatime/wakatime-cli/cmd/legacy/configread"
 	"github.com/wakatime/wakatime-cli/cmd/legacy/configwrite"
-	"github.com/wakatime/wakatime-cli/cmd/legacy/heartbeat"
+	heartbeatcmd "github.com/wakatime/wakatime-cli/cmd/legacy/heartbeat"
 	"github.com/wakatime/wakatime-cli/cmd/legacy/logfile"
 	"github.com/wakatime/wakatime-cli/cmd/legacy/today"
 	"github.com/wakatime/wakatime-cli/cmd/legacy/todaygoal"
 	"github.com/wakatime/wakatime-cli/pkg/config"
 	"github.com/wakatime/wakatime-cli/pkg/exitcode"
+	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 	"github.com/wakatime/wakatime-cli/pkg/log"
 
 	"github.com/spf13/viper"
@@ -42,6 +44,20 @@ func Run(v *viper.Viper) {
 
 	log.SetOutput(f)
 	log.SetVerbose(logfileParams.Verbose)
+
+	if v.GetBool("useragent") {
+		log.Debugln("command: useragent")
+
+		if plugin := v.GetString("plugin"); plugin != "" {
+			fmt.Println(heartbeat.UserAgent(plugin))
+
+			os.Exit(exitcode.Success)
+		}
+
+		fmt.Println(heartbeat.UserAgentUnknownPlugin())
+
+		os.Exit(exitcode.Success)
+	}
 
 	if v.GetBool("version") {
 		log.Debugln("command: version")
@@ -77,5 +93,5 @@ func Run(v *viper.Viper) {
 
 	log.Debugln("command: heartbeat")
 
-	heartbeat.Run(v)
+	heartbeatcmd.Run(v)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -173,6 +173,7 @@ func setFlags(cmd *cobra.Command, v *viper.Viper) {
 		"",
 		"Prints time for the given goal id Today, then exits"+
 			" Visit wakatime.com/api/v1/users/current/goals to find your goal id.")
+	flags.Bool("useragent", false, "Prints the wakatime-cli useragent, as it will be sent to the api, then exits.")
 	flags.Bool("verbose", false, "Turns on debug messages in log file.")
 	flags.Bool("version", false, "Prints the wakatime-cli version number, then exits.")
 	flags.Bool("write", false, "When set, tells api this heartbeat was triggered from writing to a file.")


### PR DESCRIPTION
This PR adds a flag `--useragent`, which displays the useragent, as it will be sent to the api. This is a convenience feature to allow easy validation of the os sensitive feature. It proved to be helpful during building bsd binaries implementation.

