### PR TITLE
Release v1.18.1

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -528,7 +528,7 @@ jobs:
         name: Prepare changelog
         id: changelog
         run: |
-          changelog="${{ steps.changelog-develop.outputs.changelog || fromJson(steps.changelog-release.outputs.changelog).body }}"
+          changelog="${{ steps.changelog-develop.outputs.changelog || fromJson(steps.changelog-release.outputs.pr).body }}"
           ./bin/prepare_changelog.sh $(echo ${GITHUB_REF#refs/heads/}) "$changelog"
       -
         name: Download artifacts


### PR DESCRIPTION
Changelog:
- Ensure that file entity exists in heartbeat command (bugfix #422)
- Prevent using DefaultTransport (bugfix #409)
- Show help contents when no command line arguments given (bugfix #434)
- Get correct date string in makefile (bugfix #430)
- Ensure error response parsing for 4xx and 5xx heartbeat response errors (bugfix #438)
- Lower default offline sync level to match backend maximum (bugfix #444)
- Expand users home dir for input flags (bugfix #441)
- Log warning on system cert pool error (bugfix #469)
- Add distinct sync-offline-activity command (feature #421)
- Add parameter --offline-queue-file (feature #439)
- Send diagnostics on wakatime-cli command failure (feature #436)
- Support legacy api_url param format by removing endpoint from url (feature #451)
- Add hostname to API request (feature #461)
- New --offline-count argument (feature #465)