### PR TITLE
Fix infinite loop for Windows

### DIFF
--- a/pkg/project/git.go
+++ b/pkg/project/git.go
@@ -154,7 +154,7 @@ func findGitConfigFile(fp string, directory string, match string) (string, bool)
 	}
 
 	dir := filepath.Clean(filepath.Join(fp, ".."))
-	if dir == "/" || driveLetterRegex.MatchString(dir) {
+	if dir == "." || dir == "/" || driveLetterRegex.MatchString(dir) {
 		return "", false
 	}
 

--- a/pkg/project/mercurial.go
+++ b/pkg/project/mercurial.go
@@ -61,7 +61,7 @@ func findHgConfigDir(fp string) (string, bool) {
 	}
 
 	dir := filepath.Clean(filepath.Join(fp, ".."))
-	if dir == "/" {
+	if dir == "." || dir == "/" || driveLetterRegex.MatchString(dir) {
 		return "", false
 	}
 


### PR DESCRIPTION
This PR fixes an infinite loop that may occur for some Windows users when detecting project.

Packages `git` and `mercurial` recursively looks for its configuration file and in windows machines the last path is a `C:\` (or any other drive letter) instead of only a dash. 

Closes https://github.com/wakatime/wakatime-cli/issues/359