### PR TITLE
Lower default offline sync level

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,7 +16,7 @@ const (
 	defaultTimeoutSecs = 60
 	// defaultOfflineSync is the default maximum number of heartbeats from the
 	// offline queue, which will be synced upon sending heartbeats to the API.
-	defaultOfflineSync = "100"
+	defaultOfflineSync = "24"
 )
 
 // NewRootCMD creates a rootCmd, which represents the base command when called without any subcommands.


### PR DESCRIPTION
This PR lowers the default offline sync limit to 24. This way the main heartbeat, plus 24 potential offline heartbeats, will result in 25 heartbeats being sent to backend. This matches the maximum number of heartbeats, the backend will accept at once. 

Slack conversation: https://wakatime.slack.com/archives/GUWD67UE4/p1622674192009000?thread_ts=1622669089.008400&cid=GUWD67UE4