### PR TITLE
Add double quotes to changelog variable

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -495,7 +495,7 @@ jobs:
         id: changelog-develop
         shell: bash
         run: |
-          changelog=${{ steps.changelog.outputs.changelog }}
+          changelog="${{ steps.changelog.outputs.changelog }}"
           changelog="${changelog//\`/\"}"
           changelog="${changelog//'/\"}"
           echo "::set-output name=changelog::$changelog"


### PR DESCRIPTION
This PR adds missing double quotes to changelog variable during parsing.