### PR TITLE
Ensure error response parsing for 4xx and 5xx heartbeat response errors

### DIFF
--- a/pkg/api/heartbeat.go
+++ b/pkg/api/heartbeat.go
@@ -110,7 +110,7 @@ func parseHeartbeatResponse(data []json.RawMessage) (heartbeat.Result, error) {
 		return heartbeat.Result{}, fmt.Errorf("failed to parse json status: %s", err)
 	}
 
-	if result.Status == http.StatusBadRequest {
+	if result.Status >= http.StatusBadRequest {
 		resultErrors, err := parseHeartbeatResponseError(data[0])
 		if err != nil {
 			return heartbeat.Result{}, fmt.Errorf("failed to parse result errors: %s", err)

--- a/pkg/api/heartbeat_test.go
+++ b/pkg/api/heartbeat_test.go
@@ -203,8 +203,29 @@ func TestParseHeartbeatResponses(t *testing.T) {
 	})
 }
 
-func TestParseHeartbeatResponsesErr(t *testing.T) {
+func TestParseHeartbeatResponses_Error(t *testing.T) {
 	data, err := ioutil.ReadFile("testdata/api_heartbeats_response_error.json")
+	require.NoError(t, err)
+
+	results, err := api.ParseHeartbeatResponses(data)
+	require.NoError(t, err)
+
+	// asserting here the exact order of results, which is assumed to exactly match the request order
+	assert.Len(t, results, 4)
+
+	// valid responses
+	assert.Equal(t, 201, results[0].Status)
+	assert.Equal(t, 201, results[1].Status)
+
+	// error responses
+	assert.Equal(t, 429, results[2].Status)
+	assert.Equal(t, results[2].Errors, []string{"Too many heartbeats"})
+	assert.Equal(t, 429, results[3].Status)
+	assert.Equal(t, results[3].Errors, []string{"Too many heartbeats"})
+}
+
+func TestParseHeartbeatResponses_Errors(t *testing.T) {
+	data, err := ioutil.ReadFile("testdata/api_heartbeats_response_errors.json")
 	require.NoError(t, err)
 
 	results, err := api.ParseHeartbeatResponses(data)

--- a/pkg/api/testdata/api_heartbeats_response_error.json
+++ b/pkg/api/testdata/api_heartbeats_response_error.json
@@ -2,22 +2,63 @@
     "responses": [
         [
             {
-                "errors": {
-                    "lineno": [
-                        "Number must be between 1 and 2147483647."
-                    ],
-                    "time": [
-                        "This field is required."
-                    ]
+                "data": {
+                    "branch": "",
+                    "category": "coding",
+                    "created_at": "2021-05-27T22:13:33Z",
+                    "cursorpos": null,
+                    "dependencies": [],
+                    "entity": "HIDDEN.go",
+                    "id": "7b094cd9-d9cc-4fe4-8092-86f0ce8f3fb8",
+                    "is_write": true,
+                    "language": "Go",
+                    "lineno": null,
+                    "lines": null,
+                    "machine_name_id": null,
+                    "project": "wakatime-cli",
+                    "time": 1622153573,
+                    "type": "file",
+                    "user_agent_id": null,
+                    "user_id": "9c4a41c0-eb11-4cf5-84b8-d5b7f5e91bea"
                 }
             },
-            400
+            201
         ],
         [
             {
-                "error": "Can not log time before user was created."
+                "data": {
+                    "branch": "",
+                    "category": "coding",
+                    "created_at": "2021-05-27T22:13:33Z",
+                    "cursorpos": null,
+                    "dependencies": [],
+                    "entity": "HIDDEN.go",
+                    "id": "631bf0b2-3596-4d09-af5f-558f84d10cc1",
+                    "is_write": true,
+                    "language": "Go",
+                    "lineno": null,
+                    "lines": null,
+                    "machine_name_id": null,
+                    "project": "wakatime-cli",
+                    "time": 1622153573,
+                    "type": "file",
+                    "user_agent_id": null,
+                    "user_id": "9c4a41c0-eb11-4cf5-84b8-d5b7f5e91bea"
+                }
             },
-            400
+            201
+        ],
+        [
+            {
+                "error": "Too many heartbeats"
+            },
+            429
+        ],
+        [
+            {
+                "error": "Too many heartbeats"
+            },
+            429
         ]
     ]
 }

--- a/pkg/api/testdata/api_heartbeats_response_errors.json
+++ b/pkg/api/testdata/api_heartbeats_response_errors.json
@@ -1,0 +1,23 @@
+{
+    "responses": [
+        [
+            {
+                "errors": {
+                    "lineno": [
+                        "Number must be between 1 and 2147483647."
+                    ],
+                    "time": [
+                        "This field is required."
+                    ]
+                }
+            },
+            400
+        ],
+        [
+            {
+                "error": "Can not log time before user was created."
+            },
+            400
+        ]
+    ]
+}


### PR DESCRIPTION
This PR fixes parsing of heartbeat error responses. Before it was only parsing the errors on `400` response code. Error parsing will no be executed on any 4xx or 5xx code.

2 layouts are supported:

- https://github.com/wakatime/wakatime-cli/blob/bugfix/error-response-parsing/pkg/api/testdata/api_heartbeats_response_error.json
- https://github.com/wakatime/wakatime-cli/blob/bugfix/error-response-parsing/pkg/api/testdata/api_heartbeats_response_errors.json

FYI, this should fix the problems encountered in #415 , but we cannot be 100% sure, as the user cropped the log output and some important parts might be missing. 

Closes #415 
