### PR TITLE
Log improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .DEFAULT_GOAL := build-all
 
 # globals
-BINARY_NAME=wakatime-cli
+BINARY_NAME?=wakatime-cli
 COMMIT?=$(shell git rev-parse --short HEAD)
 DATE?=$(shell date -u '+%Y-%m-%dT%H:%M:%SZ')
 REPO=github.com/wakatime/wakatime-cli

--- a/cmd/legacy/logfile/logfile.go
+++ b/cmd/legacy/logfile/logfile.go
@@ -15,8 +15,9 @@ const defaultFile = ".wakatime.log"
 
 // Params contains log file parameters.
 type Params struct {
-	File    string
-	Verbose bool
+	File     string
+	ToStdout bool
+	Verbose  bool
 }
 
 // LoadParams loads needed data from the configuration file.
@@ -62,7 +63,8 @@ func LoadParams(v *viper.Viper) (Params, error) {
 	}
 
 	return Params{
-		File:    filepath.Join(home, defaultFile),
-		Verbose: v.GetBool("verbose") || debug,
+		File:     filepath.Join(home, defaultFile),
+		ToStdout: v.GetBool("log-to-stdout"),
+		Verbose:  v.GetBool("verbose") || debug,
 	}, nil
 }

--- a/cmd/legacy/logfile/logfile_test.go
+++ b/cmd/legacy/logfile/logfile_test.go
@@ -33,6 +33,7 @@ func TestLoadParams(t *testing.T) {
 		ViperLogFile       string
 		ViperLogFileConfig string
 		ViperLogFileOld    string
+		ViperToStdout      bool
 		EnvVar             string
 		ViperDebug         bool
 		ViperDebugConfig   bool
@@ -84,6 +85,13 @@ func TestLoadParams(t *testing.T) {
 				File: filepath.Join(home, ".wakatime.log"),
 			},
 		},
+		"log to stdout": {
+			ViperToStdout: true,
+			Expected: logfile.Params{
+				File:     filepath.Join(home, ".wakatime.log"),
+				ToStdout: true,
+			},
+		},
 	}
 
 	for name, test := range tests {
@@ -91,6 +99,7 @@ func TestLoadParams(t *testing.T) {
 			v := viper.New()
 			v.Set("log-file", test.ViperLogFile)
 			v.Set("logfile", test.ViperLogFileOld)
+			v.Set("log-to-stdout", test.ViperToStdout)
 			v.Set("settings.log_file", test.ViperLogFileConfig)
 			v.Set("settings.debug", test.ViperDebug)
 			v.Set("verbose", test.ViperDebugConfig)

--- a/cmd/legacy/run.go
+++ b/cmd/legacy/run.go
@@ -37,12 +37,17 @@ func Run(v *viper.Viper) {
 		log.Fatalf("failed to load log params: %s", err)
 	}
 
-	f, err := os.OpenFile(logfileParams.File, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0666)
-	if err != nil {
-		log.Fatalf("error opening log file: %s", err)
+	if !logfileParams.ToStdout {
+		log.Debugf("log to file %s", logfileParams.File)
+
+		f, err := os.OpenFile(logfileParams.File, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0666)
+		if err != nil {
+			log.Fatalf("error opening log file: %s", err)
+		}
+
+		log.SetOutput(f)
 	}
 
-	log.SetOutput(f)
 	log.SetVerbose(logfileParams.Verbose)
 
 	if v.GetBool("useragent") {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -134,6 +134,7 @@ func setFlags(cmd *cobra.Command, v *viper.Viper) {
 	)
 	flags.String("log-file", "", "Optional log file. Defaults to '~/.wakatime.log'.")
 	flags.String("logfile", "", "(deprecated) Optional log file. Defaults to '~/.wakatime.log'.")
+	flags.Bool("log-to-stdout", false, "If enabled, logs will go to stdout. Will overwrite logfile configs.")
 	flags.Bool(
 		"no-ssl-verify",
 		false,

--- a/pkg/deps/deps.go
+++ b/pkg/deps/deps.go
@@ -31,6 +31,8 @@ type DependencyParser interface {
 func WithDetection(c Config) heartbeat.HandleOption {
 	return func(next heartbeat.Handle) heartbeat.Handle {
 		return func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+			log.Debugln("execute dependency detection")
+
 			for n, h := range hh {
 				if h.EntityType != heartbeat.FileType {
 					continue

--- a/pkg/filestats/filestats.go
+++ b/pkg/filestats/filestats.go
@@ -25,6 +25,8 @@ type Config struct {
 func WithDetection(c Config) heartbeat.HandleOption {
 	return func(next heartbeat.Handle) heartbeat.Handle {
 		return func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+			log.Debugln("execute filestats detection")
+
 			for n, h := range hh {
 				if h.EntityType != heartbeat.FileType {
 					continue

--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -25,6 +25,8 @@ type Config struct {
 func WithFiltering(config Config) heartbeat.HandleOption {
 	return func(next heartbeat.Handle) heartbeat.Handle {
 		return func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+			log.Debugln("execute heartbeat filtering")
+
 			var filtered []heartbeat.Heartbeat
 
 			for _, h := range hh {

--- a/pkg/heartbeat/sanitize.go
+++ b/pkg/heartbeat/sanitize.go
@@ -3,6 +3,7 @@ package heartbeat
 import (
 	"path/filepath"
 
+	"github.com/wakatime/wakatime-cli/pkg/log"
 	"github.com/wakatime/wakatime-cli/pkg/regex"
 )
 
@@ -23,6 +24,8 @@ type SanitizeConfig struct {
 func WithSanitization(config SanitizeConfig) HandleOption {
 	return func(next Handle) Handle {
 		return func(hh []Heartbeat) ([]Result, error) {
+			log.Debugln("execute heartbeat sanitization")
+
 			for n, h := range hh {
 				hh[n] = Sanitize(h, config)
 			}

--- a/pkg/language/language.go
+++ b/pkg/language/language.go
@@ -17,6 +17,8 @@ import (
 func WithDetection() heartbeat.HandleOption {
 	return func(next heartbeat.Handle) heartbeat.Handle {
 		return func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+			log.Debugln("execute language detection")
+
 			for n, h := range hh {
 				if hh[n].Language != nil {
 					continue

--- a/pkg/offline/offline.go
+++ b/pkg/offline/offline.go
@@ -48,6 +48,8 @@ func QueueFilepath() (string, error) {
 func WithQueue(filepath string, syncLimit int) (heartbeat.HandleOption, error) {
 	return func(next heartbeat.Handle) heartbeat.Handle {
 		return func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+			log.Debugln("execute offline queue")
+
 			db, err := bolt.Open(filepath, 0600, nil)
 			if err != nil {
 				return nil, fmt.Errorf("failed to open db connection: %s", err)

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -56,6 +56,8 @@ type MapPattern struct {
 func WithDetection(c Config) heartbeat.HandleOption {
 	return func(next heartbeat.Handle) heartbeat.Handle {
 		return func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+			log.Debugln("execute project detection")
+
 			for n, h := range hh {
 				if h.EntityType != heartbeat.FileType {
 					project := firstNonEmptyString(h.ProjectOverride, h.ProjectAlternate)


### PR DESCRIPTION
This PR improves logging. These changes proved to be helpful on debugging the windows recursion problem (#361):

- Allow logging to stdout via `--log-to-stdout` parameter
- Indicate execution of each heartbeat processing pipeline step via debug log
- Allow non-standard binary name on building via make