### PR TITLE
Fix logging caller

### DIFF
--- a/cmd/legacy/logfile/logfile.go
+++ b/cmd/legacy/logfile/logfile.go
@@ -5,9 +5,10 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/wakatime/wakatime-cli/pkg/vipertools"
+
 	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/viper"
-	"github.com/wakatime/wakatime-cli/pkg/vipertools"
 )
 
 const defaultFile = ".wakatime.log"
@@ -20,6 +21,11 @@ type Params struct {
 
 // LoadParams loads needed data from the configuration file.
 func LoadParams(v *viper.Viper) (Params, error) {
+	var debug bool
+	if b := v.GetBool("settings.debug"); v.IsSet("settings.debug") {
+		debug = b
+	}
+
 	logFile, _ := vipertools.FirstNonEmptyString(v, "log-file", "logfile", "settings.log_file")
 
 	if logFile != "" {
@@ -30,7 +36,8 @@ func LoadParams(v *viper.Viper) (Params, error) {
 		}
 
 		return Params{
-			File: p,
+			File:    p,
+			Verbose: v.GetBool("verbose") || debug,
 		}, nil
 	}
 
@@ -52,11 +59,6 @@ func LoadParams(v *viper.Viper) (Params, error) {
 			return Params{},
 				ErrLogFile(fmt.Sprintf("failed getting user's home directory: %s", err))
 		}
-	}
-
-	var debug bool
-	if b := v.GetBool("settings.debug"); v.IsSet("settings.debug") {
-		debug = b
 	}
 
 	return Params{

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.1
-	github.com/stretchr/testify v1.6.1
+	github.com/stretchr/testify v1.7.0
 	github.com/yookoala/realpath v1.0.0
 	go.etcd.io/bbolt v1.3.5
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -204,6 +204,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
@@ -290,6 +292,8 @@ golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201201145000-ef89a241ccb3 h1:kzM6+9dur93BcC2kVlYl34cHU+TYZLanmpSJHVMmL64=
 golang.org/x/sys v0.0.0-20201201145000-ef89a241ccb3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210218155724-8ebf48af031b h1:lAZ0/chPUDWwjqosYR0X4M490zQhMsiJ4K3DbA7o+3g=
+golang.org/x/sys v0.0.0-20210218155724-8ebf48af031b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -1,16 +1,41 @@
 package log
 
 import (
+	"fmt"
 	"io"
 	"os"
+	"runtime"
+	"strings"
 
 	"github.com/wakatime/wakatime-cli/pkg/version"
 
 	l "github.com/sirupsen/logrus"
 )
 
-// nolint
-var logEntry = new()
+// nolint:gochecknoglobals
+var (
+	logEntry = new()
+	// Debugf logs a message at level Debug.
+	Debugf = logEntry.Debugf
+	// Infof logs a message at level Info.
+	Infof = logEntry.Infof
+	// Warnf logs a message at level Warn.
+	Warnf = logEntry.Warnf
+	// Errorf logs a message at level Error.
+	Errorf = logEntry.Errorf
+	// Fatalf logs a message at level Fatal then the process will exit with status set to 1.
+	Fatalf = logEntry.Fatalf
+	// Debugln logs a message at level Debug.
+	Debugln = logEntry.Debugln
+	// Infoln logs a message at level Info.
+	Infoln = logEntry.Infoln
+	// Warnln logs a message at level Warn.
+	Warnln = logEntry.Warnln
+	// Errorln logs a message at level Error.
+	Errorln = logEntry.Errorln
+	// Fatalln logs a message at level Fatal then the process will exit with status set to 1.
+	Fatalln = logEntry.Fatalln
+)
 
 func new() *l.Entry {
 	entry := l.NewEntry(&l.Logger{
@@ -22,6 +47,16 @@ func new() *l.Entry {
 				l.FieldKeyMsg:  "message",
 			},
 			DisableHTMLEscape: true,
+			CallerPrettyfier: func(f *runtime.Frame) (string, string) {
+				// Simplifies function description by removing package name from it.
+				lastSlash := strings.LastIndexByte(f.Function, '/')
+				if lastSlash < 0 {
+					lastSlash = 0
+				}
+				lastDot := strings.LastIndexByte(f.Function[lastSlash:], '.') + lastSlash
+
+				return f.Function[lastDot+1:], fmt.Sprintf("%s:%d", f.File, f.Line)
+			},
 		},
 		Level:        l.InfoLevel,
 		ExitFunc:     os.Exit,
@@ -54,54 +89,4 @@ func WithField(key string, value interface{}) {
 // WithFields adds a map of fields to the Entry.
 func WithFields(fields map[string]interface{}) {
 	logEntry.WithFields(fields)
-}
-
-// Debugf logs a message at level Debug.
-func Debugf(format string, args ...interface{}) {
-	logEntry.Debugf(format, args...)
-}
-
-// Infof logs a message at level Info.
-func Infof(format string, args ...interface{}) {
-	logEntry.Infof(format, args...)
-}
-
-// Warnf logs a message at level Warn.
-func Warnf(format string, args ...interface{}) {
-	logEntry.Warnf(format, args...)
-}
-
-// Errorf logs a message at level Error.
-func Errorf(format string, args ...interface{}) {
-	logEntry.Errorf(format, args...)
-}
-
-// Fatalf logs a message at level Fatal then the process will exit with status set to 1.
-func Fatalf(format string, args ...interface{}) {
-	logEntry.Fatalf(format, args...)
-}
-
-// Debugln logs a message at level Debug.
-func Debugln(args ...interface{}) {
-	logEntry.Debugln(args...)
-}
-
-// Infoln logs a message at level Info.
-func Infoln(args ...interface{}) {
-	logEntry.Infoln(args...)
-}
-
-// Warnln logs a message at level Warn.
-func Warnln(args ...interface{}) {
-	logEntry.Warnln(args...)
-}
-
-// Errorln logs a message at level Error.
-func Errorln(args ...interface{}) {
-	logEntry.Errorln(args...)
-}
-
-// Fatalln logs a message at level Fatal then the process will exit with status set to 1.
-func Fatalln(args ...interface{}) {
-	logEntry.Fatalln(args...)
 }


### PR DESCRIPTION
This PR fixes the caller and func names when printing json. The bug was introduced in the last PR when logrus has been wrapped and internal `getCaller` function can't skip it correctly. The solution was to create variables in order to replace the current exposed funcs.

Closes https://github.com/wakatime/wakatime-cli/issues/322