### PR TITLE
Break single quote for replace string

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -497,7 +497,7 @@ jobs:
         run: |
           changelog="${{ steps.changelog.outputs.changelog }}"
           changelog="${changelog//\`/\"}"
-          changelog="${changelog//'/\"}"
+          changelog="${changelog//\'/\"}"
           echo "::set-output name=changelog::$changelog"
       -
         if: ${{ github.ref == 'refs/heads/release' }}


### PR DESCRIPTION
This PR adds a escape for single quotes when replacing string for changelog preparation.