### PR TITLE
Get correct date string in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,12 @@
 BINARY_NAME?=wakatime-cli
 BUILD_DIR?="./build"
 COMMIT?=$(shell git rev-parse --short HEAD)
-DATE?=$(shell date -u '+%Y-%m-%dT%H:%M:%SZ')
+DATE?=$(shell date -u '+%Y-%m-%dT%H:%M:%S %Z')
 REPO=github.com/wakatime/wakatime-cli
 VERSION?=<local-build>
 
 # ld flags for go build
-LD_FLAGS=-s -w -X ${REPO}/pkg/version.BuildDate=${DATE} -X ${REPO}/pkg/version.Commit=${COMMIT} -X ${REPO}/pkg/version.Version=${VERSION}
+LD_FLAGS=-s -w -X '${REPO}/pkg/version.BuildDate=${DATE}' -X ${REPO}/pkg/version.Commit=${COMMIT} -X ${REPO}/pkg/version.Version=${VERSION}
 
 # basic Go commands
 GOCMD=go

--- a/main_test.go
+++ b/main_test.go
@@ -243,7 +243,7 @@ func TestVersionVerbose(t *testing.T) {
 	out := run(exec.Command(binaryPath(t), "--version", "--verbose"))
 
 	assert.Regexp(t, regexp.MustCompile(fmt.Sprintf(
-		"wakatime-cli\n  Version: v0.0.1-test\n  Commit: [0-9a-f]{7}\n  Built: [0-9-:TZ]{20}\n  OS/Arch: %s/%s\n",
+		"wakatime-cli\n  Version: v0.0.1-test\n  Commit: [0-9a-f]{7}\n  Built: [0-9-:T]{19} UTC\n  OS/Arch: %s/%s\n",
 		runtime.GOOS,
 		runtime.GOARCH,
 	)), out)


### PR DESCRIPTION
This PR fixes the date argument passed to version package. It includes the correct timezone info.

current: `2021-05-30T14:44:45Z`
with fix: `2021-05-30T14:44:45 UTC`