### PR TITLE
Add distinct sync-offline-activity command

### DIFF
--- a/cmd/legacy/offlinesync/offlinesync.go
+++ b/cmd/legacy/offlinesync/offlinesync.go
@@ -1,0 +1,80 @@
+package offlinesync
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/wakatime/wakatime-cli/cmd/legacy/legacyapi"
+	"github.com/wakatime/wakatime-cli/cmd/legacy/legacyparams"
+	"github.com/wakatime/wakatime-cli/pkg/api"
+	"github.com/wakatime/wakatime-cli/pkg/exitcode"
+	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
+	"github.com/wakatime/wakatime-cli/pkg/log"
+	"github.com/wakatime/wakatime-cli/pkg/offline"
+
+	"github.com/spf13/viper"
+)
+
+// Run executes the sync-offline-activity command.
+func Run(v *viper.Viper) {
+	queueFilepath, err := offline.QueueFilepath()
+	if err != nil {
+		log.Fatalf("failed to load offline queue filepath: %s", err)
+	}
+
+	err = SyncOfflineActivity(v, queueFilepath)
+	if err != nil {
+		var errauth api.ErrAuth
+		if errors.As(err, &errauth) {
+			log.Errorf(
+				"failed to sync offline activity: %s. Find your api key from wakatime.com/settings/api-key",
+				errauth,
+			)
+			os.Exit(exitcode.ErrAuth)
+		}
+
+		var errapi api.Err
+		if errors.As(err, &errapi) {
+			log.Errorf("failed to sync offline activity: %s", err)
+			os.Exit(exitcode.ErrAPI)
+		}
+
+		log.Fatalf("failed to sync offline activity: %s", err)
+	}
+
+	log.Debugln("successfully synced offline activity")
+	os.Exit(exitcode.Success)
+}
+
+// SyncOfflineActivity syncs offline activity by sending heartbeats
+// from the offline queue to the WakaTime API.
+func SyncOfflineActivity(v *viper.Viper, queueFilepath string) error {
+	params, err := legacyparams.Load(v)
+	if err != nil {
+		return fmt.Errorf("failed to load command parameters: %w", err)
+	}
+
+	if params.OfflineDisabled {
+		return fmt.Errorf("sync offline is disabled. cannot sync offline activity: %w", err)
+	}
+
+	offlineHandleOpt, err := offline.WithQueue(queueFilepath, params.OfflineSyncMax)
+	if err != nil {
+		return fmt.Errorf("failed to initialize offline queue handle option: %w", err)
+	}
+
+	apiClient, err := legacyapi.NewClient(params.API)
+	if err != nil {
+		return fmt.Errorf("failed to initialize api client: %w", err)
+	}
+
+	handle := heartbeat.NewHandle(apiClient, []heartbeat.HandleOption{offlineHandleOpt}...)
+
+	_, err = handle(nil)
+	if err != nil {
+		return fmt.Errorf("failed to sync offline activity via api client: %w", err)
+	}
+
+	return nil
+}

--- a/cmd/legacy/offlinesync/offlinesync_test.go
+++ b/cmd/legacy/offlinesync/offlinesync_test.go
@@ -1,0 +1,146 @@
+package offlinesync_test
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/wakatime/wakatime-cli/cmd/legacy/offlinesync"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	bolt "go.etcd.io/bbolt"
+)
+
+func TestSyncOfflineActivity(t *testing.T) {
+	testServerURL, router, tearDown := setupTestServer()
+	defer tearDown()
+
+	var (
+		plugin   = "plugin/0.0.1"
+		numCalls int
+	)
+
+	router.HandleFunc("/v1/users/current/heartbeats.bulk", func(w http.ResponseWriter, req *http.Request) {
+		numCalls++
+
+		// check request
+		assert.Equal(t, http.MethodPost, req.Method)
+		assert.Equal(t, []string{"application/json"}, req.Header["Accept"])
+		assert.Equal(t, []string{"application/json"}, req.Header["Content-Type"])
+		assert.Equal(t, []string{"Basic MDAwMDAwMDAtMDAwMC00MDAwLTgwMDAtMDAwMDAwMDAwMDAw"}, req.Header["Authorization"])
+		assert.True(t, strings.HasSuffix(req.Header["User-Agent"][0], plugin), fmt.Sprintf(
+			"%q should have suffix %q",
+			req.Header["User-Agent"][0],
+			plugin,
+		))
+
+		expectedBody, err := ioutil.ReadFile("testdata/api_heartbeats_request_template.json")
+		require.NoError(t, err)
+
+		body, err := ioutil.ReadAll(req.Body)
+		require.NoError(t, err)
+
+		assert.JSONEq(t, string(expectedBody), string(body))
+
+		// send response
+		w.WriteHeader(http.StatusCreated)
+
+		f, err := os.Open("testdata/api_heartbeats_response.json")
+		require.NoError(t, err)
+		defer f.Close()
+
+		_, err = io.Copy(w, f)
+		require.NoError(t, err)
+	})
+
+	// setup offline queue
+	f, err := ioutil.TempFile(os.TempDir(), "")
+	require.NoError(t, err)
+
+	defer os.Remove(f.Name())
+
+	db, err := bolt.Open(f.Name(), 0600, nil)
+	require.NoError(t, err)
+
+	dataGo, err := ioutil.ReadFile("testdata/heartbeat_go.json")
+	require.NoError(t, err)
+
+	dataPy, err := ioutil.ReadFile("testdata/heartbeat_py.json")
+	require.NoError(t, err)
+
+	dataJs, err := ioutil.ReadFile("testdata/heartbeat_js.json")
+	require.NoError(t, err)
+
+	insertHeartbeatRecords(t, db, "heartbeats", []heartbeatRecord{
+		{
+			ID:        "1592868367.219124-file-coding-wakatime-cli-heartbeat-/tmp/main.go-true",
+			Heartbeat: string(dataGo),
+		},
+		{
+			ID:        "1592868386.079084-file-debugging-wakatime-summary-/tmp/main.py-false",
+			Heartbeat: string(dataPy),
+		},
+		{
+			ID:        "1592868394.084354-file-building-wakatime-todaygoal-/tmp/main.js-false",
+			Heartbeat: string(dataJs),
+		},
+	})
+
+	db.Close()
+
+	v := viper.New()
+	v.Set("api-url", testServerURL)
+	v.Set("key", "00000000-0000-4000-8000-000000000000")
+	v.Set("sync-offline-activity", 100)
+	v.Set("plugin", plugin)
+
+	err = offlinesync.SyncOfflineActivity(v, f.Name())
+	require.NoError(t, err)
+
+	assert.Eventually(t, func() bool { return numCalls == 1 }, time.Second, 50*time.Millisecond)
+}
+
+func setupTestServer() (string, *http.ServeMux, func()) {
+	router := http.NewServeMux()
+	srv := httptest.NewServer(router)
+
+	return srv.URL, router, func() { srv.Close() }
+}
+
+type heartbeatRecord struct {
+	ID        string
+	Heartbeat string
+}
+
+func insertHeartbeatRecords(t *testing.T, db *bolt.DB, bucket string, hh []heartbeatRecord) {
+	for _, h := range hh {
+		insertHeartbeatRecord(t, db, bucket, h)
+	}
+}
+
+func insertHeartbeatRecord(t *testing.T, db *bolt.DB, bucket string, h heartbeatRecord) {
+	t.Helper()
+
+	err := db.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucketIfNotExists([]byte(bucket))
+		if err != nil {
+			return fmt.Errorf("failed to create bucket: %s", err)
+		}
+
+		err = b.Put([]byte(h.ID), []byte(h.Heartbeat))
+		if err != nil {
+			return fmt.Errorf("failed put hearbeat: %s", err)
+		}
+
+		return nil
+	})
+	require.NoError(t, err)
+}

--- a/cmd/legacy/offlinesync/testdata/api_heartbeats_request_template.json
+++ b/cmd/legacy/offlinesync/testdata/api_heartbeats_request_template.json
@@ -1,0 +1,47 @@
+[
+    {
+        "branch": "heartbeat",
+        "category": "coding",
+        "cursorpos": 12,
+        "dependencies": ["dep1", "dep2"],
+        "entity": "/tmp/main.go",
+        "is_write": true,
+        "language": "Go",
+        "lineno": 42,
+        "lines": 100,
+        "project": "wakatime-cli",
+        "type": "file",
+        "time": 1592868367.219124,
+        "user_agent": "wakatime/13.0.6"
+    },
+    {
+        "branch": "summary",
+        "category": "debugging",
+        "cursorpos": 13,
+        "dependencies": ["dep3", "dep4"],
+        "entity": "/tmp/main.py",
+        "is_write": false,
+        "language": "Python",
+        "lineno": 43,
+        "lines": 101,
+        "project": "wakatime",
+        "type": "file",
+        "time": 1592868386.079084,
+        "user_agent": "wakatime/13.0.7"
+    },
+    {
+        "branch": "todaygoal",
+        "category": "building",
+        "cursorpos": 14,
+        "dependencies": ["dep5", "dep6"],
+        "entity": "/tmp/main.js",
+        "is_write": false,
+        "language": "JavaScript",
+        "lineno": 44,
+        "lines": 102,
+        "project": "wakatime",
+        "type": "file",
+        "time": 1592868394.084354,
+        "user_agent": "wakatime/13.0.8"
+    }
+]

--- a/cmd/legacy/offlinesync/testdata/api_heartbeats_response.json
+++ b/cmd/legacy/offlinesync/testdata/api_heartbeats_response.json
@@ -1,0 +1,64 @@
+{
+    "responses": [
+        [
+            {
+                "data": {
+                    "branch": "todaygoal",
+                    "category": "building",
+                    "cursorpos": 14,
+                    "dependencies": ["dep5", "dep6"],
+                    "entity": "/tmp/main.js",
+                    "is_write": false,
+                    "language": "JavaScript",
+                    "lineno": 44,
+                    "lines": 102,
+                    "project": "wakatime",
+                    "type": "file",
+                    "time": 1592868394.084354,
+                    "user_agent": "wakatime/13.0.8"
+                }
+            },
+            201
+        ],
+        [
+            {
+                "data": {
+                    "branch": "todaygoal",
+                    "category": "building",
+                    "cursorpos": 14,
+                    "dependencies": ["dep5", "dep6"],
+                    "entity": "/tmp/main.js",
+                    "is_write": false,
+                    "language": "JavaScript",
+                    "lineno": 44,
+                    "lines": 102,
+                    "project": "wakatime",
+                    "type": "file",
+                    "time": 1592868394.084354,
+                    "user_agent": "wakatime/13.0.8"
+                }
+            },
+            201
+        ],
+        [
+            {
+                "data": {
+                    "branch": "todaygoal",
+                    "category": "building",
+                    "cursorpos": 14,
+                    "dependencies": ["dep5", "dep6"],
+                    "entity": "/tmp/main.js",
+                    "is_write": false,
+                    "language": "JavaScript",
+                    "lineno": 44,
+                    "lines": 102,
+                    "project": "wakatime",
+                    "type": "file",
+                    "time": 1592868394.084354,
+                    "user_agent": "wakatime/13.0.8"
+                }
+            },
+            201
+        ]
+    ]
+}

--- a/cmd/legacy/offlinesync/testdata/heartbeat_go.json
+++ b/cmd/legacy/offlinesync/testdata/heartbeat_go.json
@@ -1,0 +1,15 @@
+{
+    "branch": "heartbeat",
+    "category": "coding",
+    "cursorpos": 12,
+    "dependencies": ["dep1", "dep2"],
+    "entity": "/tmp/main.go",
+    "is_write": true,
+    "language": "Go",
+    "lineno": 42,
+    "lines": 100,
+    "project": "wakatime-cli",
+    "type": "file",
+    "time": 1592868367.219124,
+    "user_agent": "wakatime/13.0.6"
+}

--- a/cmd/legacy/offlinesync/testdata/heartbeat_js.json
+++ b/cmd/legacy/offlinesync/testdata/heartbeat_js.json
@@ -1,0 +1,15 @@
+{
+    "branch": "todaygoal",
+    "category": "building",
+    "cursorpos": 14,
+    "dependencies": ["dep5", "dep6"],
+    "entity": "/tmp/main.js",
+    "is_write": false,
+    "language": "JavaScript",
+    "lineno": 44,
+    "lines": 102,
+    "project": "wakatime",
+    "type": "file",
+    "time": 1592868394.084354,
+    "user_agent": "wakatime/13.0.8"
+}

--- a/cmd/legacy/offlinesync/testdata/heartbeat_py.json
+++ b/cmd/legacy/offlinesync/testdata/heartbeat_py.json
@@ -1,0 +1,15 @@
+{
+    "branch": "summary",
+    "category": "debugging",
+    "cursorpos": 13,
+    "dependencies": ["dep3", "dep4"],
+    "entity": "/tmp/main.py",
+    "is_write": false,
+    "language": "Python",
+    "lineno": 43,
+    "lines": 101,
+    "project": "wakatime",
+    "type": "file",
+    "time": 1592868386.079084,
+    "user_agent": "wakatime/13.0.7"
+}

--- a/cmd/legacy/run.go
+++ b/cmd/legacy/run.go
@@ -4,11 +4,13 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/wakatime/wakatime-cli/cmd/legacy/configread"
 	"github.com/wakatime/wakatime-cli/cmd/legacy/configwrite"
 	heartbeatcmd "github.com/wakatime/wakatime-cli/cmd/legacy/heartbeat"
 	"github.com/wakatime/wakatime-cli/cmd/legacy/logfile"
+	"github.com/wakatime/wakatime-cli/cmd/legacy/offlinesync"
 	"github.com/wakatime/wakatime-cli/cmd/legacy/today"
 	"github.com/wakatime/wakatime-cli/cmd/legacy/todaygoal"
 	"github.com/wakatime/wakatime-cli/pkg/config"
@@ -100,7 +102,26 @@ func Run(v *viper.Viper) {
 		todaygoal.Run(v)
 	}
 
-	log.Debugln("command: heartbeat")
+	if v.IsSet("entity") {
+		log.Debugln("command: heartbeat")
 
-	heartbeatcmd.Run(v)
+		heartbeatcmd.Run(v)
+	}
+
+	if v.IsSet("sync-offline-activity") {
+		log.Debugln("command: sync-offline-activity")
+
+		offlinesync.Run(v)
+	}
+
+	log.Fatalf("One of the following parameters has to be provided: %s", strings.Join([]string{
+		"--config-read",
+		"--config-write",
+		"--entity",
+		"--sync-offline-activity",
+		"--today",
+		"--today-goal",
+		"--useragent",
+		"--version",
+	}, ", "))
 }


### PR DESCRIPTION
This PR adds a distinct command for syncing offline activity to handle flag `--sync-offline-activity` correctly.

Should only be merged, after merge of https://github.com/wakatime/wakatime-cli/pull/414. Ready for review though.

Closes #404 