### PR TITLE
Use workflow job outputs to preserve semver between jobs

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -143,11 +143,52 @@ jobs:
         name: "Integration tests"
         run: make test-integration
 
-  build:
-    name: Build
+  tag:
+    name: Tag
     if: ${{ github.ref == 'refs/heads/release' || github.ref == 'refs/heads/develop' }}
     runs-on: ubuntu-latest
     needs: [test, test-integration, test-windows, test-integration-windows, test-macos, test-integration-macos]
+    outputs:
+      version: ${{ steps.semver.outputs.semver_tag }}
+      prev_version: ${{ steps.semver.outputs.ancestor_tag }}
+      is_prerelease: ${{ steps.semver.outputs.is_prerelease }}
+      changelog: ${{ steps.changelog.outputs.changelog }}
+    steps:
+      -
+        name: "Calculate semver"
+        id: semver
+        uses: wakatime/semver-action@v1.3.2
+        with:
+          prerelease_id: alpha
+          main_branch_name: release
+      -
+        name: Changelog
+        uses: gandarez/changelog-action@v1.0.4
+        id: changelog
+        with:
+          current_tag: ${{ github.sha }}
+          previous_tag: ${{ steps.semver.outputs.ancestor_tag }}
+          exclude: |
+            ^Merge pull request .*
+      -
+        name: "Create tag"
+        uses: actions/github-script@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.git.createTag({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag: ${{ steps.semver.outputs.semver_tag }},
+              message: "${{ steps.changelog.outputs.changelog }}",
+              object: context.sha,
+              type: 'commit',
+            })
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    needs: tag
     steps:
       -
         name: Checkout
@@ -160,7 +201,7 @@ jobs:
       -
         name: Build binaries
         env:
-          VERSION: ${{ github.event.release.tag_name }}
+          VERSION: ${{ needs.tag.outputs.version }}
         run: make build-all
         shell: bash
       -
@@ -172,7 +213,7 @@ jobs:
 
   sign:
     name: Sign Apple binaries
-    needs: build
+    needs: [tag, build]
     runs-on: macos-latest
     steps:
       -
@@ -216,29 +257,13 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    needs: [build, sign]
+    needs: [tag, build, sign]
     steps:
       -
         name: "Checkout"
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      -
-        name: "Calculate semver tag"
-        id: semver-tag
-        uses: wakatime/semver-action@v1.3.2
-        with:
-          prerelease_id: alpha
-          main_branch_name: release
-      -
-        name: Changelog
-        uses: gandarez/changelog-action@v1.0.4
-        id: changelog
-        with:
-          current_tag: ${{ github.sha }}
-          previous_tag: ${{ steps.semver-tag.outputs.ancestor_tag }}
-          exclude: |
-            ^Merge pull request .*
       -
         name: Download artifacts
         uses: actions/download-artifact@v2
@@ -252,10 +277,10 @@ jobs:
         name: "Create release"
         uses: softprops/action-gh-release@master
         with:
-          name: ${{ steps.semver-tag.outputs.semver_tag }}
-          tag_name: ${{ steps.semver-tag.outputs.semver_tag }}
-          body: ${{ steps.changelog.outputs.changelog }}
-          prerelease: ${{ steps.semver-tag.outputs.is_prerelease }}
+          name: ${{ needs.tag.outputs.version }}
+          tag_name: ${{ needs.tag.outputs.version }}
+          body: ${{ needs.tag.outputs.changelog }}
+          prerelease: ${{ needs.tag.outputs.is_prerelease }}
           draft: false
           target_commitish: ${{ github.sha }}
           files: ./release/*
@@ -275,8 +300,8 @@ jobs:
               attachments: [{
                 color: 'good',
                 pretext: 'New <https://github.com/wakatime/wakatime-cli|wakatime-cli> version released',
-                title: `${{ steps.semver-tag.outputs.semver_tag }}`,
-                title_link: `https://github.com/wakatime/wakatime-cli/releases/tag/${{ steps.semver-tag.outputs.semver_tag }}`,
+                title: `${{ needs.tag.outputs.version }}`,
+                title_link: `https://github.com/wakatime/wakatime-cli/releases/tag/${{ needs.tag.outputs.version }}`,
                 text: `${process.env.AS_MESSAGE}`
               }]
             }

--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -1,4 +1,4 @@
-name: "Tests"
+name: Build
 
 on:
   push:
@@ -17,23 +17,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -
-        name: "Checkout"
+        name: Checkout
         uses: actions/checkout@v2
       -
         uses: actions/setup-go@v2
         with:
           go-version: ${{ env.GO_VERSION }}
       -
-        name: "Pull dependencies"
+        name: Pull dependencies
         run: make install-go-modules
       -
-        name: "Unit tests"
+        name: Unit tests
         run: make test
       -
-        name: "Linter"
+        name: Linter
         run: make lint
       -
-        name: "Send coverage"
+        name: Send coverage
         uses: shogo82148/actions-goveralls@v1
         with:
           path-to-profile: coverage.out
@@ -43,22 +43,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -
-        name: "Checkout"
+        name: Checkout
         uses: actions/checkout@v2
       -
         uses: actions/setup-go@v2
         with:
           go-version: ${{ env.GO_VERSION }}
       -
-        name: "Pull dependencies"
+        name: Pull dependencies
         run: make install-go-modules
       -
-        name: "Build binary"
+        name: Build binary
         env:
           VERSION: ${{ env.TEST_VERSION }}
         run: make build-linux-amd64
       -
-        name: "Integration tests"
+        name: Integration tests
         run: make test-integration
 
   test-windows:
@@ -66,17 +66,17 @@ jobs:
     runs-on: windows-latest
     steps:
       -
-        name: "Checkout"
+        name: Checkout
         uses: actions/checkout@v2
       -
         uses: actions/setup-go@v2
         with:
           go-version: ${{ env.GO_VERSION }}
       -
-        name: "Pull dependencies"
+        name: Pull dependencies
         run: make install-go-modules
       -
-        name: "Unit tests"
+        name: Unit tests
         run: make test
 
   test-integration-windows:
@@ -84,22 +84,22 @@ jobs:
     runs-on: windows-latest
     steps:
       -
-        name: "Checkout"
+        name: Checkout
         uses: actions/checkout@v2
       -
         uses: actions/setup-go@v2
         with:
           go-version: ${{ env.GO_VERSION }}
       -
-        name: "Pull dependencies"
+        name: Pull dependencies
         run: make install-go-modules
       -
-        name: "Build binary"
+        name: Build binary
         env:
           VERSION: ${{ env.TEST_VERSION }}
         run: make build-windows-amd64
       -
-        name: "Integration tests"
+        name: Integration tests
         run: make test-integration
 
   test-macos:
@@ -107,17 +107,17 @@ jobs:
     runs-on: macos-latest
     steps:
       -
-        name: "Checkout"
+        name: Checkout
         uses: actions/checkout@v2
       -
         uses: actions/setup-go@v2
         with:
           go-version: ${{ env.GO_VERSION }}
       -
-        name: "Pull dependencies"
+        name: Pull dependencies
         run: make install-go-modules
       -
-        name: "Unit tests"
+        name: Unit tests
         run: make test
 
   test-integration-macos:
@@ -125,22 +125,22 @@ jobs:
     runs-on: macos-latest
     steps:
       -
-        name: "Checkout"
+        name: Checkout
         uses: actions/checkout@v2
       -
         uses: actions/setup-go@v2
         with:
           go-version: ${{ env.GO_VERSION }}
       -
-        name: "Pull dependencies"
+        name: Pull dependencies
         run: make install-go-modules
       -
-        name: "Build binary"
+        name: Build binary
         env:
           VERSION: ${{ env.TEST_VERSION }}
         run: make build-darwin-amd64
       -
-        name: "Integration tests"
+        name: Integration tests
         run: make test-integration
 
   tag:
@@ -155,7 +155,7 @@ jobs:
       changelog: ${{ steps.changelog.outputs.changelog }}
     steps:
       -
-        name: "Calculate semver"
+        name: Calculate semver
         id: semver
         uses: wakatime/semver-action@v1.3.2
         with:
@@ -171,7 +171,7 @@ jobs:
           exclude: |
             ^Merge pull request .*
       -
-        name: "Create tag"
+        name: Create tag
         uses: actions/github-script@v4
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -260,7 +260,7 @@ jobs:
     needs: [tag, build, sign]
     steps:
       -
-        name: "Checkout"
+        name: Checkout
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
@@ -274,7 +274,7 @@ jobs:
         name: Prepare release assets
         run: ./bin/prepare_assets.sh
       -
-        name: "Create release"
+        name: Create release
         uses: softprops/action-gh-release@master
         with:
           name: ${{ needs.tag.outputs.version }}
@@ -287,7 +287,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       -
-        name: "Slack notification"
+        name: Slack notification
         uses: 8398a7/action-slack@v3
         if: ${{ success() }}
         with:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WakaTime CLI
 
-![Tests](https://img.shields.io/github/workflow/status/wakatime/wakatime-cli/Tests/develop?label=tests)
+![Tests](https://img.shields.io/github/workflow/status/wakatime/wakatime-cli/Build/develop?label=tests)
 [![Coverage](https://coveralls.io/repos/github/wakatime/wakatime-cli/badge.svg?branch=develop)](https://coveralls.io/github/wakatime/wakatime-cli?branch=develop)
 
 Command line interface to [WakaTime](https://wakatime.com) used by all WakaTime [text editor plugins](https://wakatime.com/editors).


### PR DESCRIPTION
Adds a new job `Tag` doing:

* calculate semver after tests pass
* calculate changelog
* create annotated tag for new version
* add version and other info to job output, so other jobs can use without re-running semver-action

Creating the tag "reserves" a version number to prevent two PRs merged around the same time from trying to use the same version.

Closes #424