### PR TITLE
Update semver to v1.3.1

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -153,7 +153,7 @@ jobs:
       -
         name: "Calculate semver tag"
         id: semver-tag
-        uses: wakatime/semver-action@v1.3.0
+        uses: wakatime/semver-action@v1.3.1
         with:
           prerelease_id: "alpha"
       -


### PR DESCRIPTION
This PR updates semver to v1.3.1 and addresses the bug when using `misc` and `doc` prefixes.