### PR TITLE
Do not send empty dependencies to the API

### DIFF
--- a/pkg/deps/deps.go
+++ b/pkg/deps/deps.go
@@ -139,8 +139,8 @@ func filterDependencies(deps []string) []string {
 			continue
 		}
 
-		// filter dependencies exceeding max length
-		if len(d) > maxDependencyLength {
+		// filter dependencies off size
+		if d == "" || len(d) > maxDependencyLength {
 			continue
 		}
 

--- a/pkg/deps/deps_test.go
+++ b/pkg/deps/deps_test.go
@@ -300,3 +300,15 @@ func TestDetect_LongDependenciesRemoved(t *testing.T) {
 		"notlongenoughnotlongenoughnotlongenoughnotlongenoughnotlongenoughnotlongenoughnotlongenoughnotlongenoughnotlongenoughnotlongenoughnotlongenoughnotlongenoughnotlongenoughnotlongenoughnotlongenoughnotlo",
 	}, deps)
 }
+
+func TestDetect_EmptyDependenciesRemoved(t *testing.T) {
+	deps, err := deps.Detect(
+		"testdata/bower_empty_dependency.json",
+		heartbeat.LanguageJSON,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{
+		"bootstrap",
+	}, deps)
+}

--- a/pkg/deps/testdata/bower_empty_dependency.json
+++ b/pkg/deps/testdata/bower_empty_dependency.json
@@ -1,0 +1,8 @@
+{
+    "name": "wakatime",
+    "version": "1.0.0",
+    "dependencies": {
+      "bootstrap": "latest",
+      "": "latest"
+    }
+}


### PR DESCRIPTION
This PR prevents sending empty dependencies to the API. 

First part of https://github.com/wakatime/wakatime-cli/issues/477