### PR TITLE
Do not use default offline queue file in integration tests

### DIFF
--- a/cmd/legacy/heartbeat/heartbeat.go
+++ b/cmd/legacy/heartbeat/heartbeat.go
@@ -144,6 +144,10 @@ func SendHeartbeats(v *viper.Viper, queueFilepath string) error {
 	}
 
 	if !params.OfflineDisabled {
+		if params.OfflineQueueFile != "" {
+			queueFilepath = params.OfflineQueueFile
+		}
+
 		offlineHandleOpt, err := offline.WithQueue(queueFilepath, params.OfflineSyncMax)
 		if err != nil {
 			return fmt.Errorf("failed to initialize offline queue handle option: %w", err)

--- a/cmd/legacy/heartbeat/params.go
+++ b/cmd/legacy/heartbeat/params.go
@@ -43,6 +43,7 @@ type Params struct {
 	LinesInFile       *int
 	LocalFile         string
 	OfflineDisabled   bool
+	OfflineQueueFile  string
 	OfflineSyncMax    int
 	Time              float64
 	API               legacyparams.API
@@ -80,9 +81,9 @@ func (p Params) String() string {
 	return fmt.Sprintf(
 		"category: '%s', cursor position: '%s', entity: '%s', entity type: '%s',"+
 			" num extra heartbeats: %d, hostname: '%s', is write: %t, language: '%s',"+
-			" line number: '%s', lines in file: '%s', offline disabled: %t, offline sync max: %d,"+
-			" time: %.5f, api params: (%s), filter params: (%s),"+
-			" project params: (%s), sanitize params: (%s)",
+			" line number: '%s', lines in file: '%s', offline disabled: %t,"+
+			" offline queue file: '%s', offline sync max: %d, time: %.5f, api params: (%s),"+
+			" filter params: (%s), project params: (%s), sanitize params: (%s)",
 		p.Category,
 		cursorPosition,
 		p.Entity,
@@ -94,6 +95,7 @@ func (p Params) String() string {
 		lineNumber,
 		linesInFile,
 		p.OfflineDisabled,
+		p.OfflineQueueFile,
 		p.OfflineSyncMax,
 		p.Time,
 		p.API,
@@ -261,6 +263,7 @@ func LoadParams(v *viper.Viper) (Params, error) {
 		LinesInFile:       linesInFile,
 		LocalFile:         vipertools.GetString(v, "local-file"),
 		OfflineDisabled:   params.OfflineDisabled,
+		OfflineQueueFile:  params.OfflineQueueFile,
 		OfflineSyncMax:    params.OfflineSyncMax,
 		Time:              timeSecs,
 		API:               params.API,

--- a/cmd/legacy/legacyparams/params.go
+++ b/cmd/legacy/legacyparams/params.go
@@ -30,9 +30,10 @@ var (
 
 // Params contains legacy params.
 type Params struct {
-	OfflineDisabled bool
-	OfflineSyncMax  int
-	API             API
+	OfflineDisabled  bool
+	OfflineQueueFile string
+	OfflineSyncMax   int
+	API              API
 }
 
 // API contains api related parameters.
@@ -98,9 +99,10 @@ func Load(v *viper.Viper) (Params, error) {
 	}
 
 	return Params{
-		OfflineDisabled: offlineDisabled,
-		OfflineSyncMax:  offlineSyncMax,
-		API:             apiParams,
+		OfflineDisabled:  offlineDisabled,
+		OfflineQueueFile: vipertools.GetString(v, "offline-queue-file"),
+		OfflineSyncMax:   offlineSyncMax,
+		API:              apiParams,
 	}, nil
 }
 

--- a/cmd/legacy/legacyparams/params_test.go
+++ b/cmd/legacy/legacyparams/params_test.go
@@ -52,6 +52,18 @@ func TestLoad_OfflineDisabled_FromFlag(t *testing.T) {
 	assert.True(t, params.OfflineDisabled)
 }
 
+func TestLoad_OfflineQueueFile(t *testing.T) {
+	v := viper.New()
+	v.Set("key", "00000000-0000-4000-8000-000000000000")
+	v.Set("entity", "/path/to/file")
+	v.Set("offline-queue-file", "/path/to/file")
+
+	params, err := legacyparams.Load(v)
+	require.NoError(t, err)
+
+	assert.Equal(t, "/path/to/file", params.OfflineQueueFile)
+}
+
 func TestLoad_OfflineSyncMax(t *testing.T) {
 	v := viper.New()
 	v.Set("key", "00000000-0000-4000-8000-000000000000")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -141,6 +141,11 @@ func setFlags(cmd *cobra.Command, v *viper.Viper) {
 		"Disables SSL certificate verification for HTTPS requests. By default,"+
 			" SSL certificates are verified.",
 	)
+	flags.String(
+		"offline-queue-file",
+		"",
+		"(internal) Specify a offline queue file, which will be used instead of the default one.",
+	)
 	flags.String("plugin", "", "Optional text editor plugin name and version for User-Agent header.")
 	flags.String("project", "", "Override auto-detected project."+
 		" Use --alternate-project to supply a fallback project if one can't be auto-detected.")
@@ -178,7 +183,11 @@ func setFlags(cmd *cobra.Command, v *viper.Viper) {
 		"",
 		"Prints time for the given goal id Today, then exits"+
 			" Visit wakatime.com/api/v1/users/current/goals to find your goal id.")
-	flags.Bool("useragent", false, "Prints the wakatime-cli useragent, as it will be sent to the api, then exits.")
+	flags.Bool(
+		"useragent",
+		false,
+		"(internal) Prints the wakatime-cli useragent, as it will be sent to the api, then exits.",
+	)
 	flags.Bool("verbose", false, "Turns on debug messages in log file.")
 	flags.Bool("version", false, "Prints the wakatime-cli version number, then exits.")
 	flags.Bool("write", false, "When set, tells api this heartbeat was triggered from writing to a file.")
@@ -192,6 +201,7 @@ func setFlags(cmd *cobra.Command, v *viper.Viper) {
 	_ = flags.MarkHidden("logfile")
 
 	// hide internal flags
+	_ = flags.MarkHidden("offline-queue-file")
 	_ = flags.MarkHidden("useragent")
 
 	err := v.BindPFlags(flags)

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/slongfield/pyfmt v0.0.0-20180124071345-020a7cb18bca
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/jwalterweatherman v1.1.0
-	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.7.0
 	github.com/yookoala/realpath v1.0.0

--- a/main_test.go
+++ b/main_test.go
@@ -106,6 +106,11 @@ func testSendHeartbeats(t *testing.T, entity, project string) {
 
 	version.Version = testVersion
 
+	offlineQueueFile, err := ioutil.TempFile(os.TempDir(), "")
+	require.NoError(t, err)
+
+	defer os.Remove(offlineQueueFile.Name())
+
 	cmd := exec.Command(
 		binaryPath(t),
 		"--api-url", apiUrl,
@@ -113,6 +118,7 @@ func testSendHeartbeats(t *testing.T, entity, project string) {
 		"--config", "testdata/wakatime.cfg",
 		"--entity", entity,
 		"--cursorpos", "12",
+		"--offline-queue-file", offlineQueueFile.Name(),
 		"--lineno", "42",
 		"--lines-in-file", "100",
 		"--time", "1585598059",
@@ -138,7 +144,6 @@ func TestTodayGoal(t *testing.T) {
 
 		// check request
 		assert.Equal(t, http.MethodGet, req.Method)
-		t.Logf("%#v\n", req.Header)
 		assert.Equal(t, []string{"application/json"}, req.Header["Accept"])
 		assert.Equal(t, []string{"Basic MDAwMDAwMDAtMDAwMC00MDAwLTgwMDAtMDAwMDAwMDAwMDAw"}, req.Header["Authorization"])
 		assert.Equal(t, []string{heartbeat.UserAgentUnknownPlugin()}, req.Header["User-Agent"])
@@ -179,7 +184,6 @@ func TestTodaySummary(t *testing.T) {
 
 		// check request
 		assert.Equal(t, http.MethodGet, req.Method)
-		t.Logf("%#v\n", req.Header)
 		assert.Equal(t, []string{"application/json"}, req.Header["Accept"])
 		assert.Equal(t, []string{"Basic MDAwMDAwMDAtMDAwMC00MDAwLTgwMDAtMDAwMDAwMDAwMDAw"}, req.Header["Authorization"])
 		assert.Equal(t, []string{heartbeat.UserAgentUnknownPlugin()}, req.Header["User-Agent"])


### PR DESCRIPTION
This PR adds a new internal parameter `--offline-queue-file`, to prevent using the default offline queue in integration tests. Otherwise, on local runs of integration tests, heartbeats from your offline queue will be loaded.