### PR TITLE
Configure jww to capture logs from viper

### DIFF
--- a/cmd/legacy/run.go
+++ b/cmd/legacy/run.go
@@ -26,18 +26,21 @@ func Run(v *viper.Viper) {
 		log.Fatalf("failed to load log params: %s", err)
 	}
 
+	logFile := os.Stdout
+
 	if !logfileParams.ToStdout {
 		log.Debugf("log to file %s", logfileParams.File)
 
-		f, err := os.OpenFile(logfileParams.File, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0666)
+		logFile, err = os.OpenFile(logfileParams.File, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0666)
 		if err != nil {
 			log.Fatalf("error opening log file: %s", err)
 		}
 
-		log.SetOutput(f)
+		log.SetOutput(logFile)
 	}
 
 	log.SetVerbose(logfileParams.Verbose)
+	log.SetJww(logfileParams.Verbose, logFile)
 
 	if v.GetBool("useragent") {
 		log.Debugln("command: useragent")

--- a/cmd/legacy/run.go
+++ b/cmd/legacy/run.go
@@ -21,6 +21,24 @@ import (
 
 // Run executes legacy commands following the interface of the old python implementation of the WakaTime script.
 func Run(v *viper.Viper) {
+	logfileParams, err := logfile.LoadParams(v)
+	if err != nil {
+		log.Fatalf("failed to load log params: %s", err)
+	}
+
+	if !logfileParams.ToStdout {
+		log.Debugf("log to file %s", logfileParams.File)
+
+		f, err := os.OpenFile(logfileParams.File, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0666)
+		if err != nil {
+			log.Fatalf("error opening log file: %s", err)
+		}
+
+		log.SetOutput(f)
+	}
+
+	log.SetVerbose(logfileParams.Verbose)
+
 	if v.GetBool("useragent") {
 		log.Debugln("command: useragent")
 
@@ -53,24 +71,6 @@ func Run(v *viper.Viper) {
 
 		os.Exit(exitcode.ErrDefault)
 	}
-
-	logfileParams, err := logfile.LoadParams(v)
-	if err != nil {
-		log.Fatalf("failed to load log params: %s", err)
-	}
-
-	if !logfileParams.ToStdout {
-		log.Debugf("log to file %s", logfileParams.File)
-
-		f, err := os.OpenFile(logfileParams.File, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0666)
-		if err != nil {
-			log.Fatalf("error opening log file: %s", err)
-		}
-
-		log.SetOutput(f)
-	}
-
-	log.SetVerbose(logfileParams.Verbose)
 
 	if v.IsSet("config-read") {
 		log.Debugln("command: config-read")

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/slongfield/pyfmt v0.0.0-20180124071345-020a7cb18bca
 	github.com/spf13/cobra v1.1.1
+	github.com/spf13/jwalterweatherman v1.0.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.7.0

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -10,6 +10,7 @@ import (
 	"github.com/wakatime/wakatime-cli/pkg/version"
 
 	l "github.com/sirupsen/logrus"
+	jww "github.com/spf13/jwalterweatherman"
 )
 
 // nolint:gochecknoglobals
@@ -78,6 +79,14 @@ func SetVerbose(verbose bool) {
 		logEntry.Logger.SetLevel(l.DebugLevel)
 	} else {
 		logEntry.Logger.SetLevel(l.InfoLevel)
+	}
+}
+
+// SetJww sets jww log when debug enabled.
+func SetJww(verbose bool, w io.Writer) {
+	if verbose {
+		jww.SetLogThreshold(jww.LevelDebug)
+		jww.SetLogOutput(w)
 	}
 }
 


### PR DESCRIPTION
This PR configures jww to capture logs from `viper`. It's useful when we need more verbose from the external lib. I also changed the order we configure logging to be the first thing to do in `run` otherwise no log is printed before it.