### PR TITLE
Rename master branch to release

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -141,7 +141,7 @@ jobs:
 
   release:
     name: Release
-    if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop' }}
+    if: ${{ github.ref == 'refs/heads/release' || github.ref == 'refs/heads/develop' }}
     runs-on: ubuntu-latest
     needs: [test, test-integration, test-windows, test-integration-windows, test-macos, test-integration-macos]
     steps:

--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -155,7 +155,8 @@ jobs:
         id: semver-tag
         uses: wakatime/semver-action@v1.3.2
         with:
-          prerelease_id: "alpha"
+          prerelease_id: alpha
+          main_branch_name: release
       -
         name: Changelog
         uses: gandarez/changelog-action@v1.0.4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ After cloning, install dependencies with `make install`.
 This project currently has two branches
 
 - `develop` - Default branch for every new `feature` or `fix`
-- `master` - Branch for production releases and hotfixes
+- `release` - Branch for production releases and hotfixes
 
 ## Testing and Linting
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WakaTime CLI
 
-![Tests master](https://img.shields.io/github/workflow/status/wakatime/wakatime-cli/Create%20Release/master?label=%20tests) ![Build master](https://img.shields.io/github/workflow/status/wakatime/wakatime-cli/Build%20and%20upload%20release%20assets) [![Coverage Status](https://coveralls.io/repos/github/wakatime/wakatime-cli/badge.svg?branch=master)](https://coveralls.io/github/wakatime/wakatime-cli?branch=master)
+![Tests](https://img.shields.io/github/workflow/status/wakatime/wakatime-cli/Create%20Release/release?label=%20tests) ![Build](https://img.shields.io/github/workflow/status/wakatime/wakatime-cli/Build%20and%20upload%20release%20assets) [![Coverage Status](https://coveralls.io/repos/github/wakatime/wakatime-cli/badge.svg?branch=release)](https://coveralls.io/github/wakatime/wakatime-cli?branch=release)
 
 Command line interface to [WakaTime](https://wakatime.com) used by all WakaTime [text editor plugins](https://wakatime.com/editors).
 


### PR DESCRIPTION
`release` is more descriptive than `master`, since we only use this branch for releases. It also keeps me from accidentally typing `git checkout master` from muscle memory, and then accidentally working off the release branch when I meant to work from `develop` branch.