### PR TITLE
Rename configuring doc to usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,8 @@ If you are building a plugin using the [WakaTime API](https://wakatime.com/devel
 
 Some more usage information is available in the [FAQ](https://wakatime.com/faq).
 
-## Configuring
-
-Options can be passed via command line, or set in the `$WAKATIME_HOME/.wakatime.cfg` config file. Command line arguments take precedence over config file settings. The `$WAKATIME_HOME/.wakatime.cfg` file is in [INI](http://en.wikipedia.org/wiki/INI_file) format. See [Configuring](CONFIGURING.md) for more details.
+The `$WAKATIME_HOME/.wakatime.cfg` file uses the [INI](http://en.wikipedia.org/wiki/INI_file) format.
+See [Usage](USAGE.md) for more details.
 
 ## Contributing
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,6 +1,13 @@
-# Configuring
+# Usage
 
-Here's an example config file with all available options:
+Options can be passed to wakatime-cli via command line, or set in the `$WAKATIME_HOME/.wakatime.cfg` config file.
+`$WAKATIME_HOME` defaults to your user's `$HOME` directory.
+Command line arguments take precedence over config file settings.
+Run `wakatime-cli --help` for available command line options.
+
+## INI Config File
+
+Here's an example `$WAKATIME_HOME/.wakatime.cfg` config file with all available options:
 
 ```ini
 [settings]
@@ -34,7 +41,7 @@ projects/foo = new project name
 submodules_disabled = false
 ```
 
-## Settings Section
+### Settings Section
 
 | option                         | description | allowed values |
 | ---                            | ---         | ---            |
@@ -57,7 +64,7 @@ submodules_disabled = false
 | timeout                        | Number of seconds to wait when sending heartbeats to api. Defaults to 60 seconds. | _integer_ |
 | hostname                       | Optional name of local machine. Defaults to local machine name read from system. | _machinename_ |
 
-## Project Map Section
+### Project Map Section
 
 A key value pair list separated by new line.
 
@@ -67,10 +74,14 @@ projects/foo = new project name
 ^/home/user/projects/bar(\d+)/ = project{0}
 ```
 
-## Git Section
+### Git Section
 
 | option                         | description | allowed values |
 | ---                            | ---         | ---            |
 | submodules_disabled            | It will be matched against the submodule path and if matching, will skip it. | true;false;regex list |
 
 For commonly used configuration options, see examples in the [FAQ](https://wakatime.com/faq).
+
+### Internal Section
+
+This section is reserved for internal plugin configs, like caching GitHub API requests when checking for wakatime-cli updates.


### PR DESCRIPTION
`CONFIGURING` is too similar to `CONTRIBUTING`.