### PR TITLE
Add hostname to API request

### DIFF
--- a/cmd/legacy/heartbeat/params.go
+++ b/cmd/legacy/heartbeat/params.go
@@ -36,7 +36,6 @@ type Params struct {
 	Entity            string
 	EntityType        heartbeat.EntityType
 	ExtraHeartbeats   []heartbeat.Heartbeat
-	Hostname          string
 	IsWrite           *bool
 	Language          *string
 	LanguageAlternate string
@@ -81,7 +80,7 @@ func (p Params) String() string {
 
 	return fmt.Sprintf(
 		"category: '%s', cursor position: '%s', entity: '%s', entity type: '%s',"+
-			" num extra heartbeats: %d, hostname: '%s', is write: %t, language: '%s',"+
+			" num extra heartbeats: %d, is write: %t, language: '%s',"+
 			" line number: '%s', lines in file: '%s', offline disabled: %t,"+
 			" offline queue file: '%s', offline sync max: %d, time: %.5f, api params: (%s),"+
 			" filter params: (%s), project params: (%s), sanitize params: (%s)",
@@ -90,7 +89,6 @@ func (p Params) String() string {
 		p.Entity,
 		p.EntityType,
 		len(p.ExtraHeartbeats),
-		p.Hostname,
 		isWrite,
 		language,
 		lineNumber,
@@ -214,14 +212,6 @@ func LoadParams(v *viper.Viper) (Params, error) {
 		}
 	}
 
-	hostname, ok := vipertools.FirstNonEmptyString(v, "hostname", "settings.hostname")
-	if !ok {
-		hostname, err = os.Hostname()
-		if err != nil {
-			return Params{}, fmt.Errorf("failed to retrieve hostname from system: %s", err)
-		}
-	}
-
 	var isWrite *bool
 	if b := v.GetBool("write"); v.IsSet("write") {
 		isWrite = heartbeat.Bool(b)
@@ -263,7 +253,6 @@ func LoadParams(v *viper.Viper) (Params, error) {
 		Entity:            entityExpanded,
 		ExtraHeartbeats:   extraHeartbeats,
 		EntityType:        entityType,
-		Hostname:          hostname,
 		IsWrite:           isWrite,
 		Language:          language,
 		LanguageAlternate: vipertools.GetString(v, "alternate-language"),

--- a/cmd/legacy/heartbeat/params_test.go
+++ b/cmd/legacy/heartbeat/params_test.go
@@ -370,48 +370,6 @@ func TestLoadParams_ExtraHeartbeats_WithStringValues(t *testing.T) {
 	}, params.ExtraHeartbeats)
 }
 
-func TestLoadParams_Hostname_FlagTakesPrecedence(t *testing.T) {
-	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
-	v.Set("entity", "/path/to/file")
-	v.Set("hostname", "my-machine")
-	v.Set("settings.hostname", "ignored")
-
-	params, err := cmd.LoadParams(v)
-	require.NoError(t, err)
-
-	assert.Equal(t, "my-machine", params.Hostname)
-}
-
-func TestLoadParams_Hostname_FromConfig(t *testing.T) {
-	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
-	v.Set("entity", "/path/to/file")
-	v.Set("settings.hostname", "my-machine")
-
-	params, err := cmd.LoadParams(v)
-	require.NoError(t, err)
-
-	assert.Equal(t, "my-machine", params.Hostname)
-}
-
-func TestLoadParams_Hostname_DefaultFromSystem(t *testing.T) {
-	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
-	v.Set("entity", "/path/to/file")
-
-	params, err := cmd.LoadParams(v)
-	require.NoError(t, err)
-
-	expected, err := os.Hostname()
-	require.NoError(t, err)
-
-	assert.Equal(t, expected, params.Hostname)
-}
-
 func TestLoadParams_IsWrite(t *testing.T) {
 	tests := map[string]bool{
 		"is write":    true,

--- a/cmd/legacy/legacyapi/api.go
+++ b/cmd/legacy/legacyapi/api.go
@@ -30,6 +30,7 @@ func NewClientWithoutAuth(params legacyparams.API) (*api.Client, error) {
 // newClient contains the logic of client initialization, except auth initialization.
 func newClient(params legacyparams.API, opts ...api.Option) (*api.Client, error) {
 	opts = append(opts, api.WithTimeout(params.Timeout))
+	opts = append(opts, api.WithHostname(params.Hostname))
 
 	if params.DisableSSLVerify {
 		opts = append(opts, api.WithDisableSSLVerify())

--- a/cmd/legacy/legacyparams/params_test.go
+++ b/cmd/legacy/legacyparams/params_test.go
@@ -159,8 +159,9 @@ func TestLoad_API_APIKey(t *testing.T) {
 			ViperAPIKeyConfigOld: "20000000-0000-4000-8000-000000000000",
 			Expected: legacyparams.Params{
 				API: legacyparams.API{
-					Key: "00000000-0000-4000-8000-000000000000",
-					URL: "https://api.wakatime.com/api/v1",
+					Key:      "00000000-0000-4000-8000-000000000000",
+					URL:      "https://api.wakatime.com/api/v1",
+					Hostname: "my-computer",
 				},
 			},
 		},
@@ -169,8 +170,9 @@ func TestLoad_API_APIKey(t *testing.T) {
 			ViperAPIKeyConfigOld: "10000000-0000-4000-8000-000000000000",
 			Expected: legacyparams.Params{
 				API: legacyparams.API{
-					Key: "00000000-0000-4000-8000-000000000000",
-					URL: "https://api.wakatime.com/api/v1",
+					Key:      "00000000-0000-4000-8000-000000000000",
+					URL:      "https://api.wakatime.com/api/v1",
+					Hostname: "my-computer",
 				},
 			},
 		},
@@ -178,8 +180,9 @@ func TestLoad_API_APIKey(t *testing.T) {
 			ViperAPIKeyConfigOld: "00000000-0000-4000-8000-000000000000",
 			Expected: legacyparams.Params{
 				API: legacyparams.API{
-					Key: "00000000-0000-4000-8000-000000000000",
-					URL: "https://api.wakatime.com/api/v1",
+					Key:      "00000000-0000-4000-8000-000000000000",
+					URL:      "https://api.wakatime.com/api/v1",
+					Hostname: "my-computer",
 				},
 			},
 		},
@@ -192,6 +195,7 @@ func TestLoad_API_APIKey(t *testing.T) {
 			v.Set("key", test.ViperAPIKey)
 			v.Set("settings.api_key", test.ViperAPIKeyConfig)
 			v.Set("settings.apikey", test.ViperAPIKeyConfigOld)
+			v.Set("hostname", "my-computer")
 
 			params, err := legacyparams.Load(v)
 			require.NoError(t, err)
@@ -237,8 +241,9 @@ func TestLoad_API_APIUrl(t *testing.T) {
 			ViperAPIUrlOld:    "http://localhost:8082",
 			Expected: legacyparams.Params{
 				API: legacyparams.API{
-					Key: "00000000-0000-4000-8000-000000000000",
-					URL: "http://localhost:8080",
+					Key:      "00000000-0000-4000-8000-000000000000",
+					URL:      "http://localhost:8080",
+					Hostname: "my-computer",
 				},
 			},
 		},
@@ -247,8 +252,9 @@ func TestLoad_API_APIUrl(t *testing.T) {
 			ViperAPIUrlOld:    "http://localhost:8082",
 			Expected: legacyparams.Params{
 				API: legacyparams.API{
-					Key: "00000000-0000-4000-8000-000000000000",
-					URL: "http://localhost:8082",
+					Key:      "00000000-0000-4000-8000-000000000000",
+					URL:      "http://localhost:8082",
+					Hostname: "my-computer",
 				},
 			},
 		},
@@ -256,8 +262,9 @@ func TestLoad_API_APIUrl(t *testing.T) {
 			ViperAPIUrlConfig: "http://localhost:8081",
 			Expected: legacyparams.Params{
 				API: legacyparams.API{
-					Key: "00000000-0000-4000-8000-000000000000",
-					URL: "http://localhost:8081",
+					Key:      "00000000-0000-4000-8000-000000000000",
+					URL:      "http://localhost:8081",
+					Hostname: "my-computer",
 				},
 			},
 		},
@@ -265,8 +272,9 @@ func TestLoad_API_APIUrl(t *testing.T) {
 			ViperAPIUrl: "http://localhost:8080/api/v1/heartbeats.bulk",
 			Expected: legacyparams.Params{
 				API: legacyparams.API{
-					Key: "00000000-0000-4000-8000-000000000000",
-					URL: "http://localhost:8080/api/v1",
+					Key:      "00000000-0000-4000-8000-000000000000",
+					URL:      "http://localhost:8080/api/v1",
+					Hostname: "my-computer",
 				},
 			},
 		},
@@ -274,8 +282,9 @@ func TestLoad_API_APIUrl(t *testing.T) {
 			ViperAPIUrl: "http://localhost:8080/api/",
 			Expected: legacyparams.Params{
 				API: legacyparams.API{
-					Key: "00000000-0000-4000-8000-000000000000",
-					URL: "http://localhost:8080/api",
+					Key:      "00000000-0000-4000-8000-000000000000",
+					URL:      "http://localhost:8080/api",
+					Hostname: "my-computer",
 				},
 			},
 		},
@@ -283,8 +292,9 @@ func TestLoad_API_APIUrl(t *testing.T) {
 			ViperAPIUrl: "http://localhost:8080/api/heartbeat",
 			Expected: legacyparams.Params{
 				API: legacyparams.API{
-					Key: "00000000-0000-4000-8000-000000000000",
-					URL: "http://localhost:8080/api",
+					Key:      "00000000-0000-4000-8000-000000000000",
+					URL:      "http://localhost:8080/api",
+					Hostname: "my-computer",
 				},
 			},
 		},
@@ -298,6 +308,7 @@ func TestLoad_API_APIUrl(t *testing.T) {
 			v.Set("api-url", test.ViperAPIUrl)
 			v.Set("apiurl", test.ViperAPIUrlOld)
 			v.Set("settings.api_url", test.ViperAPIUrlConfig)
+			v.Set("hostname", "my-computer")
 
 			params, err := legacyparams.Load(v)
 			require.NoError(t, err)
@@ -324,14 +335,16 @@ func TestLoad_API_Plugin(t *testing.T) {
 	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("plugin", "plugin/10.0.0")
+	v.Set("hostname", "my-computer")
 
 	params, err := legacyparams.Load(v)
 	require.NoError(t, err)
 
 	assert.Equal(t, legacyparams.API{
-		Key:    "00000000-0000-4000-8000-000000000000",
-		URL:    "https://api.wakatime.com/api/v1",
-		Plugin: "plugin/10.0.0",
+		Key:      "00000000-0000-4000-8000-000000000000",
+		URL:      "https://api.wakatime.com/api/v1",
+		Plugin:   "plugin/10.0.0",
+		Hostname: "my-computer",
 	}, params.API)
 }
 
@@ -490,4 +503,43 @@ func TestLoad_API_SSLCertFilepath_FromConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "/path/to/cert.pem", params.API.SSLCertFilepath)
+}
+
+func TestLoadParams_Hostname_FlagTakesPrecedence(t *testing.T) {
+	v := viper.New()
+	v.Set("key", "00000000-0000-4000-8000-000000000000")
+	v.Set("entity", "/path/to/file")
+	v.Set("hostname", "my-machine")
+	v.Set("settings.hostname", "ignored")
+
+	params, err := legacyparams.Load(v)
+	require.NoError(t, err)
+
+	assert.Equal(t, "my-machine", params.API.Hostname)
+}
+
+func TestLoadParams_Hostname_FromConfig(t *testing.T) {
+	v := viper.New()
+	v.Set("key", "00000000-0000-4000-8000-000000000000")
+	v.Set("entity", "/path/to/file")
+	v.Set("settings.hostname", "my-machine")
+
+	params, err := legacyparams.Load(v)
+	require.NoError(t, err)
+
+	assert.Equal(t, "my-machine", params.API.Hostname)
+}
+
+func TestLoadParams_Hostname_DefaultFromSystem(t *testing.T) {
+	v := viper.New()
+	v.Set("key", "00000000-0000-4000-8000-000000000000")
+	v.Set("entity", "/path/to/file")
+
+	params, err := legacyparams.Load(v)
+	require.NoError(t, err)
+
+	expected, err := os.Hostname()
+	require.NoError(t, err)
+
+	assert.Equal(t, expected, params.API.Hostname)
 }

--- a/pkg/api/diagnostic.go
+++ b/pkg/api/diagnostic.go
@@ -39,7 +39,7 @@ func (c *Client) SendDiagnostics(plugin string, diagnostics ...diagnostic.Diagno
 		case diagnostic.TypeStack:
 			body.Stack = d.Value
 		default:
-			return fmt.Errorf("Unknown diagnostic type %d", d.Type)
+			return fmt.Errorf("unknown diagnostic type %d", d.Type)
 		}
 	}
 


### PR DESCRIPTION
This PR adds hostname to current API request. Reference from legacy code [here](https://github.com/wakatime/wakatime/blob/master/wakatime/api.py#L75).

Closes #459 