### PR TITLE
Calculate semver version in build job

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -158,9 +158,16 @@ jobs:
         with:
           go-version: "1.16"
       -
+        name: "Calculate semver tag"
+        id: semver-tag
+        uses: wakatime/semver-action@v1.3.2
+        with:
+          prerelease_id: alpha
+          main_branch_name: release
+      -
         name: Build binaries
         env:
-          VERSION: ${{ github.event.release.tag_name }}
+          VERSION: ${{ steps.semver-tag.outputs.semver_tag }}
         run: make build-all
         shell: bash
       -


### PR DESCRIPTION
Since building of binaries is triggered by `push` event now, we cannot take the version from the release event, but have to run semver action also at in build job to calculate it.

I decided to run semver a second time, as running it once and sharing data between jobs is more complicated. As jobs run on different runners, variables cannot be easily shared (https://github.community/t/sharing-a-variable-between-jobs/16967). We could write it to a file and upload/download as an artifact, but as semver action has a number of outputs, we would need to share these as well.

Closes #424 