### PR TITLE
Do not build binaries on alpha releases

### DIFF
--- a/.github/workflows/on_prerelease.yaml
+++ b/.github/workflows/on_prerelease.yaml
@@ -1,0 +1,33 @@
+name: Notify about new prerelease
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  notify:
+    if: "github.event.release.prerelease"
+    name: Send slack notification
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: "Slack notification"
+        uses: 8398a7/action-slack@v3
+        if: ${{ success() }}
+        with:
+          status: custom
+          fields: message
+          custom_payload: |
+            {
+              username: 'WakaTime Bot',
+              icon_emoji: ':mega:',
+              attachments: [{
+                color: 'good',
+                pretext: 'New <https://github.com/wakatime/wakatime-cli|wakatime-cli> version released',
+                title: `${{ steps.version.outputs.version }}`,
+                title_link: `https://github.com/wakatime/wakatime-cli/releases/tag/${{ steps.version.outputs.version }}`,
+                text: `${process.env.AS_MESSAGE}`
+              }]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/on_release.yaml
+++ b/.github/workflows/on_release.yaml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   build:
+    if: "!github.event.release.prerelease"
     name: Build release assets
     runs-on: ubuntu-latest
     steps:
@@ -99,7 +100,12 @@ jobs:
         name: "Get version"
         id: version
         run: echo ::set-output name=version::$(echo $GITHUB_REF | cut -d / -f 3)
-      - 
+  notify:
+    name: Send slack notification
+    needs: upload
+    runs-on: ubuntu-latest
+    steps:
+      -
         name: "Slack notification"
         uses: 8398a7/action-slack@v3
         if: ${{ success() }}


### PR DESCRIPTION
This PR changes `on_release` workflow, to not run on prereleases. This is achieved by adding a condition to `on_release` workflow to skip it for prereleases.

To continue notifying to slack on alpha releases, a new workflow `on_prerelease` is added.

Closes #328 