### PR TITLE
Fix naming of diagnostics plugin key

### DIFF
--- a/cmd/legacy/testdata/diagnostics_request_template.json
+++ b/cmd/legacy/testdata/diagnostics_request_template.json
@@ -1,7 +1,7 @@
 {
 	"platform": "some os",
 	"architecture": "some architecture",
-	"editor": "vim",
+	"plugin": "vim",
 	"logs": "%s",
 	"stacktrace": "%s"
 }

--- a/cmd/legacy/testdata/diagnostics_request_template_no_logs.json
+++ b/cmd/legacy/testdata/diagnostics_request_template_no_logs.json
@@ -1,6 +1,6 @@
 {
 	"platform": "some os",
 	"architecture": "some architecture",
-	"editor": "vim",
+	"plugin": "vim",
 	"stacktrace": "%s"
 }

--- a/pkg/api/diagnostic.go
+++ b/pkg/api/diagnostic.go
@@ -15,7 +15,7 @@ import (
 type diagnosticsBody struct {
 	Platform     string `json:"platform"`
 	Architecture string `json:"architecture"`
-	Editor       string `json:"editor"`
+	Plugin       string `json:"plugin"`
 	Logs         string `json:"logs,omitempty"`
 	Stack        string `json:"stacktrace,omitempty"`
 }
@@ -29,7 +29,7 @@ func (c *Client) SendDiagnostics(plugin string, diagnostics ...diagnostic.Diagno
 	body := diagnosticsBody{
 		Platform:     version.OS,
 		Architecture: version.Arch,
-		Editor:       plugin,
+		Plugin:       plugin,
 	}
 
 	for _, d := range diagnostics {

--- a/pkg/api/testdata/diagnostics_request.json
+++ b/pkg/api/testdata/diagnostics_request.json
@@ -1,7 +1,7 @@
 {
 	"platform": "linux",
 	"architecture": "amd64",
-	"editor": "vim",
+	"plugin": "vim",
 	"logs": "some logs",
 	"stacktrace": "some stack"
 }


### PR DESCRIPTION
API is expecting `plugin` instead of `editor`.