### PR TITLE
Support legacy api_url param format by removing endpoint from url

### DIFF
--- a/cmd/legacy/heartbeat/heartbeat_test.go
+++ b/cmd/legacy/heartbeat/heartbeat_test.go
@@ -29,7 +29,7 @@ func TestSendHeartbeats(t *testing.T) {
 		numCalls int
 	)
 
-	router.HandleFunc("/v1/users/current/heartbeats.bulk", func(w http.ResponseWriter, req *http.Request) {
+	router.HandleFunc("/users/current/heartbeats.bulk", func(w http.ResponseWriter, req *http.Request) {
 		// check request
 		assert.Equal(t, http.MethodPost, req.Method)
 		assert.Equal(t, []string{"application/json"}, req.Header["Accept"])
@@ -107,7 +107,7 @@ func TestSendHeartbeats_WithFiltering_Exclude(t *testing.T) {
 
 	var numCalls int
 
-	router.HandleFunc("/v1/users/current/heartbeats.bulk", func(w http.ResponseWriter, req *http.Request) {
+	router.HandleFunc("/users/current/heartbeats.bulk", func(w http.ResponseWriter, req *http.Request) {
 		w.WriteHeader(500)
 
 		numCalls++
@@ -145,7 +145,7 @@ func TestSendHeartbeats_ExtraHeartbeats(t *testing.T) {
 		numCalls int
 	)
 
-	router.HandleFunc("/v1/users/current/heartbeats.bulk", func(w http.ResponseWriter, req *http.Request) {
+	router.HandleFunc("/users/current/heartbeats.bulk", func(w http.ResponseWriter, req *http.Request) {
 		// check request
 		expectedBody, err := ioutil.ReadFile("testdata/api_heartbeats_request_extra_heartbeats_template.json")
 		require.NoError(t, err)

--- a/cmd/legacy/legacyparams/params.go
+++ b/cmd/legacy/legacyparams/params.go
@@ -123,6 +123,13 @@ func loadAPIParams(v *viper.Viper) (API, error) {
 		apiURL = u
 	}
 
+	// remove endpoint from api base url to support legacy api_url param
+	apiURL = strings.TrimSuffix(apiURL, "/")
+	apiURL = strings.TrimSuffix(apiURL, ".bulk")
+	apiURL = strings.TrimSuffix(apiURL, "/users/current/heartbeats")
+	apiURL = strings.TrimSuffix(apiURL, "/heartbeats")
+	apiURL = strings.TrimSuffix(apiURL, "/heartbeat")
+
 	proxyURL, _ := vipertools.FirstNonEmptyString(v, "proxy", "settings.proxy")
 
 	rgx := proxyRegex

--- a/cmd/legacy/legacyparams/params_test.go
+++ b/cmd/legacy/legacyparams/params_test.go
@@ -156,7 +156,7 @@ func TestLoad_API_APIKey(t *testing.T) {
 			Expected: legacyparams.Params{
 				API: legacyparams.API{
 					Key: "00000000-0000-4000-8000-000000000000",
-					URL: "https://api.wakatime.com/api",
+					URL: "https://api.wakatime.com/api/v1",
 				},
 			},
 		},
@@ -166,7 +166,7 @@ func TestLoad_API_APIKey(t *testing.T) {
 			Expected: legacyparams.Params{
 				API: legacyparams.API{
 					Key: "00000000-0000-4000-8000-000000000000",
-					URL: "https://api.wakatime.com/api",
+					URL: "https://api.wakatime.com/api/v1",
 				},
 			},
 		},
@@ -175,7 +175,7 @@ func TestLoad_API_APIKey(t *testing.T) {
 			Expected: legacyparams.Params{
 				API: legacyparams.API{
 					Key: "00000000-0000-4000-8000-000000000000",
-					URL: "https://api.wakatime.com/api",
+					URL: "https://api.wakatime.com/api/v1",
 				},
 			},
 		},
@@ -255,6 +255,33 @@ func TestLoad_API_APIUrl(t *testing.T) {
 				},
 			},
 		},
+		"api url with legacy heartbeats endpoint": {
+			ViperAPIUrl: "http://localhost:8080/api/v1/heartbeats.bulk",
+			Expected: legacyparams.Params{
+				API: legacyparams.API{
+					Key: "00000000-0000-4000-8000-000000000000",
+					URL: "http://localhost:8080/api/v1",
+				},
+			},
+		},
+		"api url with trailing slash": {
+			ViperAPIUrl: "http://localhost:8080/api/",
+			Expected: legacyparams.Params{
+				API: legacyparams.API{
+					Key: "00000000-0000-4000-8000-000000000000",
+					URL: "http://localhost:8080/api",
+				},
+			},
+		},
+		"api url with wakapi style endpoint": {
+			ViperAPIUrl: "http://localhost:8080/api/heartbeat",
+			Expected: legacyparams.Params{
+				API: legacyparams.API{
+					Key: "00000000-0000-4000-8000-000000000000",
+					URL: "http://localhost:8080/api",
+				},
+			},
+		},
 	}
 
 	for name, test := range tests {
@@ -294,7 +321,7 @@ func TestLoad_API_Plugin(t *testing.T) {
 
 	assert.Equal(t, legacyparams.API{
 		Key:    "00000000-0000-4000-8000-000000000000",
-		URL:    "https://api.wakatime.com/api",
+		URL:    "https://api.wakatime.com/api/v1",
 		Plugin: "plugin/10.0.0",
 	}, params.API)
 }

--- a/cmd/legacy/offlinesync/offlinesync_test.go
+++ b/cmd/legacy/offlinesync/offlinesync_test.go
@@ -28,7 +28,7 @@ func TestSyncOfflineActivity(t *testing.T) {
 		numCalls int
 	)
 
-	router.HandleFunc("/v1/users/current/heartbeats.bulk", func(w http.ResponseWriter, req *http.Request) {
+	router.HandleFunc("/users/current/heartbeats.bulk", func(w http.ResponseWriter, req *http.Request) {
 		numCalls++
 
 		// check request

--- a/cmd/legacy/run_test.go
+++ b/cmd/legacy/run_test.go
@@ -50,7 +50,7 @@ func TestRunCmd_SendDiagnostics(t *testing.T) {
 	testServerURL, router, tearDown := setupTestServer()
 	defer tearDown()
 
-	router.HandleFunc("/v1/plugins/errors", func(w http.ResponseWriter, req *http.Request) {
+	router.HandleFunc("/plugins/errors", func(w http.ResponseWriter, req *http.Request) {
 		// check request
 		assert.Equal(t, http.MethodPost, req.Method)
 		assert.Nil(t, req.Header["Authorization"])

--- a/cmd/legacy/today/today_test.go
+++ b/cmd/legacy/today/today_test.go
@@ -29,7 +29,7 @@ func TestSummary(t *testing.T) {
 		numCalls  int
 	)
 
-	router.HandleFunc("/v1/users/current/summaries", func(w http.ResponseWriter, req *http.Request) {
+	router.HandleFunc("/users/current/summaries", func(w http.ResponseWriter, req *http.Request) {
 		numCalls++
 
 		// check request
@@ -76,7 +76,7 @@ func TestSummary_ErrApi(t *testing.T) {
 
 	var numCalls int
 
-	router.HandleFunc("/v1/users/current/summaries", func(w http.ResponseWriter, req *http.Request) {
+	router.HandleFunc("/users/current/summaries", func(w http.ResponseWriter, req *http.Request) {
 		numCalls++
 		w.WriteHeader(http.StatusInternalServerError)
 	})
@@ -94,7 +94,7 @@ func TestSummary_ErrApi(t *testing.T) {
 
 	expectedMsg := fmt.Sprintf(
 		`failed fetching summaries from api: `+
-			`invalid response status from "%s/v1/users/current/summaries". got: 500, want: 200. body: ""`,
+			`invalid response status from "%s/users/current/summaries". got: 500, want: 200. body: ""`,
 		testServerURL,
 	)
 	assert.Equal(t, expectedMsg, err.Error())
@@ -107,7 +107,7 @@ func TestSummary_ErrAuth(t *testing.T) {
 
 	var numCalls int
 
-	router.HandleFunc("/v1/users/current/summaries", func(w http.ResponseWriter, req *http.Request) {
+	router.HandleFunc("/users/current/summaries", func(w http.ResponseWriter, req *http.Request) {
 		numCalls++
 		w.WriteHeader(http.StatusUnauthorized)
 	})
@@ -125,7 +125,7 @@ func TestSummary_ErrAuth(t *testing.T) {
 
 	expectedMsg := fmt.Sprintf(
 		`failed fetching summaries from api: `+
-			`authentication failed at "%s/v1/users/current/summaries". body: ""`,
+			`authentication failed at "%s/users/current/summaries". body: ""`,
 		testServerURL,
 	)
 	assert.Equal(t, expectedMsg, err.Error())

--- a/cmd/legacy/todaygoal/todaygoal_test.go
+++ b/cmd/legacy/todaygoal/todaygoal_test.go
@@ -28,7 +28,7 @@ func TestGoal(t *testing.T) {
 	)
 
 	router.HandleFunc(
-		"/v1/users/current/goals/00000000-0000-4000-8000-000000000000", func(w http.ResponseWriter, req *http.Request) {
+		"/users/current/goals/00000000-0000-4000-8000-000000000000", func(w http.ResponseWriter, req *http.Request) {
 			numCalls++
 
 			// check request
@@ -69,7 +69,7 @@ func TestGoal_ErrApi(t *testing.T) {
 	var numCalls int
 
 	router.HandleFunc(
-		"/v1/users/current/goals/00000000-0000-4000-8000-000000000000", func(w http.ResponseWriter, req *http.Request) {
+		"/users/current/goals/00000000-0000-4000-8000-000000000000", func(w http.ResponseWriter, req *http.Request) {
 			numCalls++
 			w.WriteHeader(http.StatusInternalServerError)
 		})
@@ -88,7 +88,7 @@ func TestGoal_ErrApi(t *testing.T) {
 
 	expectedMsg := fmt.Sprintf(
 		`failed fetching todays goal from api: `+
-			`invalid response status from "%s/v1/users/current/goals/00000000-0000-4000-8000-000000000000". `+
+			`invalid response status from "%s/users/current/goals/00000000-0000-4000-8000-000000000000". `+
 			`got: 500, want: 200. body: ""`,
 		testServerURL,
 	)
@@ -103,7 +103,7 @@ func TestGoal_ErrAuth(t *testing.T) {
 	var numCalls int
 
 	router.HandleFunc(
-		"/v1/users/current/goals/00000000-0000-4000-8000-000000000000", func(w http.ResponseWriter, req *http.Request) {
+		"/users/current/goals/00000000-0000-4000-8000-000000000000", func(w http.ResponseWriter, req *http.Request) {
 			numCalls++
 			w.WriteHeader(http.StatusUnauthorized)
 		})
@@ -122,7 +122,7 @@ func TestGoal_ErrAuth(t *testing.T) {
 
 	expectedMsg := fmt.Sprintf(
 		`failed fetching todays goal from api: `+
-			`authentication failed at "%s/v1/users/current/goals/00000000-0000-4000-8000-000000000000". body: ""`,
+			`authentication failed at "%s/users/current/goals/00000000-0000-4000-8000-000000000000". body: ""`,
 		testServerURL,
 	)
 	assert.Equal(t, expectedMsg, err.Error())

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -41,8 +41,17 @@ func setFlags(cmd *cobra.Command, v *viper.Viper) {
 	flags := cmd.Flags()
 	flags.String("alternate-language", "", "Optional alternate language name. Auto-detected language takes priority.")
 	flags.String("alternate-project", "", "Optional alternate project name. Auto-detected project takes priority.")
-	flags.String("api-url", "", "Heartbeats api url. For debugging with a local server.")
-	flags.String("apiurl", "", "(deprecated) Heartbeats api url. For debugging with a local server.")
+	flags.String(
+		"api-url",
+		"",
+		"API base url used when sending heartbeats and fetching code stats. Defaults to https://api.wakatime.com/api/v1/.",
+	)
+	flags.String(
+		"apiurl",
+		"",
+		"(deprecated) API base url used when sending heartbeats and fetching code stats. Defaults to"+
+			" https://api.wakatime.com/api/v1/.",
+	)
 	flags.String(
 		"category",
 		"",

--- a/main_test.go
+++ b/main_test.go
@@ -65,7 +65,7 @@ func testSendHeartbeats(t *testing.T, entity, project string) {
 
 	var numCalls int
 
-	router.HandleFunc("/v1/users/current/heartbeats.bulk", func(w http.ResponseWriter, req *http.Request) {
+	router.HandleFunc("/users/current/heartbeats.bulk", func(w http.ResponseWriter, req *http.Request) {
 		numCalls++
 
 		// check headers
@@ -139,7 +139,7 @@ func TestTodayGoal(t *testing.T) {
 
 	var numCalls int
 
-	router.HandleFunc("/v1/users/current/goals/11111111-1111-4111-8111-111111111111", func(w http.ResponseWriter, req *http.Request) {
+	router.HandleFunc("/users/current/goals/11111111-1111-4111-8111-111111111111", func(w http.ResponseWriter, req *http.Request) {
 		numCalls++
 
 		// check request
@@ -179,7 +179,7 @@ func TestTodaySummary(t *testing.T) {
 
 	var numCalls int
 
-	router.HandleFunc("/v1/users/current/summaries", func(w http.ResponseWriter, req *http.Request) {
+	router.HandleFunc("/users/current/summaries", func(w http.ResponseWriter, req *http.Request) {
 		numCalls++
 
 		// check request

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -6,7 +6,7 @@ import (
 )
 
 // BaseURL is the base url of the wakatime api.
-const BaseURL = "https://api.wakatime.com/api"
+const BaseURL = "https://api.wakatime.com/api/v1"
 
 // Client communicates with the wakatime api.
 type Client struct {

--- a/pkg/api/diagnostic.go
+++ b/pkg/api/diagnostic.go
@@ -22,7 +22,7 @@ type diagnosticsBody struct {
 
 // SendDiagnostics sends diagnostics to the WakaTime api.
 func (c *Client) SendDiagnostics(plugin string, diagnostics ...diagnostic.Diagnostic) error {
-	url := c.baseURL + "/v1/plugins/errors"
+	url := c.baseURL + "/plugins/errors"
 
 	log.Debugf("sending diagnostic data to api at %s", url)
 

--- a/pkg/api/diagnostic_test.go
+++ b/pkg/api/diagnostic_test.go
@@ -20,7 +20,7 @@ func TestClient_SendDiagnostics(t *testing.T) {
 
 	var numCalls int
 
-	router.HandleFunc("/v1/plugins/errors", func(w http.ResponseWriter, req *http.Request) {
+	router.HandleFunc("/plugins/errors", func(w http.ResponseWriter, req *http.Request) {
 		numCalls++
 
 		// check method and headers

--- a/pkg/api/goal.go
+++ b/pkg/api/goal.go
@@ -15,7 +15,7 @@ import (
 // ErrAuth is returned upon receiving a 401 Unauthorized api response.
 // Err is returned on any other api response related error.
 func (c *Client) Goal(id string) (*goal.Goal, error) {
-	url := c.baseURL + "/v1/users/current/goals/" + id
+	url := c.baseURL + "/users/current/goals/" + id
 
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {

--- a/pkg/api/goal_test.go
+++ b/pkg/api/goal_test.go
@@ -23,7 +23,7 @@ func TestClient_Goal(t *testing.T) {
 	var numCalls int
 
 	router.HandleFunc(
-		"/v1/users/current/goals/00000000-0000-4000-8000-000000000000", func(w http.ResponseWriter, req *http.Request) {
+		"/users/current/goals/00000000-0000-4000-8000-000000000000", func(w http.ResponseWriter, req *http.Request) {
 			numCalls++
 
 			// check request
@@ -59,7 +59,7 @@ func TestClient_GoalWithTimeout(t *testing.T) {
 	defer close(called)
 
 	router.HandleFunc(
-		"/v1/users/current/goals/00000000-0000-4000-8000-000000000000", func(w http.ResponseWriter, req *http.Request) {
+		"/users/current/goals/00000000-0000-4000-8000-000000000000", func(w http.ResponseWriter, req *http.Request) {
 			<-block
 			called <- struct{}{}
 		})
@@ -88,7 +88,7 @@ func TestClient_Goal_Err(t *testing.T) {
 	var numCalls int
 
 	router.HandleFunc(
-		"/v1/users/current/goals/00000000-0000-4000-8000-000000000000", func(w http.ResponseWriter, req *http.Request) {
+		"/users/current/goals/00000000-0000-4000-8000-000000000000", func(w http.ResponseWriter, req *http.Request) {
 			numCalls++
 			w.WriteHeader(http.StatusInternalServerError)
 		})
@@ -109,7 +109,7 @@ func TestClient_Goal_ErrAuth(t *testing.T) {
 	var numCalls int
 
 	router.HandleFunc(
-		"/v1/users/current/goals/00000000-0000-4000-8000-000000000000", func(w http.ResponseWriter, req *http.Request) {
+		"/users/current/goals/00000000-0000-4000-8000-000000000000", func(w http.ResponseWriter, req *http.Request) {
 			numCalls++
 			w.WriteHeader(http.StatusUnauthorized)
 		})

--- a/pkg/api/heartbeat.go
+++ b/pkg/api/heartbeat.go
@@ -21,7 +21,7 @@ import (
 // ErrAuth is returned upon receiving a 401 Unauthorized api response.
 // Err is returned on any other api response related error.
 func (c *Client) Send(heartbeats []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
-	url := c.baseURL + "/v1/users/current/heartbeats.bulk"
+	url := c.baseURL + "/users/current/heartbeats.bulk"
 
 	log.Debugf("sending %d heartbeat(s) to api at %s", len(heartbeats), url)
 

--- a/pkg/api/heartbeat_test.go
+++ b/pkg/api/heartbeat_test.go
@@ -29,7 +29,7 @@ func TestClient_Send(t *testing.T) {
 
 			var numCalls int
 
-			router.HandleFunc("/v1/users/current/heartbeats.bulk", func(w http.ResponseWriter, req *http.Request) {
+			router.HandleFunc("/users/current/heartbeats.bulk", func(w http.ResponseWriter, req *http.Request) {
 				numCalls++
 
 				// check headers
@@ -110,7 +110,7 @@ func TestClient_Send_Err(t *testing.T) {
 
 	var numCalls int
 
-	router.HandleFunc("/v1/users/current/heartbeats.bulk", func(w http.ResponseWriter, req *http.Request) {
+	router.HandleFunc("/users/current/heartbeats.bulk", func(w http.ResponseWriter, req *http.Request) {
 		numCalls++
 		w.WriteHeader(http.StatusInternalServerError)
 	})
@@ -131,7 +131,7 @@ func TestClient_Send_ErrAuth(t *testing.T) {
 
 	var numCalls int
 
-	router.HandleFunc("/v1/users/current/heartbeats.bulk", func(w http.ResponseWriter, req *http.Request) {
+	router.HandleFunc("/users/current/heartbeats.bulk", func(w http.ResponseWriter, req *http.Request) {
 		numCalls++
 		w.WriteHeader(http.StatusUnauthorized)
 	})

--- a/pkg/api/summary.go
+++ b/pkg/api/summary.go
@@ -18,7 +18,7 @@ const dateFormat = "2006-01-02"
 // ErrAuth is returned upon receiving a 401 Unauthorized api response.
 // Err is returned on any other api response related error.
 func (c *Client) Summaries(startDate, endDate time.Time) ([]summary.Summary, error) {
-	url := c.baseURL + "/v1/users/current/summaries"
+	url := c.baseURL + "/users/current/summaries"
 
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {

--- a/pkg/api/summary_test.go
+++ b/pkg/api/summary_test.go
@@ -25,7 +25,7 @@ func TestClient_Summaries(t *testing.T) {
 
 	var numCalls int
 
-	router.HandleFunc("/v1/users/current/summaries", func(w http.ResponseWriter, req *http.Request) {
+	router.HandleFunc("/users/current/summaries", func(w http.ResponseWriter, req *http.Request) {
 		numCalls++
 
 		// check request
@@ -76,7 +76,7 @@ func TestClient_SummariesByCategory(t *testing.T) {
 
 	var numCalls int
 
-	router.HandleFunc("/v1/users/current/summaries", func(w http.ResponseWriter, req *http.Request) {
+	router.HandleFunc("/users/current/summaries", func(w http.ResponseWriter, req *http.Request) {
 		numCalls++
 
 		f, err := os.Open("testdata/api_summaries_by_category_response.json")
@@ -132,7 +132,7 @@ func TestClient_SummariesWithTimeout(t *testing.T) {
 	called := make(chan struct{})
 	defer close(called)
 
-	router.HandleFunc("/v1/users/current/summaries", func(w http.ResponseWriter, req *http.Request) {
+	router.HandleFunc("/users/current/summaries", func(w http.ResponseWriter, req *http.Request) {
 		<-block
 		called <- struct{}{}
 	})
@@ -163,7 +163,7 @@ func TestClient_Summaries_Err(t *testing.T) {
 
 	var numCalls int
 
-	router.HandleFunc("/v1/users/current/summaries", func(w http.ResponseWriter, req *http.Request) {
+	router.HandleFunc("/users/current/summaries", func(w http.ResponseWriter, req *http.Request) {
 		numCalls++
 		w.WriteHeader(http.StatusInternalServerError)
 	})
@@ -186,7 +186,7 @@ func TestClient_Summaries_ErrAuth(t *testing.T) {
 
 	var numCalls int
 
-	router.HandleFunc("/v1/users/current/summaries", func(w http.ResponseWriter, req *http.Request) {
+	router.HandleFunc("/users/current/summaries", func(w http.ResponseWriter, req *http.Request) {
 		numCalls++
 		w.WriteHeader(http.StatusUnauthorized)
 	})


### PR DESCRIPTION
Fixes #384.