### PR TITLE
Use go env var for all steps

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -221,7 +221,7 @@ jobs:
         name: Setup go
         uses: actions/setup-go@master
         with:
-          go-version: "1.16"
+          go-version: ${{ env.GO_VERSION }}
       -
         name: Build binaries
         shell: bash
@@ -258,7 +258,7 @@ jobs:
         name: Setup go
         uses: actions/setup-go@master
         with:
-          go-version: "1.16"
+          go-version: ${{ env.GO_VERSION }}
       -
         name: Build binaries
         shell: bash
@@ -295,7 +295,7 @@ jobs:
         name: Setup go
         uses: actions/setup-go@master
         with:
-          go-version: "1.16"
+          go-version: ${{ env.GO_VERSION }}
       -
         name: Build binaries
         shell: bash
@@ -332,7 +332,7 @@ jobs:
         name: Setup go
         uses: actions/setup-go@master
         with:
-          go-version: "1.16"
+          go-version: ${{ env.GO_VERSION }}
       -
         name: Build binaries
         shell: bash
@@ -369,7 +369,7 @@ jobs:
         name: Setup go
         uses: actions/setup-go@master
         with:
-          go-version: "1.16"
+          go-version: ${{ env.GO_VERSION }}
       -
         name: Build binaries
         shell: bash
@@ -406,7 +406,7 @@ jobs:
         name: Setup go
         uses: actions/setup-go@master
         with:
-          go-version: "1.16"
+          go-version: ${{ env.GO_VERSION }}
       -
         name: Build binaries
         shell: bash


### PR DESCRIPTION
This PR forces the usage of Go environment variable version in all steps.