### PR TITLE
Read INI config file before setting up logging

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   GO_VERSION: "1.16"
-  TEST_VERSION: "v0.0.1-test"
+  TEST_VERSION: "<local-build>"
 
 jobs:
   test:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,6 +19,10 @@ linters:
     - unparam
     - whitespace
     - wsl
+linters-settings:
+  gosec:
+    excludes:
+      - G204
 issues:
   include:
     - EXC0002

--- a/cmd/legacy/logfile/logfile.go
+++ b/cmd/legacy/logfile/logfile.go
@@ -28,7 +28,6 @@ func LoadParams(v *viper.Viper) (Params, error) {
 	}
 
 	logFile, ok := vipertools.FirstNonEmptyString(v, "log-file", "logfile", "settings.log_file")
-
 	if ok {
 		p, err := homedir.Expand(logFile)
 		if err != nil {

--- a/cmd/legacy/run.go
+++ b/cmd/legacy/run.go
@@ -32,6 +32,12 @@ import (
 
 // Run executes legacy commands following the interface of the old python implementation of the WakaTime script.
 func Run(cmd *cobra.Command, v *viper.Viper) {
+	if err := config.ReadInConfig(v, config.FilePath); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to load configuration file: %s", err)
+
+		os.Exit(exitcode.ErrConfigFileParse)
+	}
+
 	SetupLogging(v)
 
 	if v.GetBool("useragent") {
@@ -52,12 +58,6 @@ func Run(cmd *cobra.Command, v *viper.Viper) {
 		log.Debugln("command: version")
 
 		RunCmd(v, runVersion)
-	}
-
-	if err := config.ReadInConfig(v, config.FilePath); err != nil {
-		log.Errorf("failed to load configuration file: %s", err)
-
-		os.Exit(exitcode.ErrConfigFileParse)
 	}
 
 	if v.IsSet("config-read") {
@@ -123,6 +123,7 @@ func Run(cmd *cobra.Command, v *viper.Viper) {
 func SetupLogging(v *viper.Viper) {
 	logfileParams, err := logfile.LoadParams(v)
 	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to load log params: %s", err)
 		log.Fatalf("failed to load log params: %s", err)
 	}
 
@@ -133,6 +134,7 @@ func SetupLogging(v *viper.Viper) {
 
 		logFile, err = os.OpenFile(logfileParams.File, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0666)
 		if err != nil {
+			fmt.Fprintf(os.Stderr, "error opening log file: %s", err)
 			log.Fatalf("error opening log file: %s", err)
 		}
 

--- a/main_test.go
+++ b/main_test.go
@@ -31,7 +31,7 @@ const (
 	binaryPathDarwin  = "./build/wakatime-cli-darwin-amd64"
 	binaryPathLinux   = "./build/wakatime-cli-linux-amd64"
 	binaryPathWindows = "./build/wakatime-cli-windows-amd64.exe"
-	testVersion       = "v0.0.1-test"
+	testVersion       = "<local-build>"
 )
 
 func binaryPath(t *testing.T) string {
@@ -60,7 +60,7 @@ func TestSendHeartbeats_EntityFileInTempDir(t *testing.T) {
 }
 
 func testSendHeartbeats(t *testing.T, entity, project string) {
-	apiUrl, router, close := setupTestServer()
+	apiURL, router, close := setupTestServer()
 	defer close()
 
 	var numCalls int
@@ -104,8 +104,6 @@ func testSendHeartbeats(t *testing.T, entity, project string) {
 		require.NoError(t, err)
 	})
 
-	version.Version = testVersion
-
 	offlineQueueFile, err := ioutil.TempFile(os.TempDir(), "")
 	require.NoError(t, err)
 
@@ -113,7 +111,7 @@ func testSendHeartbeats(t *testing.T, entity, project string) {
 
 	runWakatimeCli(
 		t,
-		"--api-url", apiUrl,
+		"--api-url", apiURL,
 		"--key", "00000000-0000-4000-8000-000000000000",
 		"--config", "testdata/wakatime.cfg",
 		"--entity", entity,
@@ -131,7 +129,7 @@ func testSendHeartbeats(t *testing.T, entity, project string) {
 }
 
 func TestTodayGoal(t *testing.T) {
-	apiUrl, router, close := setupTestServer()
+	apiURL, router, close := setupTestServer()
 	defer close()
 
 	var numCalls int
@@ -154,11 +152,9 @@ func TestTodayGoal(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	version.Version = testVersion
-
 	out := runWakatimeCli(
 		t,
-		"--api-url", apiUrl,
+		"--api-url", apiURL,
 		"--key", "00000000-0000-4000-8000-000000000000",
 		"--config", "testdata/wakatime.cfg",
 		"--today-goal", "11111111-1111-4111-8111-111111111111",
@@ -171,7 +167,7 @@ func TestTodayGoal(t *testing.T) {
 }
 
 func TestTodaySummary(t *testing.T) {
-	apiUrl, router, close := setupTestServer()
+	apiURL, router, close := setupTestServer()
 	defer close()
 
 	var numCalls int
@@ -206,11 +202,9 @@ func TestTodaySummary(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	version.Version = testVersion
-
 	out := runWakatimeCli(
 		t,
-		"--api-url", apiUrl,
+		"--api-url", apiURL,
 		"--key", "00000000-0000-4000-8000-000000000000",
 		"--config", "testdata/wakatime.cfg",
 		"--today",
@@ -240,7 +234,7 @@ func TestOfflineCountEmpty(t *testing.T) {
 }
 
 func TestOfflineCountWithOneHeartbeat(t *testing.T) {
-	apiUrl, router, close := setupTestServer()
+	apiURL, router, close := setupTestServer()
 	defer close()
 
 	router.HandleFunc("/users/current/heartbeats.bulk", func(w http.ResponseWriter, req *http.Request) {
@@ -249,8 +243,6 @@ func TestOfflineCountWithOneHeartbeat(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	version.Version = testVersion
-
 	offlineQueueFile, err := ioutil.TempFile(os.TempDir(), "")
 	require.NoError(t, err)
 
@@ -258,7 +250,7 @@ func TestOfflineCountWithOneHeartbeat(t *testing.T) {
 
 	runWakatimeCliExpectErr(
 		t,
-		"--api-url", apiUrl,
+		"--api-url", apiURL,
 		"--key", "00000000-0000-4000-8000-000000000000",
 		"--config", "testdata/wakatime.cfg",
 		"--entity", "testdata/main.go",
@@ -298,14 +290,14 @@ func TestUseragentWithPlugin(t *testing.T) {
 func TestVersion(t *testing.T) {
 	out := runWakatimeCli(t, "--version")
 
-	assert.Equal(t, "v0.0.1-test\n", out)
+	assert.Equal(t, "<local-build>\n", out)
 }
 
 func TestVersionVerbose(t *testing.T) {
 	out := runWakatimeCli(t, "--version", "--verbose")
 
 	assert.Regexp(t, regexp.MustCompile(fmt.Sprintf(
-		"wakatime-cli\n  Version: v0.0.1-test\n  Commit: [0-9a-f]{7}\n  Built: [0-9-:T]{19} UTC\n  OS/Arch: %s/%s\n",
+		"wakatime-cli\n  Version: <local-build>\n  Commit: [0-9a-f]{7}\n  Built: [0-9-:T]{19} UTC\n  OS/Arch: %s/%s\n",
 		runtime.GOOS,
 		runtime.GOARCH,
 	)), out)
@@ -351,11 +343,14 @@ func runWakatimeCliExpectErr(t *testing.T, args ...string) string {
 
 func runCmd(cmd *exec.Cmd) string {
 	fmt.Println(cmd.String())
+
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
 
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
+
+	version.Version = testVersion
 
 	err := cmd.Run()
 	if err != nil {
@@ -370,11 +365,14 @@ func runCmd(cmd *exec.Cmd) string {
 
 func runCmdExpectErr(cmd *exec.Cmd) string {
 	fmt.Println(cmd.String())
+
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
 
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
+
+	version.Version = testVersion
 
 	err := cmd.Run()
 	if err == nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -75,7 +75,7 @@ func ReadInConfig(v *viper.Viper, filepathFn func(v *viper.Viper) (string, error
 
 	// check if file exists
 	if _, err := os.Stat(configFilepath); os.IsNotExist(err) {
-		log.Warnf("config file not present or not accessible")
+		log.Debugf("config file not present or not accessible")
 
 		return nil
 	}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -11,5 +11,5 @@ var (
 	// OS specifies the target operating system of the wakatime-cli build.
 	OS = "unset"
 	// Version states the version of the wakatime-cli build.
-	Version = "v1"
+	Version = "unset"
 )


### PR DESCRIPTION
This fixes a bug where `debug = true` wasn't enabling debug logs because logging was setup before reading the config file.