### PR TITLE
Expand users home dir for input flags

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -34,6 +34,7 @@ no_ssl_verify = false
 ssl_certs_file =
 timeout = 30
 hostname = machinename
+log_file = 
 [projectmap]
 projects/foo = new project name
 ^/home/user/projects/bar(\d+)/ = project{0}
@@ -63,6 +64,7 @@ submodules_disabled = false
 | ssl_certs_file                 | Override the bundled CA certs file. By default, uses system ca certs. | _filepath_ |
 | timeout                        | Number of seconds to wait when sending heartbeats to api. Defaults to 60 seconds. | _integer_ |
 | hostname                       | Optional name of local machine. Defaults to local machine name read from system. | _machinename_ |
+| log_file                       | Optional log file path. Defaults to `~/.wakatime.log`. | _filepath_ |
 
 ### Project Map Section
 

--- a/cmd/legacy/heartbeat/params_test.go
+++ b/cmd/legacy/heartbeat/params_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
@@ -145,12 +146,15 @@ func TestLoadParams_Entity_EntityFlagTakesPrecedence(t *testing.T) {
 func TestLoadParams_Entity_FileFlag(t *testing.T) {
 	v := viper.New()
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
-	v.Set("file", "/path/to/file")
+	v.Set("file", "~/path/to/file")
+
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
 
 	params, err := cmd.LoadParams(v)
 	require.NoError(t, err)
 
-	assert.Equal(t, "/path/to/file", params.Entity)
+	assert.Equal(t, filepath.Join(home, "/path/to/file"), params.Entity)
 }
 
 func TestLoadParams_Entity_Unset(t *testing.T) {

--- a/cmd/legacy/legacyparams/params.go
+++ b/cmd/legacy/legacyparams/params.go
@@ -8,13 +8,14 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mitchellh/go-homedir"
 	"github.com/wakatime/wakatime-cli/pkg/api"
 	"github.com/wakatime/wakatime-cli/pkg/vipertools"
 
 	"github.com/spf13/viper"
 )
 
-const errMsgTemplate = "Invalid url %q. Must be in format" +
+const errMsgTemplate = "invalid url %q. Must be in format" +
 	"'https://user:pass@host:port' or " +
 	"'socks5://user:pass@host:port' or " +
 	"'domain\\\\user:pass.'"
@@ -133,7 +134,21 @@ func loadAPIParams(v *viper.Viper) (API, error) {
 		return API{}, fmt.Errorf(errMsgTemplate, proxyURL)
 	}
 
-	sslCertFilepath, _ := vipertools.FirstNonEmptyString(v, "ssl-certs-file", "settings.ssl_certs_file")
+	var (
+		sslCertFilepath string
+		err             error
+	)
+
+	sslCertFilepath, ok = vipertools.FirstNonEmptyString(v, "ssl-certs-file", "settings.ssl_certs_file")
+	if ok {
+		sslCertFilepath, err = homedir.Expand(sslCertFilepath)
+		if err != nil {
+			if err != nil {
+				return API{},
+					fmt.Errorf("failed expanding ssl certs file: %s", err)
+			}
+		}
+	}
 
 	var timeout time.Duration
 

--- a/cmd/legacy/legacyparams/params_test.go
+++ b/cmd/legacy/legacyparams/params_test.go
@@ -2,6 +2,8 @@ package legacyparams_test
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -420,12 +422,15 @@ func TestLoad_API_SSLCertFilepath_FlagTakesPrecedence(t *testing.T) {
 	v := viper.New()
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
-	v.Set("ssl-certs-file", "/path/to/cert.pem")
+	v.Set("ssl-certs-file", "~/path/to/cert.pem")
+
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
 
 	params, err := legacyparams.Load(v)
 	require.NoError(t, err)
 
-	assert.Equal(t, "/path/to/cert.pem", params.API.SSLCertFilepath)
+	assert.Equal(t, filepath.Join(home, "/path/to/cert.pem"), params.API.SSLCertFilepath)
 }
 
 func TestLoad_API_SSLCertFilepath_FromConfig(t *testing.T) {

--- a/cmd/legacy/logfile/logfile.go
+++ b/cmd/legacy/logfile/logfile.go
@@ -27,13 +27,13 @@ func LoadParams(v *viper.Viper) (Params, error) {
 		debug = b
 	}
 
-	logFile, _ := vipertools.FirstNonEmptyString(v, "log-file", "logfile", "settings.log_file")
+	logFile, ok := vipertools.FirstNonEmptyString(v, "log-file", "logfile", "settings.log_file")
 
-	if logFile != "" {
+	if ok {
 		p, err := homedir.Expand(logFile)
 		if err != nil {
 			return Params{},
-				ErrLogFile(fmt.Sprintf("failed expading log file: %s", err))
+				ErrLogFile(fmt.Sprintf("failed expanding log file: %s", err))
 		}
 
 		return Params{

--- a/pkg/api/option.go
+++ b/pkg/api/option.go
@@ -13,7 +13,6 @@ import (
 	"github.com/wakatime/wakatime-cli/pkg/log"
 
 	"github.com/Azure/go-ntlmssp"
-	"github.com/mitchellh/go-homedir"
 )
 
 // Option is a functional option for Client.
@@ -130,12 +129,7 @@ func WithProxy(proxyURL string) (Option, error) {
 
 // WithSSLCertFile overrides the default CA certs file to trust specified cert file.
 func WithSSLCertFile(filepath string) (Option, error) {
-	expanded, err := homedir.Expand(filepath)
-	if err != nil {
-		return nil, fmt.Errorf("failed expanding filepath %q: %s", filepath, err)
-	}
-
-	caCert, err := ioutil.ReadFile(expanded)
+	caCert, err := ioutil.ReadFile(filepath)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/filestats/filestats.go
+++ b/pkg/filestats/filestats.go
@@ -36,15 +36,15 @@ func WithDetection(c Config) heartbeat.HandleOption {
 					continue
 				}
 
-				filepath := h.Entity
-				if h.LocalFile != "" {
-					filepath = h.LocalFile
-				}
-
 				if c.LinesInFile != nil {
 					hh[n].Lines = heartbeat.Int(*c.LinesInFile)
 
 					continue
+				}
+
+				filepath := h.Entity
+				if h.LocalFile != "" {
+					filepath = h.LocalFile
 				}
 
 				fileInfo, err := os.Stat(filepath)


### PR DESCRIPTION
This PR adds a feature to expand user's home directory of all input flag that are file paths. It prevents errors if paths starts with "~".

Closes https://github.com/wakatime/wakatime-cli/issues/440