### PR TITLE
Add concurrency attribute to avoid claiming the same version

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -143,11 +143,52 @@ jobs:
         name: "Integration tests"
         run: make test-integration
 
+  version:
+    name: Version
+    concurrency: tagging
+    if: ${{ github.ref == 'refs/heads/release' || github.ref == 'refs/heads/develop' }}
+    runs-on: ubuntu-latest
+    needs: [
+      test,
+      test-integration,
+      test-windows,
+      test-integration-windows,
+      test-macos,
+      test-integration-macos]
+    outputs:
+      semver_tag: ${{ steps.semver-tag.outputs.semver_tag }}
+      ancestor_tag: ${{ steps.semver-tag.outputs.ancestor_tag }}
+      is_prerelease: ${{ steps.semver-tag.outputs.is_prerelease }}
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      -
+        name: Calculate semver tag
+        id: semver-tag
+        uses: wakatime/semver-action@v1.3.2
+        with:
+          prerelease_id: alpha
+          main_branch_name: release
+      - name: Create tag
+        uses: actions/github-script@v4
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            github.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: "refs/tags/${{ steps.semver-tag.outputs.semver_tag }}",
+              sha: context.sha
+            })
+
   build:
     name: Build
     if: ${{ github.ref == 'refs/heads/release' || github.ref == 'refs/heads/develop' }}
     runs-on: ubuntu-latest
-    needs: [test, test-integration, test-windows, test-integration-windows, test-macos, test-integration-macos]
+    needs: [version]
     steps:
       -
         name: Checkout
@@ -159,20 +200,32 @@ jobs:
           go-version: "1.16"
       -
         name: Build binaries
-        env:
-          VERSION: ${{ github.event.release.tag_name }}
-        run: make build-all
         shell: bash
+        env:
+          VERSION: ${{ needs.version.outputs.semver_tag }}
+        run: make build-all
       -
         name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
           name: binaries
           path: build/
+      - 
+        name: Remove tag if failure
+        if: ${{ failure() }}
+        uses: actions/github-script@v4
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            github.git.deleteRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: "refs/tags/${{ needs.version.outputs.semver_tag }}"
+            })
 
   sign:
     name: Sign Apple binaries
-    needs: build
+    needs: [version, build]
     runs-on: macos-latest
     steps:
       -
@@ -212,11 +265,23 @@ jobs:
         with:
           name: binaries
           path: build/
+      - 
+        name: Remove tag if failure
+        if: ${{ failure() }}
+        uses: actions/github-script@v4
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            github.git.deleteRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: "refs/tags/${{ needs.version.outputs.semver_tag }}"
+            })
 
   release:
     name: Release
     runs-on: ubuntu-latest
-    needs: [build, sign]
+    needs: [version, build, sign]
     steps:
       -
         name: "Checkout"
@@ -224,19 +289,12 @@ jobs:
         with:
           fetch-depth: 0
       -
-        name: "Calculate semver tag"
-        id: semver-tag
-        uses: wakatime/semver-action@v1.3.2
-        with:
-          prerelease_id: alpha
-          main_branch_name: release
-      -
         name: Changelog
         uses: gandarez/changelog-action@v1.0.4
         id: changelog
         with:
           current_tag: ${{ github.sha }}
-          previous_tag: ${{ steps.semver-tag.outputs.ancestor_tag }}
+          previous_tag: ${{ needs.version.outputs.ancestor_tag }}
           exclude: |
             ^Merge pull request .*
       -
@@ -252,15 +310,27 @@ jobs:
         name: "Create release"
         uses: softprops/action-gh-release@master
         with:
-          name: ${{ steps.semver-tag.outputs.semver_tag }}
-          tag_name: ${{ steps.semver-tag.outputs.semver_tag }}
+          name: ${{ needs.version.outputs.semver_tag }}
+          tag_name: ${{ needs.version.outputs.semver_tag }}
           body: ${{ steps.changelog.outputs.changelog }}
-          prerelease: ${{ steps.semver-tag.outputs.is_prerelease }}
-          draft: false
+          prerelease: ${{ needs.version.outputs.is_prerelease }}
           target_commitish: ${{ github.sha }}
+          draft: false
           files: ./release/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - 
+        name: Remove tag if failure
+        if: ${{ failure() }}
+        uses: actions/github-script@v4
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            github.git.deleteRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: "refs/tags/${{ needs.version.outputs.semver_tag }}"
+            })
       -
         name: "Slack notification"
         uses: 8398a7/action-slack@v3
@@ -275,8 +345,8 @@ jobs:
               attachments: [{
                 color: 'good',
                 pretext: 'New <https://github.com/wakatime/wakatime-cli|wakatime-cli> version released',
-                title: `${{ steps.semver-tag.outputs.semver_tag }}`,
-                title_link: `https://github.com/wakatime/wakatime-cli/releases/tag/${{ steps.semver-tag.outputs.semver_tag }}`,
+                title: `${{ needs.version.outputs.semver_tag }}`,
+                title_link: `https://github.com/wakatime/wakatime-cli/releases/tag/${{ needs.version.outputs.semver_tag }}`,
                 text: `${process.env.AS_MESSAGE}`
               }]
             }


### PR DESCRIPTION
This PR suggests few changes to release pipeline.

- Adds attribute `concurrency` to avoid claiming the same version by two concurrent jobs. Docs can be found [here](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency).
- Creates a separate job (called `version`) for claiming semver tag and outputs (shares) the result to other jobs. It won't outputs changelog at this step since it's used only at `release` job.
- Makes `build`, `sign` and `release` dependant on `version`.
- Adds a fallback to delete current tag if any jobs fail.

Related to https://github.com/wakatime/wakatime-cli/pull/427
Fixes https://github.com/wakatime/wakatime-cli/issues/424