### PR TITLE
Send all queued heartbeats in offline sync

### DIFF
--- a/cmd/legacy/heartbeat/heartbeat_test.go
+++ b/cmd/legacy/heartbeat/heartbeat_test.go
@@ -73,6 +73,7 @@ func TestSendHeartbeats(t *testing.T) {
 	})
 
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("api-url", testServerURL)
 	v.Set("category", "debugging")
 	v.Set("cursorpos", 42)
@@ -114,6 +115,7 @@ func TestSendHeartbeats_WithFiltering_Exclude(t *testing.T) {
 	})
 
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("api-url", testServerURL)
 	v.Set("category", "debugging")
 	v.Set("entity", "/tmp/main.go")
@@ -214,6 +216,7 @@ func TestSendHeartbeats_ExtraHeartbeats(t *testing.T) {
 	}()
 
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("api-url", testServerURL)
 	v.Set("category", "debugging")
 	v.Set("cursorpos", 42)
@@ -244,6 +247,7 @@ func TestSendHeartbeats_ExtraHeartbeats(t *testing.T) {
 
 func TestSendHeartbeats_NonExistingEntity(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("api-url", "https://example.org")
 	v.Set("entity", "nonexisting")
 	v.Set("entity-type", "file")
@@ -286,6 +290,7 @@ func TestSendHeartbeats_NonExistingExtraHeartbeatsEntity(t *testing.T) {
 	}()
 
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("api-url", "https://example.org")
 	v.Set("entity", "testdata/main.go")
 	v.Set("entity-type", "file")

--- a/cmd/legacy/heartbeat/params.go
+++ b/cmd/legacy/heartbeat/params.go
@@ -185,15 +185,13 @@ func LoadParams(v *viper.Viper) (Params, error) {
 	var entity string
 
 	entity, ok := vipertools.FirstNonEmptyString(v, "entity", "file")
-	if ok {
-		entity, err = homedir.Expand(entity)
-		if err != nil {
-			return Params{}, fmt.Errorf("failed expanding entity: %s", err)
-		}
+	if !ok {
+		return Params{}, errors.New("failed to retrieve entity")
 	}
 
-	if !ok && !v.IsSet("sync-offline-activity") {
-		return Params{}, errors.New("failed to retrieve entity")
+	entityExpanded, err := homedir.Expand(entity)
+	if err != nil {
+		return Params{}, fmt.Errorf("failed expanding entity: %s", err)
 	}
 
 	var entityType heartbeat.EntityType
@@ -262,7 +260,7 @@ func LoadParams(v *viper.Viper) (Params, error) {
 	return Params{
 		Category:          category,
 		CursorPosition:    cursorPosition,
-		Entity:            entity,
+		Entity:            entityExpanded,
 		ExtraHeartbeats:   extraHeartbeats,
 		EntityType:        entityType,
 		Hostname:          hostname,

--- a/cmd/legacy/heartbeat/params_test.go
+++ b/cmd/legacy/heartbeat/params_test.go
@@ -23,6 +23,7 @@ import (
 
 func TestLoadParams_AlternateProject(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("alternate-project", "web")
@@ -35,6 +36,7 @@ func TestLoadParams_AlternateProject(t *testing.T) {
 
 func TestLoadParams_AlternateProject_Unset(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 
@@ -61,6 +63,7 @@ func TestLoadParams_Category(t *testing.T) {
 	for name, category := range tests {
 		t.Run(name, func(t *testing.T) {
 			v := viper.New()
+			v.SetDefault("sync-offline-activity", 1000)
 			v.Set("key", "00000000-0000-4000-8000-000000000000")
 			v.Set("entity", "/path/to/file")
 			v.Set("category", name)
@@ -75,6 +78,7 @@ func TestLoadParams_Category(t *testing.T) {
 
 func TestLoadParams_Category_Default(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 
@@ -86,6 +90,7 @@ func TestLoadParams_Category_Default(t *testing.T) {
 
 func TestLoadParams_Category_Invalid(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("category", "invalid")
@@ -98,6 +103,7 @@ func TestLoadParams_Category_Invalid(t *testing.T) {
 
 func TestLoadParams_CursorPosition(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("entity", "/path/to/file")
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("cursorpos", 42)
@@ -110,6 +116,7 @@ func TestLoadParams_CursorPosition(t *testing.T) {
 
 func TestLoadParams_CursorPosition_Zero(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("entity", "/path/to/file")
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("cursorpos", 0)
@@ -122,6 +129,7 @@ func TestLoadParams_CursorPosition_Zero(t *testing.T) {
 
 func TestLoadParams_CursorPosition_Unset(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("entity", "/path/to/file")
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 
@@ -133,6 +141,7 @@ func TestLoadParams_CursorPosition_Unset(t *testing.T) {
 
 func TestLoadParams_Entity_EntityFlagTakesPrecedence(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("file", "ignored")
@@ -145,6 +154,7 @@ func TestLoadParams_Entity_EntityFlagTakesPrecedence(t *testing.T) {
 
 func TestLoadParams_Entity_FileFlag(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("file", "~/path/to/file")
 
@@ -159,6 +169,7 @@ func TestLoadParams_Entity_FileFlag(t *testing.T) {
 
 func TestLoadParams_Entity_Unset(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 
 	_, err := cmd.LoadParams(v)
@@ -177,6 +188,7 @@ func TestLoadParams_EntityType(t *testing.T) {
 	for name, entityType := range tests {
 		t.Run(name, func(t *testing.T) {
 			v := viper.New()
+			v.SetDefault("sync-offline-activity", 1000)
 			v.Set("key", "00000000-0000-4000-8000-000000000000")
 			v.Set("entity", "/path/to/file")
 			v.Set("entity-type", name)
@@ -191,6 +203,7 @@ func TestLoadParams_EntityType(t *testing.T) {
 
 func TestLoadParams_EntityType_Default(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 
@@ -202,6 +215,7 @@ func TestLoadParams_EntityType_Default(t *testing.T) {
 
 func TestLoadParams_EntityType_Invalid(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("entity-type", "invalid")
@@ -238,6 +252,7 @@ func TestLoadParams_ExtraHeartbeats(t *testing.T) {
 	}()
 
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("extra-heartbeats", true)
@@ -312,6 +327,7 @@ func TestLoadParams_ExtraHeartbeats_WithStringValues(t *testing.T) {
 	}()
 
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("extra-heartbeats", true)
@@ -356,6 +372,7 @@ func TestLoadParams_ExtraHeartbeats_WithStringValues(t *testing.T) {
 
 func TestLoadParams_Hostname_FlagTakesPrecedence(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("hostname", "my-machine")
@@ -369,6 +386,7 @@ func TestLoadParams_Hostname_FlagTakesPrecedence(t *testing.T) {
 
 func TestLoadParams_Hostname_FromConfig(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("settings.hostname", "my-machine")
@@ -381,6 +399,7 @@ func TestLoadParams_Hostname_FromConfig(t *testing.T) {
 
 func TestLoadParams_Hostname_DefaultFromSystem(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 
@@ -402,6 +421,7 @@ func TestLoadParams_IsWrite(t *testing.T) {
 	for name, isWrite := range tests {
 		t.Run(name, func(t *testing.T) {
 			v := viper.New()
+			v.SetDefault("sync-offline-activity", 1000)
 			v.Set("key", "00000000-0000-4000-8000-000000000000")
 			v.Set("entity", "/path/to/file")
 			v.Set("write", isWrite)
@@ -416,6 +436,7 @@ func TestLoadParams_IsWrite(t *testing.T) {
 
 func TestLoadParams_IsWrite_Unset(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 
@@ -427,6 +448,7 @@ func TestLoadParams_IsWrite_Unset(t *testing.T) {
 
 func TestLoadParams_Language(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("entity", "/path/to/file")
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("language", "Go")
@@ -440,6 +462,7 @@ func TestLoadParams_Language(t *testing.T) {
 
 func TestLoadParams_LanguageAlternate(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("entity", "/path/to/file")
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("alternate-language", "Go")
@@ -453,6 +476,7 @@ func TestLoadParams_LanguageAlternate(t *testing.T) {
 
 func TestLoadParams_LineNumber(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("entity", "/path/to/file")
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("lineno", 42)
@@ -465,6 +489,7 @@ func TestLoadParams_LineNumber(t *testing.T) {
 
 func TestLoadParams_LineNumber_Zero(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("entity", "/path/to/file")
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("lineno", 0)
@@ -477,6 +502,7 @@ func TestLoadParams_LineNumber_Zero(t *testing.T) {
 
 func TestLoadParams_LineNumber_Unset(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("entity", "/path/to/file")
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 
@@ -488,6 +514,7 @@ func TestLoadParams_LineNumber_Unset(t *testing.T) {
 
 func TestLoadParams_LocalFile(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("entity", "/path/to/file")
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("local-file", "/path/to/file")
@@ -500,6 +527,7 @@ func TestLoadParams_LocalFile(t *testing.T) {
 
 func TestLoadParams_Plugin(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("plugin", "plugin/10.0.0")
@@ -512,6 +540,7 @@ func TestLoadParams_Plugin(t *testing.T) {
 
 func TestLoadParams_Plugin_Unset(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 
@@ -523,6 +552,7 @@ func TestLoadParams_Plugin_Unset(t *testing.T) {
 
 func TestLoadParams_Project(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("project", "billing")
@@ -535,6 +565,7 @@ func TestLoadParams_Project(t *testing.T) {
 
 func TestLoadParams_Project_Unset(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 
@@ -578,6 +609,7 @@ func TestLoadParams_ProjectMap(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			v := viper.New()
+			v.SetDefault("sync-offline-activity", 1000)
 			v.Set("key", "00000000-0000-4000-8000-000000000000")
 			v.Set("entity", test.Entity)
 			v.Set(fmt.Sprintf("projectmap.%s", test.Regex.String()), test.Project)
@@ -592,6 +624,7 @@ func TestLoadParams_ProjectMap(t *testing.T) {
 
 func TestLoadParams_Timeout_FlagTakesPreceedence(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("timeout", 5)
@@ -605,6 +638,7 @@ func TestLoadParams_Timeout_FlagTakesPreceedence(t *testing.T) {
 
 func TestLoadParams_Timeout_FromConfig(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("entity", "/path/to/file")
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("settings.timeout", 10)
@@ -617,6 +651,7 @@ func TestLoadParams_Timeout_FromConfig(t *testing.T) {
 
 func TestLoadParams_Time(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("time", 1590609206.1)
@@ -629,6 +664,7 @@ func TestLoadParams_Time(t *testing.T) {
 
 func TestLoadParams_Time_Default(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 
@@ -642,6 +678,7 @@ func TestLoadParams_Time_Default(t *testing.T) {
 
 func TestLoadParams_Filter_Exclude(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("exclude", []string{".*", "wakatime.*"})
@@ -662,6 +699,7 @@ func TestLoadParams_Filter_Exclude(t *testing.T) {
 
 func TestLoadParams_Filter_Exclude_IgnoresInvalidRegex(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("exclude", []string{".*", "["})
@@ -682,6 +720,7 @@ func TestLoadParams_Filter_Exclude_PerlRegexPatterns(t *testing.T) {
 	for name, pattern := range tests {
 		t.Run(name, func(t *testing.T) {
 			v := viper.New()
+			v.SetDefault("sync-offline-activity", 1000)
 			v.Set("key", "00000000-0000-4000-8000-000000000000")
 			v.Set("entity", "/path/to/file")
 			v.Set("exclude", []string{pattern})
@@ -697,6 +736,7 @@ func TestLoadParams_Filter_Exclude_PerlRegexPatterns(t *testing.T) {
 
 func TestLoadParams_Filter_ExcludeUnknownProject(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("exclude-unknown-project", true)
@@ -709,6 +749,7 @@ func TestLoadParams_Filter_ExcludeUnknownProject(t *testing.T) {
 
 func TestLoadParams_Filter_ExcludeUnknownProject_FromConfig(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("exclude-unknown-project", false)
@@ -722,6 +763,7 @@ func TestLoadParams_Filter_ExcludeUnknownProject_FromConfig(t *testing.T) {
 
 func TestLoadParams_Filter_Include(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("include", []string{".*", "wakatime.*"})
@@ -739,6 +781,7 @@ func TestLoadParams_Filter_Include(t *testing.T) {
 
 func TestLoadParams_Filter_Include_IgnoresInvalidRegex(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("include", []string{".*", "["})
@@ -759,6 +802,7 @@ func TestLoadParams_Filter_Include_PerlRegexPatterns(t *testing.T) {
 	for name, pattern := range tests {
 		t.Run(name, func(t *testing.T) {
 			v := viper.New()
+			v.SetDefault("sync-offline-activity", 1000)
 			v.Set("key", "00000000-0000-4000-8000-000000000000")
 			v.Set("entity", "/path/to/file")
 			v.Set("include", []string{pattern})
@@ -774,6 +818,7 @@ func TestLoadParams_Filter_Include_PerlRegexPatterns(t *testing.T) {
 
 func TestLoadParams_Filter_IncludeOnlyWithProjectFile(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("include-only-with-project-file", true)
@@ -786,6 +831,7 @@ func TestLoadParams_Filter_IncludeOnlyWithProjectFile(t *testing.T) {
 
 func TestLoadParams_Filter_IncludeOnlyWithProjectFile_FromConfig(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("include-only-with-project-file", false)
@@ -807,6 +853,7 @@ func TestLoadParams_SanitizeParams_HideBranchNames_True(t *testing.T) {
 	for name, viperValue := range tests {
 		t.Run(name, func(t *testing.T) {
 			v := viper.New()
+			v.SetDefault("sync-offline-activity", 1000)
 			v.Set("key", "00000000-0000-4000-8000-000000000000")
 			v.Set("entity", "/path/to/file")
 			v.Set("hide-branch-names", viperValue)
@@ -831,6 +878,7 @@ func TestLoadParams_SanitizeParams_HideBranchNames_False(t *testing.T) {
 	for name, viperValue := range tests {
 		t.Run(name, func(t *testing.T) {
 			v := viper.New()
+			v.SetDefault("sync-offline-activity", 1000)
 			v.Set("key", "00000000-0000-4000-8000-000000000000")
 			v.Set("entity", "/path/to/file")
 			v.Set("hide-branch-names", viperValue)
@@ -866,6 +914,7 @@ func TestLoadParams_SanitizeParams_HideBranchNames_List(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			v := viper.New()
+			v.SetDefault("sync-offline-activity", 1000)
 			v.Set("key", "00000000-0000-4000-8000-000000000000")
 			v.Set("entity", "/path/to/file")
 			v.Set("hide-branch-names", test.ViperValue)
@@ -882,6 +931,7 @@ func TestLoadParams_SanitizeParams_HideBranchNames_List(t *testing.T) {
 
 func TestLoadParams_SanitizeParams_HideBranchNames_FlagTakesPrecedence(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("hide-branch-names", "true")
@@ -899,6 +949,7 @@ func TestLoadParams_SanitizeParams_HideBranchNames_FlagTakesPrecedence(t *testin
 
 func TestLoadParams_SanitizeParams_HideBranchNames_ConfigTakesPrecedence(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("settings.hide_branch_names", "true")
@@ -915,6 +966,7 @@ func TestLoadParams_SanitizeParams_HideBranchNames_ConfigTakesPrecedence(t *test
 
 func TestLoadParams_SanitizeParams_HideBranchNames_ConfigDeprecatedOneTakesPrecedence(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("settings.hide_branchnames", "true")
@@ -930,6 +982,7 @@ func TestLoadParams_SanitizeParams_HideBranchNames_ConfigDeprecatedOneTakesPrece
 
 func TestLoadParams_SanitizeParams_HideBranchNames_ConfigDeprecatedTwo(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("settings.hidebranchnames", "true")
@@ -944,6 +997,7 @@ func TestLoadParams_SanitizeParams_HideBranchNames_ConfigDeprecatedTwo(t *testin
 
 func TestLoadParams_SanitizeParams_HideBranchNames_InvalidRegex(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("hide-branch-names", ".*secret.*\n[0-9+")
@@ -969,6 +1023,7 @@ func TestLoadParams_SanitizeParams_HideProjectNames_True(t *testing.T) {
 	for name, viperValue := range tests {
 		t.Run(name, func(t *testing.T) {
 			v := viper.New()
+			v.SetDefault("sync-offline-activity", 1000)
 			v.Set("key", "00000000-0000-4000-8000-000000000000")
 			v.Set("entity", "/path/to/file")
 			v.Set("hide-project-names", viperValue)
@@ -993,6 +1048,7 @@ func TestLoadParams_SanitizeParams_HideProjectNames_False(t *testing.T) {
 	for name, viperValue := range tests {
 		t.Run(name, func(t *testing.T) {
 			v := viper.New()
+			v.SetDefault("sync-offline-activity", 1000)
 			v.Set("key", "00000000-0000-4000-8000-000000000000")
 			v.Set("entity", "/path/to/file")
 			v.Set("hide-project-names", viperValue)
@@ -1028,6 +1084,7 @@ func TestLoadParams_SanitizeParams_HideProjecthNames_List(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			v := viper.New()
+			v.SetDefault("sync-offline-activity", 1000)
 			v.Set("key", "00000000-0000-4000-8000-000000000000")
 			v.Set("entity", "/path/to/file")
 			v.Set("hide-project-names", test.ViperValue)
@@ -1044,6 +1101,7 @@ func TestLoadParams_SanitizeParams_HideProjecthNames_List(t *testing.T) {
 
 func TestLoadParams_SanitizeParams_HideProjectNames_FlagTakesPrecedence(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("hide-project-names", "true")
@@ -1061,6 +1119,7 @@ func TestLoadParams_SanitizeParams_HideProjectNames_FlagTakesPrecedence(t *testi
 
 func TestLoadParams_SanitizeParams_HideProjectNames_ConfigTakesPrecedence(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("settings.hide_project_names", "true")
@@ -1077,6 +1136,7 @@ func TestLoadParams_SanitizeParams_HideProjectNames_ConfigTakesPrecedence(t *tes
 
 func TestLoadParams_SanitizeParams_HideProjectNames_ConfigDeprecatedOneTakesPrecedence(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("settings.hide_projectnames", "true")
@@ -1092,6 +1152,7 @@ func TestLoadParams_SanitizeParams_HideProjectNames_ConfigDeprecatedOneTakesPrec
 
 func TestLoadParams_SanitizeParams_HideProjectNames_ConfigDeprecatedTwo(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("settings.hideprojectnames", "true")
@@ -1106,6 +1167,7 @@ func TestLoadParams_SanitizeParams_HideProjectNames_ConfigDeprecatedTwo(t *testi
 
 func TestLoadParams_SanitizeParams_HideProjectNames_InvalidRegex(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("hide-project-names", ".*secret.*\n[0-9+")
@@ -1131,6 +1193,7 @@ func TestLoadParams_SanitizeParams_HideFileNames_True(t *testing.T) {
 	for name, viperValue := range tests {
 		t.Run(name, func(t *testing.T) {
 			v := viper.New()
+			v.SetDefault("sync-offline-activity", 1000)
 			v.Set("key", "00000000-0000-4000-8000-000000000000")
 			v.Set("entity", "/path/to/file")
 			v.Set("hide-file-names", viperValue)
@@ -1155,6 +1218,7 @@ func TestLoadParams_SanitizeParams_HideFileNames_False(t *testing.T) {
 	for name, viperValue := range tests {
 		t.Run(name, func(t *testing.T) {
 			v := viper.New()
+			v.SetDefault("sync-offline-activity", 1000)
 			v.Set("key", "00000000-0000-4000-8000-000000000000")
 			v.Set("entity", "/path/to/file")
 			v.Set("hide-file-names", viperValue)
@@ -1190,6 +1254,7 @@ func TestLoadParams_SanitizeParams_HideFilehNames_List(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			v := viper.New()
+			v.SetDefault("sync-offline-activity", 1000)
 			v.Set("key", "00000000-0000-4000-8000-000000000000")
 			v.Set("entity", "/path/to/file")
 			v.Set("hide-file-names", test.ViperValue)
@@ -1206,6 +1271,7 @@ func TestLoadParams_SanitizeParams_HideFilehNames_List(t *testing.T) {
 
 func TestLoadParams_SanitizeParams_HideFileNames_FlagTakesPrecedence(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("hide-file-names", "true")
@@ -1225,6 +1291,7 @@ func TestLoadParams_SanitizeParams_HideFileNames_FlagTakesPrecedence(t *testing.
 
 func TestLoadParams_SanitizeParams_HideFileNames_FlagDeprecatedOneTakesPrecedence(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("hide-filenames", "true")
@@ -1243,6 +1310,7 @@ func TestLoadParams_SanitizeParams_HideFileNames_FlagDeprecatedOneTakesPrecedenc
 
 func TestLoadParams_SanitizeParams_HideFileNames_FlagDeprecatedTwoTakesPrecedence(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("hidefilenames", "true")
@@ -1260,6 +1328,7 @@ func TestLoadParams_SanitizeParams_HideFileNames_FlagDeprecatedTwoTakesPrecedenc
 
 func TestLoadParams_SanitizeParams_HideFileNames_ConfigTakesPrecedence(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("settings.hide_file_names", "true")
@@ -1276,6 +1345,7 @@ func TestLoadParams_SanitizeParams_HideFileNames_ConfigTakesPrecedence(t *testin
 
 func TestLoadParams_SanitizeParams_HideFileNames_ConfigDeprecatedOneTakesPrecedence(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("settings.hide_filenames", "true")
@@ -1291,6 +1361,7 @@ func TestLoadParams_SanitizeParams_HideFileNames_ConfigDeprecatedOneTakesPrecede
 
 func TestLoadParams_SanitizeParams_HideFileNames_ConfigDeprecatedTwo(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("settings.hidefilenames", "true")
@@ -1305,6 +1376,7 @@ func TestLoadParams_SanitizeParams_HideFileNames_ConfigDeprecatedTwo(t *testing.
 
 func TestLoadParams_SanitizeParams_HideFileNames_InvalidRegex(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("hide-file-names", ".*secret.*\n[0-9+")
@@ -1330,6 +1402,7 @@ func TestLoadParams_DisableSubmodule_True(t *testing.T) {
 	for name, viperValue := range tests {
 		t.Run(name, func(t *testing.T) {
 			v := viper.New()
+			v.SetDefault("sync-offline-activity", 1000)
 			v.Set("key", "00000000-0000-4000-8000-000000000000")
 			v.Set("entity", "/path/to/file")
 			v.Set("git.submodules_disabled", viperValue)
@@ -1352,6 +1425,7 @@ func TestLoadParams_DisableSubmodule_False(t *testing.T) {
 	for name, viperValue := range tests {
 		t.Run(name, func(t *testing.T) {
 			v := viper.New()
+			v.SetDefault("sync-offline-activity", 1000)
 			v.Set("key", "00000000-0000-4000-8000-000000000000")
 			v.Set("entity", "/path/to/file")
 			v.Set("git.submodules_disabled", viperValue)
@@ -1388,6 +1462,7 @@ func TestLoadParams_DisableSubmodule_List(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			multilineOption := viper.IniLoadOptions(ini.LoadOptions{AllowPythonMultilineValues: true})
 			v := viper.NewWithOptions(multilineOption)
+			v.SetDefault("sync-offline-activity", 1000)
 			v.Set("key", "00000000-0000-4000-8000-000000000000")
 			v.Set("entity", "/path/to/file")
 			v.Set("git.submodules_disabled", test.ViperValue)

--- a/cmd/legacy/legacyparams/params_test.go
+++ b/cmd/legacy/legacyparams/params_test.go
@@ -17,6 +17,7 @@ import (
 
 func TestLoad_OfflineDisabled_ConfigTakesPrecedence(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("disable-offline", false)
@@ -31,6 +32,7 @@ func TestLoad_OfflineDisabled_ConfigTakesPrecedence(t *testing.T) {
 
 func TestLoad_OfflineDisabled_FlagDeprecatedTakesPrecedence(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("disable-offline", false)
@@ -44,6 +46,7 @@ func TestLoad_OfflineDisabled_FlagDeprecatedTakesPrecedence(t *testing.T) {
 
 func TestLoad_OfflineDisabled_FromFlag(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("disable-offline", true)
@@ -56,6 +59,7 @@ func TestLoad_OfflineDisabled_FromFlag(t *testing.T) {
 
 func TestLoad_OfflineQueueFile(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("offline-queue-file", "/path/to/file")
@@ -68,10 +72,10 @@ func TestLoad_OfflineQueueFile(t *testing.T) {
 
 func TestLoad_OfflineSyncMax(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("sync-offline-activity", 42)
-	v.SetDefault("sync-offline-activity", 100)
 
 	params, err := legacyparams.Load(v)
 	require.NoError(t, err)
@@ -81,9 +85,9 @@ func TestLoad_OfflineSyncMax(t *testing.T) {
 
 func TestLoad_OfflineSyncMax_NoEntity(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("sync-offline-activity", 42)
-	v.SetDefault("sync-offline-activity", 100)
 
 	params, err := legacyparams.Load(v)
 	require.NoError(t, err)
@@ -93,10 +97,10 @@ func TestLoad_OfflineSyncMax_NoEntity(t *testing.T) {
 
 func TestLoad_OfflineSyncMax_None(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("sync-offline-activity", "none")
-	v.SetDefault("sync-offline-activity", 100)
 
 	params, err := legacyparams.Load(v)
 	require.NoError(t, err)
@@ -106,22 +110,22 @@ func TestLoad_OfflineSyncMax_None(t *testing.T) {
 
 func TestLoad_OfflineSyncMax_Default(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
-	v.SetDefault("sync-offline-activity", 100)
 
 	params, err := legacyparams.Load(v)
 	require.NoError(t, err)
 
-	assert.Equal(t, 100, params.OfflineSyncMax)
+	assert.Equal(t, 1000, params.OfflineSyncMax)
 }
 
 func TestLoad_OfflineSyncMax_NegativeNumber(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("sync-offline-activity", -1)
-	v.SetDefault("sync-offline-activity", 100)
 
 	_, err := legacyparams.Load(v)
 	require.Error(t, err)
@@ -131,10 +135,10 @@ func TestLoad_OfflineSyncMax_NegativeNumber(t *testing.T) {
 
 func TestLoad_OfflineSyncMax_NonIntegerValue(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("sync-offline-activity", "invalid")
-	v.SetDefault("sync-offline-activity", 100)
 
 	_, err := legacyparams.Load(v)
 	require.Error(t, err)
@@ -184,6 +188,7 @@ func TestLoad_API_APIKey(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			v := viper.New()
+			v.Set("sync-offline-activity", "none")
 			v.Set("key", test.ViperAPIKey)
 			v.Set("settings.api_key", test.ViperAPIKeyConfig)
 			v.Set("settings.apikey", test.ViperAPIKeyConfigOld)
@@ -207,6 +212,7 @@ func TestLoad_API_APIKeyInvalid(t *testing.T) {
 	for name, value := range tests {
 		t.Run(name, func(t *testing.T) {
 			v := viper.New()
+			v.SetDefault("sync-offline-activity", 1000)
 			v.Set("key", value)
 
 			_, err := legacyparams.Load(v)
@@ -287,6 +293,7 @@ func TestLoad_API_APIUrl(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			v := viper.New()
+			v.Set("sync-offline-activity", "none")
 			v.Set("key", "00000000-0000-4000-8000-000000000000")
 			v.Set("api-url", test.ViperAPIUrl)
 			v.Set("apiurl", test.ViperAPIUrlOld)
@@ -302,6 +309,7 @@ func TestLoad_API_APIUrl(t *testing.T) {
 
 func TestLoad_APIUrl_Default(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 
@@ -313,6 +321,7 @@ func TestLoad_APIUrl_Default(t *testing.T) {
 
 func TestLoad_API_Plugin(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("plugin", "plugin/10.0.0")
 
@@ -328,6 +337,7 @@ func TestLoad_API_Plugin(t *testing.T) {
 
 func TestLoad_API_Timeout_FlagTakesPreceedence(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("timeout", 5)
 	v.Set("settings.timeout", 10)
@@ -340,6 +350,7 @@ func TestLoad_API_Timeout_FlagTakesPreceedence(t *testing.T) {
 
 func TestLoad_API_Timeout_FromConfig(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("settings.timeout", 10)
 
@@ -351,6 +362,7 @@ func TestLoad_API_Timeout_FromConfig(t *testing.T) {
 
 func TestLoad_API_DisableSSLVerify_FlagTakesPrecedence(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("no-ssl-verify", true)
@@ -364,6 +376,7 @@ func TestLoad_API_DisableSSLVerify_FlagTakesPrecedence(t *testing.T) {
 
 func TestLoad_API_DisableSSLVerify_FromConfig(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("settings.no_ssl_verify", true)
@@ -376,6 +389,7 @@ func TestLoad_API_DisableSSLVerify_FromConfig(t *testing.T) {
 
 func TestLoad_API_DisableSSLVerify_Default(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 
@@ -396,6 +410,7 @@ func TestLoad_API_ProxyURL(t *testing.T) {
 	for name, proxyURL := range tests {
 		t.Run(name, func(t *testing.T) {
 			v := viper.New()
+			v.SetDefault("sync-offline-activity", 1000)
 			v.Set("key", "00000000-0000-4000-8000-000000000000")
 			v.Set("entity", "/path/to/file")
 			v.Set("proxy", proxyURL)
@@ -410,6 +425,7 @@ func TestLoad_API_ProxyURL(t *testing.T) {
 
 func TestLoad_API_ProxyURL_FlagTakesPrecedence(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("proxy", "https://john:secret@example.org:8888")
@@ -423,6 +439,7 @@ func TestLoad_API_ProxyURL_FlagTakesPrecedence(t *testing.T) {
 
 func TestLoad_API_ProxyURL_FromConfig(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("settings.proxy", "https://john:secret@example.org:8888")
@@ -437,6 +454,7 @@ func TestLoad_API_ProxyURL_InvalidFormat(t *testing.T) {
 	proxyURL := "ftp://john:secret@example.org:8888"
 
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("proxy", proxyURL)
@@ -447,6 +465,7 @@ func TestLoad_API_ProxyURL_InvalidFormat(t *testing.T) {
 
 func TestLoad_API_SSLCertFilepath_FlagTakesPrecedence(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("ssl-certs-file", "~/path/to/cert.pem")
@@ -462,6 +481,7 @@ func TestLoad_API_SSLCertFilepath_FlagTakesPrecedence(t *testing.T) {
 
 func TestLoad_API_SSLCertFilepath_FromConfig(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("settings.ssl_certs_file", "/path/to/cert.pem")

--- a/cmd/legacy/today/today_test.go
+++ b/cmd/legacy/today/today_test.go
@@ -59,6 +59,7 @@ func TestSummary(t *testing.T) {
 	})
 
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("api-url", testServerURL)
 	v.Set("plugin", plugin)
@@ -82,6 +83,7 @@ func TestSummary_ErrApi(t *testing.T) {
 	})
 
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("api-url", testServerURL)
 
@@ -113,6 +115,7 @@ func TestSummary_ErrAuth(t *testing.T) {
 	})
 
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("api-url", testServerURL)
 

--- a/cmd/legacy/todaygoal/todaygoal_test.go
+++ b/cmd/legacy/todaygoal/todaygoal_test.go
@@ -50,6 +50,7 @@ func TestGoal(t *testing.T) {
 		})
 
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("api-url", testServerURL)
 	v.Set("plugin", plugin)
@@ -75,6 +76,7 @@ func TestGoal_ErrApi(t *testing.T) {
 		})
 
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("api-url", testServerURL)
 	v.Set("today-goal", "00000000-0000-4000-8000-000000000000")
@@ -109,6 +111,7 @@ func TestGoal_ErrAuth(t *testing.T) {
 		})
 
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("api-url", testServerURL)
 	v.Set("today-goal", "00000000-0000-4000-8000-000000000000")
@@ -146,6 +149,7 @@ func TestGoal_ErrAuth_UnsetAPIKey(t *testing.T) {
 
 func TestLoadParams_GoalID(t *testing.T) {
 	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("today-goal", "00000000-0000-4000-8000-000000000001")
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,7 +1,10 @@
 package cmd
 
 import (
+	"strconv"
+
 	"github.com/wakatime/wakatime-cli/cmd/legacy"
+	"github.com/wakatime/wakatime-cli/pkg/offline"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -14,9 +17,6 @@ const (
 	defaultConfigSection = "settings"
 	// defaultTimeoutSecs is the default timeout used for requests to the wakatime api.
 	defaultTimeoutSecs = 60
-	// defaultOfflineSync is the default maximum number of heartbeats from the
-	// offline queue, which will be synced upon sending heartbeats to the API.
-	defaultOfflineSync = "24"
 )
 
 // NewRootCMD creates a rootCmd, which represents the base command when called without any subcommands.
@@ -173,12 +173,13 @@ func setFlags(cmd *cobra.Command, v *viper.Viper) {
 	)
 	flags.String(
 		"sync-offline-activity",
-		defaultOfflineSync,
+		strconv.Itoa(offline.SyncMaxDefault),
 		"Amount of offline activity to sync from your local ~/.wakatime.bdb bolt"+
 			" file to your WakaTime Dashboard before exiting. Can be \"none\" or"+
-			" a positive integer. Defaults to 100, meaning for every heartbeat sent"+
-			" while online, 100 offline heartbeats are synced. Can be used without"+
-			" --entity to only sync offline activity without generating new heartbeats.",
+			" a positive integer. Defaults to 1000, meaning after sending a heartbeat"+
+			" while online, all queued offline heartbeats are sent to WakaTime API, up"+
+			" to a limit of 1000. Can be used without --entity to only sync offline"+
+			" activity without generating new heartbeats.",
 	)
 	flags.Int(
 		"timeout",


### PR DESCRIPTION
This PR changes offline sync to send all queued heartbeats to the WakaTime API.

- Any API results which are not 201/202/400 will be retried.
- Send limit of `24` is used as the maximum amount of heartbeats send per request
- Overall sync limit restricts the maximum number of heartbeats that will be sent in one wakatime-cli execution. It is set to a default of 1000 and can be provided via `--sync-offline-activity` flag. 

Closes #449 