### PR TITLE
Use commit sha as current tag

### DIFF
--- a/.github/workflows/on_push_protected_branches.yml
+++ b/.github/workflows/on_push_protected_branches.yml
@@ -70,10 +70,10 @@ jobs:
           prerelease_id: "alpha"
       - 
         name: Changelog
-        uses: gandarez/changelog-action@v1.0.2
+        uses: gandarez/changelog-action@v1.0.3
         id: changelog
         with:
-          current_tag: ${{ steps.semver-tag.outputs.semver_tag }}
+          current_tag: $GITHUB_SHA
           exclude: |
             ^Merge pull request .*
       - 


### PR DESCRIPTION
This PR fixes the `on push protected branches` workflow by passing the commit sha to be used by changelog. Otherwise it doesn't know which tag/commit is and breaks the pipeline as seen [here](https://github.com/wakatime/wakatime-cli/runs/2478764130?check_suite_focus=true).