### PR TITLE
Distinct offline sync function (send all queued preparation pt1)

### DIFF
--- a/cmd/legacy/offlinesync/offlinesync.go
+++ b/cmd/legacy/offlinesync/offlinesync.go
@@ -61,10 +61,6 @@ func SyncOfflineActivity(v *viper.Viper, queueFilepath string) error {
 		return fmt.Errorf("failed to load command parameters: %w", err)
 	}
 
-	if params.OfflineDisabled {
-		return fmt.Errorf("sync offline is disabled. cannot sync offline activity: %w", err)
-	}
-
 	apiClient, err := legacyapi.NewClient(params.API)
 	if err != nil {
 		return fmt.Errorf("failed to initialize api client: %w", err)

--- a/cmd/legacy/offlinesync/offlinesync.go
+++ b/cmd/legacy/offlinesync/offlinesync.go
@@ -66,6 +66,10 @@ func SyncOfflineActivity(v *viper.Viper, queueFilepath string) error {
 		return fmt.Errorf("failed to initialize api client: %w", err)
 	}
 
+	if params.OfflineQueueFile != "" {
+		queueFilepath = params.OfflineQueueFile
+	}
+
 	syncFn := offline.Sync(queueFilepath, params.OfflineSyncMax)
 
 	err = syncFn(apiClient.SendHeartbeats)

--- a/pkg/api/heartbeat.go
+++ b/pkg/api/heartbeat.go
@@ -13,14 +13,14 @@ import (
 	"github.com/wakatime/wakatime-cli/pkg/log"
 )
 
-// Send sends a bulk of heartbeats to the wakatime api and returns the result.
+// SendHeartbeats sends a bulk of heartbeats to the wakatime api and returns the result.
 // The API does not guarantuee the setting of the Heartbeat property of the result.
 // On certain errors, like 429/too many heartbeats, this is omitted and not set.
 //
 // ErrRequest is returned upon request failure with no received response from api.
 // ErrAuth is returned upon receiving a 401 Unauthorized api response.
 // Err is returned on any other api response related error.
-func (c *Client) Send(heartbeats []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+func (c *Client) SendHeartbeats(heartbeats []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
 	url := c.baseURL + "/users/current/heartbeats.bulk"
 
 	log.Debugf("sending %d heartbeat(s) to api at %s", len(heartbeats), url)

--- a/pkg/api/heartbeat_test.go
+++ b/pkg/api/heartbeat_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestClient_Send(t *testing.T) {
+func TestClient_SendHeartbeats(t *testing.T) {
 	tests := []int{
 		http.StatusCreated,
 		http.StatusAccepted,
@@ -56,7 +56,7 @@ func TestClient_Send(t *testing.T) {
 			})
 
 			c := api.NewClient(url)
-			results, err := c.Send(testHeartbeats())
+			results, err := c.SendHeartbeats(testHeartbeats())
 			require.NoError(t, err)
 
 			// check via assert.Equal on complete slice here, to assert exact order of results,
@@ -104,7 +104,7 @@ func TestClient_Send(t *testing.T) {
 	}
 }
 
-func TestClient_Send_Err(t *testing.T) {
+func TestClient_SendHeartbeats_Err(t *testing.T) {
 	url, router, close := setupTestServer()
 	defer close()
 
@@ -116,7 +116,7 @@ func TestClient_Send_Err(t *testing.T) {
 	})
 
 	c := api.NewClient(url)
-	_, err := c.Send(testHeartbeats())
+	_, err := c.SendHeartbeats(testHeartbeats())
 
 	var errapi api.Err
 
@@ -125,7 +125,7 @@ func TestClient_Send_Err(t *testing.T) {
 	assert.Eventually(t, func() bool { return numCalls == 1 }, time.Second, 50*time.Millisecond)
 }
 
-func TestClient_Send_ErrAuth(t *testing.T) {
+func TestClient_SendHeartbeats_ErrAuth(t *testing.T) {
 	url, router, close := setupTestServer()
 	defer close()
 
@@ -137,7 +137,7 @@ func TestClient_Send_ErrAuth(t *testing.T) {
 	})
 
 	c := api.NewClient(url)
-	_, err := c.Send(testHeartbeats())
+	_, err := c.SendHeartbeats(testHeartbeats())
 
 	var errauth api.ErrAuth
 
@@ -146,9 +146,9 @@ func TestClient_Send_ErrAuth(t *testing.T) {
 	assert.Eventually(t, func() bool { return numCalls == 1 }, time.Second, 50*time.Millisecond)
 }
 
-func TestClient_Send_ErrRequest(t *testing.T) {
+func TestClient_SendHeartbeats_ErrRequest(t *testing.T) {
 	c := api.NewClient("invalid-url")
-	_, err := c.Send(testHeartbeats())
+	_, err := c.SendHeartbeats(testHeartbeats())
 
 	var errreq api.ErrRequest
 

--- a/pkg/heartbeat/heartbeat.go
+++ b/pkg/heartbeat/heartbeat.go
@@ -136,7 +136,7 @@ type Result struct {
 
 // Sender sends heartbeats to the wakatime api.
 type Sender interface {
-	Send(hh []Heartbeat) ([]Result, error)
+	SendHeartbeats(hh []Heartbeat) ([]Result, error)
 }
 
 // Handle does processing of heartbeats.
@@ -149,7 +149,7 @@ type HandleOption func(next Handle) Handle
 // with a sender eventually sending the heartbeats.
 func NewHandle(sender Sender, opts ...HandleOption) Handle {
 	return func(hh []Heartbeat) ([]Result, error) {
-		var h Handle = sender.Send
+		var h Handle = sender.SendHeartbeats
 		for i := len(opts) - 1; i >= 0; i-- {
 			h = opts[i](h)
 		}

--- a/pkg/heartbeat/heartbeat_test.go
+++ b/pkg/heartbeat/heartbeat_test.go
@@ -173,7 +173,7 @@ func TestHeartbeat_JSON_NilFields(t *testing.T) {
 
 func TestNewHandle(t *testing.T) {
 	sender := mockSender{
-		SendFn: func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+		SendHeartbeatsFn: func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
 			assert.Equal(t, []heartbeat.Heartbeat{
 				{
 					Branch:     heartbeat.String("test"),
@@ -252,11 +252,11 @@ func TestPluginFromUserAgent(t *testing.T) {
 }
 
 type mockSender struct {
-	SendFn        func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error)
-	SendFnInvoked bool
+	SendHeartbeatsFn        func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error)
+	SendHeartbeatsFnInvoked bool
 }
 
-func (m *mockSender) Send(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
-	m.SendFnInvoked = true
-	return m.SendFn(hh)
+func (m *mockSender) SendHeartbeats(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+	m.SendHeartbeatsFnInvoked = true
+	return m.SendHeartbeatsFn(hh)
 }

--- a/pkg/offline/offline_test.go
+++ b/pkg/offline/offline_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 	"github.com/wakatime/wakatime-cli/pkg/offline"
@@ -146,13 +147,19 @@ func TestWithQueue_ApiError(t *testing.T) {
 	require.NoError(t, err)
 
 	handle := opt(func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
-		assert.Equal(t, hh, testHeartbeats())
+		assert.Equal(t, hh, []heartbeat.Heartbeat{
+			testHeartbeats()[0],
+			testHeartbeats()[1],
+		})
 
 		return []heartbeat.Result{}, errors.New("error")
 	})
 
 	// run
-	_, err = handle(testHeartbeats())
+	_, err = handle([]heartbeat.Heartbeat{
+		testHeartbeats()[0],
+		testHeartbeats()[1],
+	})
 	require.Error(t, err)
 
 	// check
@@ -207,8 +214,12 @@ func TestWithQueue_InvalidResults(t *testing.T) {
 
 		return []heartbeat.Result{
 			{
-				Status:    500,
+				Status:    201,
 				Heartbeat: testHeartbeats()[0],
+			},
+			{
+				Status:    500,
+				Heartbeat: testHeartbeats()[1],
 			},
 			{
 				Status: 429,
@@ -224,8 +235,12 @@ func TestWithQueue_InvalidResults(t *testing.T) {
 	// check
 	assert.Equal(t, []heartbeat.Result{
 		{
-			Status:    500,
+			Status:    201,
 			Heartbeat: testHeartbeats()[0],
+		},
+		{
+			Status:    500,
+			Heartbeat: testHeartbeats()[1],
 		},
 		{
 			Status: 429,
@@ -233,6 +248,7 @@ func TestWithQueue_InvalidResults(t *testing.T) {
 		},
 	}, results)
 
+	// check db
 	db, err := bolt.Open(f.Name(), 0600, nil)
 	require.NoError(t, err)
 
@@ -254,19 +270,19 @@ func TestWithQueue_InvalidResults(t *testing.T) {
 
 	db.Close()
 
-	dataGo, err := ioutil.ReadFile("testdata/heartbeat_go.json")
+	dataPy, err := ioutil.ReadFile("testdata/heartbeat_py.json")
 	require.NoError(t, err)
 
-	dataPy, err := ioutil.ReadFile("testdata/heartbeat_py.json")
+	dataJs, err := ioutil.ReadFile("testdata/heartbeat_js.json")
 	require.NoError(t, err)
 
 	assert.Len(t, stored, 2)
 
-	assert.Equal(t, "1592868367.219124-file-coding-wakatime-cli-heartbeat-/tmp/main.go-true", stored[0].ID)
-	assert.JSONEq(t, string(dataGo), stored[0].Heartbeat)
+	assert.Equal(t, "1592868386.079084-file-debugging-wakatime-summary-/tmp/main.py-false", stored[0].ID)
+	assert.JSONEq(t, string(dataPy), stored[0].Heartbeat)
 
-	assert.Equal(t, "1592868386.079084-file-debugging-wakatime-summary-/tmp/main.py-false", stored[1].ID)
-	assert.JSONEq(t, string(dataPy), stored[1].Heartbeat)
+	assert.Equal(t, "1592868394.084354-file-building-wakatime-todaygoal-/tmp/main.js-false", stored[1].ID)
+	assert.JSONEq(t, string(dataJs), stored[1].Heartbeat)
 }
 
 func TestWithQueue_HandleLeftovers(t *testing.T) {
@@ -326,9 +342,273 @@ func TestWithQueue_HandleLeftovers(t *testing.T) {
 	dataPy, err := ioutil.ReadFile("testdata/heartbeat_py.json")
 	require.NoError(t, err)
 
-	assert.Len(t, stored, 1)
+	dataJs, err := ioutil.ReadFile("testdata/heartbeat_js.json")
+	require.NoError(t, err)
+
+	require.Len(t, stored, 2)
+
 	assert.Equal(t, "1592868386.079084-file-debugging-wakatime-summary-/tmp/main.py-false", stored[0].ID)
 	assert.JSONEq(t, string(dataPy), stored[0].Heartbeat)
+
+	assert.Equal(t, "1592868394.084354-file-building-wakatime-todaygoal-/tmp/main.js-false", stored[1].ID)
+	assert.JSONEq(t, string(dataJs), stored[1].Heartbeat)
+}
+
+func TestSync(t *testing.T) {
+	// setup
+	f, err := ioutil.TempFile(os.TempDir(), "")
+	require.NoError(t, err)
+
+	defer os.RemoveAll(f.Name())
+
+	db, err := bolt.Open(f.Name(), 0600, nil)
+	require.NoError(t, err)
+
+	dataGo, err := ioutil.ReadFile("testdata/heartbeat_go.json")
+	require.NoError(t, err)
+
+	dataPy, err := ioutil.ReadFile("testdata/heartbeat_py.json")
+	require.NoError(t, err)
+
+	insertHeartbeatRecords(t, db, "heartbeats", []heartbeatRecord{
+		{
+			ID:        "1592868367.219124-file-coding-wakatime-cli-heartbeat-/tmp/main.go-true",
+			Heartbeat: string(dataGo),
+		},
+		{
+			ID:        "1592868386.079084-file-debugging-wakatime-summary-/tmp/main.py-false",
+			Heartbeat: string(dataPy),
+		},
+	})
+
+	db.Close()
+
+	syncFn := offline.Sync(f.Name(), 10)
+
+	var numCalls int
+
+	err = syncFn(func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+		numCalls++
+
+		assert.Equal(t, []heartbeat.Heartbeat{
+			testHeartbeats()[0],
+			testHeartbeats()[1],
+		}, hh)
+
+		results := []heartbeat.Result{
+			{
+				Status:    http.StatusCreated,
+				Heartbeat: testHeartbeats()[0],
+			},
+			{
+				Status:    http.StatusCreated,
+				Heartbeat: testHeartbeats()[1],
+			},
+		}
+
+		return results, nil
+	})
+	require.NoError(t, err)
+
+	// check db
+	db, err = bolt.Open(f.Name(), 0600, nil)
+	require.NoError(t, err)
+
+	var stored []heartbeatRecord
+
+	err = db.View(func(tx *bolt.Tx) error {
+		c := tx.Bucket([]byte("heartbeats")).Cursor()
+
+		for key, value := c.First(); key != nil; key, value = c.Next() {
+			stored = append(stored, heartbeatRecord{
+				ID:        string(key),
+				Heartbeat: string(value),
+			})
+		}
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	db.Close()
+
+	require.Len(t, stored, 0)
+
+	assert.Eventually(t, func() bool { return numCalls == 1 }, time.Second, 50*time.Millisecond)
+}
+
+func TestSync_APIError(t *testing.T) {
+	// setup
+	f, err := ioutil.TempFile(os.TempDir(), "")
+	require.NoError(t, err)
+
+	defer os.RemoveAll(f.Name())
+
+	db, err := bolt.Open(f.Name(), 0600, nil)
+	require.NoError(t, err)
+
+	dataGo, err := ioutil.ReadFile("testdata/heartbeat_go.json")
+	require.NoError(t, err)
+
+	dataPy, err := ioutil.ReadFile("testdata/heartbeat_py.json")
+	require.NoError(t, err)
+
+	insertHeartbeatRecords(t, db, "heartbeats", []heartbeatRecord{
+		{
+			ID:        "1592868367.219124-file-coding-wakatime-cli-heartbeat-/tmp/main.go-true",
+			Heartbeat: string(dataGo),
+		},
+		{
+			ID:        "1592868386.079084-file-debugging-wakatime-summary-/tmp/main.py-false",
+			Heartbeat: string(dataPy),
+		},
+	})
+
+	db.Close()
+
+	syncFn := offline.Sync(f.Name(), 10)
+
+	var numCalls int
+
+	err = syncFn(func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+		numCalls++
+
+		assert.Equal(t, []heartbeat.Heartbeat{
+			testHeartbeats()[0],
+			testHeartbeats()[1],
+		}, hh)
+
+		return nil, errors.New("failed")
+	})
+	require.Error(t, err)
+
+	// check db
+	db, err = bolt.Open(f.Name(), 0600, nil)
+	require.NoError(t, err)
+
+	var stored []heartbeatRecord
+
+	err = db.View(func(tx *bolt.Tx) error {
+		c := tx.Bucket([]byte("heartbeats")).Cursor()
+
+		for key, value := c.First(); key != nil; key, value = c.Next() {
+			stored = append(stored, heartbeatRecord{
+				ID:        string(key),
+				Heartbeat: string(value),
+			})
+		}
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	db.Close()
+
+	require.Len(t, stored, 2)
+
+	assert.Eventually(t, func() bool { return numCalls == 1 }, time.Second, 50*time.Millisecond)
+}
+
+func TestSync_InvalidResults(t *testing.T) {
+	// setup
+	f, err := ioutil.TempFile(os.TempDir(), "")
+	require.NoError(t, err)
+
+	defer os.RemoveAll(f.Name())
+
+	db, err := bolt.Open(f.Name(), 0600, nil)
+	require.NoError(t, err)
+
+	dataGo, err := ioutil.ReadFile("testdata/heartbeat_go.json")
+	require.NoError(t, err)
+
+	dataPy, err := ioutil.ReadFile("testdata/heartbeat_py.json")
+	require.NoError(t, err)
+
+	dataJs, err := ioutil.ReadFile("testdata/heartbeat_js.json")
+	require.NoError(t, err)
+
+	insertHeartbeatRecords(t, db, "heartbeats", []heartbeatRecord{
+		{
+			ID:        "1592868367.219124-file-coding-wakatime-cli-heartbeat-/tmp/main.go-true",
+			Heartbeat: string(dataGo),
+		},
+		{
+			ID:        "1592868386.079084-file-debugging-wakatime-summary-/tmp/main.py-false",
+			Heartbeat: string(dataPy),
+		},
+		{
+			ID:        "1592868394.084354-file-building-wakatime-todaygoal-/tmp/main.js-false",
+			Heartbeat: string(dataJs),
+		},
+	})
+
+	db.Close()
+
+	syncFn := offline.Sync(f.Name(), 10)
+
+	var numCalls int
+
+	err = syncFn(func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+		numCalls++
+
+		require.Len(t, hh, 3)
+		assert.Equal(t, []heartbeat.Heartbeat{
+			testHeartbeats()[0],
+			testHeartbeats()[1],
+			testHeartbeats()[2],
+		}, hh)
+
+		results := []heartbeat.Result{
+			{
+				Status:    201,
+				Heartbeat: testHeartbeats()[0],
+			},
+			{
+				Status:    500,
+				Heartbeat: testHeartbeats()[1],
+			},
+			{
+				Status: 429,
+				Errors: []string{"Too many heartbeats"},
+			},
+		}
+
+		return results, nil
+	})
+	require.NoError(t, err)
+
+	// check db
+	db, err = bolt.Open(f.Name(), 0600, nil)
+	require.NoError(t, err)
+
+	var stored []heartbeatRecord
+
+	err = db.View(func(tx *bolt.Tx) error {
+		c := tx.Bucket([]byte("heartbeats")).Cursor()
+
+		for key, value := c.First(); key != nil; key, value = c.Next() {
+			stored = append(stored, heartbeatRecord{
+				ID:        string(key),
+				Heartbeat: string(value),
+			})
+		}
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	db.Close()
+
+	require.Len(t, stored, 2)
+
+	assert.Equal(t, "1592868386.079084-file-debugging-wakatime-summary-/tmp/main.py-false", stored[0].ID)
+	assert.JSONEq(t, string(dataPy), stored[0].Heartbeat)
+
+	assert.Equal(t, "1592868394.084354-file-building-wakatime-todaygoal-/tmp/main.js-false", stored[1].ID)
+	assert.JSONEq(t, string(dataJs), stored[1].Heartbeat)
+
+	assert.Eventually(t, func() bool { return numCalls == 1 }, time.Second, 50*time.Millisecond)
 }
 
 func TestQueue_PopMany(t *testing.T) {
@@ -525,6 +805,21 @@ func testHeartbeats() []heartbeat.Heartbeat {
 			Project:        heartbeat.String("wakatime"),
 			Time:           1592868386.079084,
 			UserAgent:      "wakatime/13.0.7",
+		},
+		{
+			Branch:         heartbeat.String("todaygoal"),
+			Category:       heartbeat.BuildingCategory,
+			CursorPosition: heartbeat.Int(14),
+			Dependencies:   []string{"dep5", "dep6"},
+			Entity:         "/tmp/main.js",
+			EntityType:     heartbeat.FileType,
+			IsWrite:        heartbeat.Bool(false),
+			Language:       heartbeat.String("JavaScript"),
+			LineNumber:     heartbeat.Int(44),
+			Lines:          heartbeat.Int(102),
+			Project:        heartbeat.String("wakatime"),
+			Time:           1592868394.084354,
+			UserAgent:      "wakatime/13.0.8",
 		},
 	}
 }


### PR DESCRIPTION
This PR adds a distinct function `offline.Sync()` for offline activity syncing. This is a first step, to separate offline syncing from the heartbeats pipeline. It is a preparation to sync all queued heartbeats on wakatime cli execution.

- Adds helper functions `popHeartbeats` and `pushHeartbeats` to pop and push without keeping the db connection open.

Related to: https://github.com/wakatime/wakatime-cli/issues/449