### PR TITLE
Ignore tags for on push event

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -1,6 +1,11 @@
 name: "Tests"
 
-on: push
+on:
+  push:
+    branches:
+      - "**"
+    tags-ignore:
+      - "**"
 
 env:
   GO_VERSION: "1.16"


### PR DESCRIPTION
This PR ignores tags for `on push event`. We've been running all tests twice where the first one when PR gets merged and later when tagging.

<img width="958" alt="Screen Shot 2021-05-20 at 18 51 14" src="https://user-images.githubusercontent.com/782854/119053522-2c08ba80-b994-11eb-922e-95f132b4a53e.png">