### PR TITLE
Separate changelog for develop and release

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,22 @@
+---
+name: 🐛 Bug report
+about: Report a bug to help us improve WakaTime CLI
+labels: kind/bug
+---
+<!--
+Thank you for sending a bug report! Here are some tips:
+
+1. Please fill out the template below to make it easier to debug your problem.
+2. If you are not sure if it is a bug or not, you can ask in the WakaTime slack.
+-->
+
+**Expected behavior (what you expected to happen)**:
+
+**Actual behavior (what actually happened)**:
+
+**Environment**:
+
+- wakatime-cli version:
+- OS/Arch:
+
+**Anything else we should know?**:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+blank_issues_enabled: false
+contact_links:
+  - name: ❓ Ask a question
+    url: https://github.com/wakatime/wakatime-cli/discussions/new?category=q-a
+    about: Ask and discuss questions with other WakaTime community members
+
+  - name: 💬 Slack channel
+    url: https://wakaslack.herokuapp.com
+    about: Please ask and answer questions here

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,21 @@
+---
+name: 🚀 Feature request
+about: Suggest an idea for WakaTime
+labels: to discuss
+---
+<!--
+ Thank you for sending a feature request!
+ Please describe what you would like to change/add and why in detail by filling out the template below.
+ -->
+
+**Is your feature request related to a problem? Please describe.**
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
+
+**Describe the solution you'd like to see**
+<!-- A clear and concise description of what would you like to happen. -->
+
+**Describe alternatives you've considered**
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
+
+**Additional context**
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/.github/PULL_REQUEST_TEMPLATE/develop.md
+++ b/.github/PULL_REQUEST_TEMPLATE/develop.md
@@ -1,0 +1,12 @@
+---
+name: Alpha version
+about: Create a Pull Request to development
+labels: develop
+---
+
+**Describe the pull request**
+<!--
+This PR fixes...
+This PR adds...
+-->
+A clear and concise description of what the bug/feature is.

--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -1,0 +1,18 @@
+---
+name: Release to production (only for maintainers)
+about: Create a Pull Request to release a stable version
+labels: release
+---
+
+**Describe the pull request**
+<!--
+This PR releases version x.x.x
+-->
+A clear and concise description of what the bug/feature is.
+
+**Changelog:**
+<!--
+In the changelog section compile as much as possible all changes involved in this PR.
+-->
+- Fix bug that...
+- Add new feature...

--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -480,7 +480,8 @@ jobs:
         with:
           fetch-depth: 0
       -
-        name: Changelog
+        if: ${{ github.ref == 'refs/heads/develop' }}
+        name: Changelog for develop
         uses: gandarez/changelog-action@v1.0.4
         id: changelog
         with:
@@ -488,6 +489,26 @@ jobs:
           previous_tag: ${{ needs.version.outputs.ancestor_tag }}
           exclude: |
             ^Merge pull request .*
+      -
+        if: ${{ github.ref == 'refs/heads/release' }}
+        name: Changelog for release (stable version)
+        uses: 8BitJonny/gh-get-current-pr@1.1.0
+        id: pr
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - 
+        if: ${{ github.ref == 'refs/heads/release' }}
+        name: Prepare changelog
+        id: changelog-pr
+        shell: bash
+        run: |
+          body="${{ fromJson(steps.pr.outputs.pr).body }}"
+          body="$(awk 'f;/Changelog:/{f=1}' <<< $body)"
+          body="${body//'%'/'%25'}"
+          body="${body//$'\n'/'%0A'}"
+          body="${body//$'\r'/'%0D'}"
+          body="## Changelog%0A$body"
+          echo "::set-output name=changelog::$body"
       -
         name: Download artifacts
         uses: actions/download-artifact@v2
@@ -503,7 +524,7 @@ jobs:
         with:
           name: ${{ needs.version.outputs.semver_tag }}
           tag_name: ${{ needs.version.outputs.semver_tag }}
-          body: ${{ steps.changelog.outputs.changelog }}
+          body: ${{ steps.changelog.outputs.changelog || steps.changelog-pr.outputs.changelog }}
           prerelease: ${{ needs.version.outputs.is_prerelease }}
           target_commitish: ${{ github.sha }}
           draft: false
@@ -538,7 +559,7 @@ jobs:
                 pretext: 'New <https://github.com/wakatime/wakatime-cli|wakatime-cli> version released',
                 title: `${{ needs.version.outputs.semver_tag }}`,
                 title_link: `https://github.com/wakatime/wakatime-cli/releases/tag/${{ needs.version.outputs.semver_tag }}`,
-                text: `${process.env.AS_MESSAGE}`
+                text: `${{ steps.changelog.outputs.changelog || steps.changelog-pr.outputs.changelog }}`
               }]
             }
         env:


### PR DESCRIPTION
This PR proposes a new cleaner way to demonstrate the changelog for `release` branch (stable). When releasing a stable version only the commit messages weren't enough to explain what actually changed. After this PR gets merged it will need to always add the changelog description when merging into release branch. For develop branch nothing has changed and the commits are still in use.

For example:
```
This PR release version 1.8.0.

Changelog:
- Add SSL feature
- Add offline command
- Fix x509 certificate error
- etc...
```

Any string after `Changelog:` will be taken and added to the Release body. It's not case insensitive at this moment.

In addition I added some templates for `issue` and `pull request`.

Closes https://github.com/wakatime/wakatime-cli/issues/418