### PR TITLE
Fix alternate-language param info

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -39,8 +39,8 @@ func NewRootCMD() *cobra.Command {
 
 func setFlags(cmd *cobra.Command, v *viper.Viper) {
 	flags := cmd.Flags()
-	flags.String("alternate-language", "", "(deprecated)")
-	flags.String("alternate-project", "", "Optional alternate project name. Auto-discovered project takes priority.")
+	flags.String("alternate-language", "", "Optional alternate language name. Auto-detected language takes priority.")
+	flags.String("alternate-project", "", "Optional alternate project name. Auto-detected project takes priority.")
 	flags.String("api-url", "", "Heartbeats api url. For debugging with a local server.")
 	flags.String("apiurl", "", "(deprecated) Heartbeats api url. For debugging with a local server.")
 	flags.String(


### PR DESCRIPTION
This PR fixed the info for `--alternate-language` parameter.