### PR TITLE
Set the target commit for releasing

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -173,6 +173,7 @@ jobs:
           tag_name: ${{ steps.semver-tag.outputs.semver_tag }}
           body: ${{ steps.changelog.outputs.changelog }}
           prerelease: ${{ steps.semver-tag.outputs.is_prerelease }}
+          target_commitish: ${{ github.sha }} 
         env:
           # PAT is mandatory here to trigger new workflows
           # https://docs.github.com/en/actions/reference/authentication-in-a-workflow#using-the-github_token-in-a-workflow


### PR DESCRIPTION
This PR adds the target commit to Release step to avoid tagging being tagged into the previous commit.

Fixes https://github.com/wakatime/wakatime-cli/issues/399