### PR TITLE
Refactor git project detection

### DIFF
--- a/pkg/project/git.go
+++ b/pkg/project/git.go
@@ -63,22 +63,22 @@ func (g Git) Detect() (Result, bool, error) {
 	gitConfigFile, ok := findFileOrDirectory(fp, ".git", "config")
 
 	if ok {
-		dir, _ := filepath.Split(gitConfigFile)
-		project := filepath.Base(filepath.Join(dir, ".."))
+		gitDir := filepath.Dir(gitConfigFile)
+		projectDir := filepath.Join(gitDir, "..")
 
-		branch, err := findGitBranch(filepath.Join(gitConfigFile, "../HEAD"))
+		branch, err := findGitBranch(filepath.Join(gitDir, "HEAD"))
 		if err != nil {
 			log.Errorf(
 				"error finding for branch name from %q: %s",
-				filepath.Join(filepath.Dir(filepath.Join(gitConfigFile, "..")), "HEAD"),
+				filepath.Join(gitDir, "HEAD"),
 				err,
 			)
 		}
 
 		return Result{
-			Project: project,
+			Project: filepath.Base(projectDir),
 			Branch:  branch,
-			Folder:  filepath.Join(dir, ".."),
+			Folder:  projectDir,
 		}, true, nil
 	}
 


### PR DESCRIPTION
This PR suggests some refactoring in `git project detection` as requested in https://github.com/wakatime/wakatime-cli/pull/372.

**On additional remark from @dron22**

Links: https://github.com/wakatime/wakatime-cli/pull/372#discussion_r633008776 + https://github.com/wakatime/wakatime-cli/pull/372#discussion_r633008920

> This is actually the .git directory, not the git config file.

It's talking about [this piece of code](https://github.com/wakatime/wakatime-cli/blob/1a4abf116ffcdcf5529c747174641a87b02a2066/pkg/project/git.go#L153). No, it's a plain `.git` file.

> Inside findGitdir, readFile will be executed on the input parameter. But we will pass in .git directory path, right? This can never work, or am I missing something?

Actually it works fine because the input parameter is a file.  