### PR TITLE
Remove ignore case directive from go deps exclude regex

### DIFF
--- a/pkg/deps/golang.go
+++ b/pkg/deps/golang.go
@@ -11,7 +11,7 @@ import (
 	"github.com/alecthomas/chroma/lexers/g"
 )
 
-var goExcludeRegex = regexp.MustCompile(`(?i)^"fmt"$`)
+var goExcludeRegex = regexp.MustCompile(`^"fmt"$`)
 
 // StateGo is a token parsing state.
 type StateGo int


### PR DESCRIPTION
This PR removes an unnecessary ignore case directive from the golang deps parser exclude regex. This was in the project backlog for quite a while, so let's get rid of it :wink: 

Closes #181 