### PR TITLE
Use master branch for softprops/action-gh-release

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -250,7 +250,7 @@ jobs:
         run: ./bin/prepare_assets.sh
       -
         name: "Create release"
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@master
         with:
           name: ${{ steps.semver-tag.outputs.semver_tag }}
           tag_name: ${{ steps.semver-tag.outputs.semver_tag }}


### PR DESCRIPTION
This PR changes the action `softprops/action-gh-release` to use master branch instead v1. It allows to specify the target commit correctly.

Fix https://github.com/wakatime/wakatime-cli/issues/413
