### PR TITLE
Fix wakatime project file priority

### DIFF
--- a/pkg/api/heartbeat.go
+++ b/pkg/api/heartbeat.go
@@ -30,6 +30,8 @@ func (c *Client) SendHeartbeats(heartbeats []heartbeat.Heartbeat) ([]heartbeat.R
 		return nil, fmt.Errorf("failed to json encode body: %s", err)
 	}
 
+	log.Debugf("heartbeats: %s", string(data))
+
 	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(data))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %s", err)

--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -116,11 +116,7 @@ func filterFileEntity(filepath string, includeOnlyWithProjectFile bool) error {
 
 	// check wakatime project file exists
 	if includeOnlyWithProjectFile {
-		_, ok, err := project.FindFile(filepath)
-		if err != nil {
-			return fmt.Errorf("error detecting project file: %s", err)
-		}
-
+		_, ok := project.FindFileOrDirectory(filepath, "", ".wakatime-project")
 		if !ok {
 			return Err("skipping because of missing .wakatime-project file in parent path")
 		}

--- a/pkg/project/git.go
+++ b/pkg/project/git.go
@@ -22,6 +22,8 @@ type Git struct {
 // Detect gets information about the git project for a given file.
 // It tries to return a project and branch name.
 func (g Git) Detect() (Result, bool, error) {
+	log.Debugln("execute git project detection")
+
 	fp, err := realpath.Realpath(g.Filepath)
 	if err != nil {
 		return Result{}, false,
@@ -60,7 +62,7 @@ func (g Git) Detect() (Result, bool, error) {
 	}
 
 	// Find for .git/config file
-	gitConfigFile, ok := findFileOrDirectory(fp, ".git", "config")
+	gitConfigFile, ok := FindFileOrDirectory(fp, ".git", "config")
 
 	if ok {
 		gitDir := filepath.Dir(gitConfigFile)
@@ -83,7 +85,7 @@ func (g Git) Detect() (Result, bool, error) {
 	}
 
 	// Find for .git file
-	gitConfigFile, ok = findFileOrDirectory(fp, "", ".git")
+	gitConfigFile, ok = FindFileOrDirectory(fp, "", ".git")
 	if !ok {
 		return Result{}, false, nil
 	}
@@ -150,7 +152,7 @@ func findSubmodule(fp string, patterns []regex.Regex) (string, bool, error) {
 		return "", false, nil
 	}
 
-	gitConfigFile, ok := findFileOrDirectory(fp, "", ".git")
+	gitConfigFile, ok := FindFileOrDirectory(fp, "", ".git")
 	if !ok {
 		return "", false, nil
 	}

--- a/pkg/project/map.go
+++ b/pkg/project/map.go
@@ -27,6 +27,8 @@ type Map struct {
 // project name 'new project name' and file '/home/user/projects/bar42/main.c'
 // to have project name 'project42'.
 func (m Map) Detect() (Result, bool, error) {
+	log.Debugln("execute map project detection")
+
 	if len(m.Patterns) == 0 {
 		return Result{}, false, nil
 	}

--- a/pkg/project/mercurial.go
+++ b/pkg/project/mercurial.go
@@ -18,6 +18,8 @@ type Mercurial struct {
 
 // Detect gets information about the mercurial project for a given file.
 func (m Mercurial) Detect() (Result, bool, error) {
+	log.Debugln("execute mercurial project detection")
+
 	fp, err := realpath.Realpath(m.Filepath)
 	if err != nil {
 		return Result{}, false,
@@ -30,7 +32,7 @@ func (m Mercurial) Detect() (Result, bool, error) {
 	}
 
 	// Find for .hg folder
-	hgDirectory, ok := findFileOrDirectory(fp, "", ".hg")
+	hgDirectory, ok := FindFileOrDirectory(fp, "", ".hg")
 	if !ok {
 		return Result{}, false, nil
 	}

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -219,10 +219,10 @@ func generateProjectName() string {
 	return strings.Join(str, " ")
 }
 
-// findFileOrDirectory searches for a file or directory with name `filename`.
+// FindFileOrDirectory searches for a file or directory with name `filename`.
 // Search starts in `startDir` and will traverse through all parent directories until the file is found,
 // root directory is reached or `maxRecursiveIteration` is exceeded.
-func findFileOrDirectory(startDir, fileDir, filename string) (string, bool) {
+func FindFileOrDirectory(startDir, fileDir, filename string) (string, bool) {
 	i := 0
 	for i < maxRecursiveIteration {
 		if fileExists(filepath.Join(startDir, fileDir, filename)) {

--- a/pkg/project/subversion.go
+++ b/pkg/project/subversion.go
@@ -20,6 +20,8 @@ type Subversion struct {
 
 // Detect gets information about the svn project for a given file.
 func (s Subversion) Detect() (Result, bool, error) {
+	log.Debugln("execute subversion project detection")
+
 	binary, ok := findSvnBinary()
 	if !ok {
 		log.Debugln("svn binary not found")
@@ -37,7 +39,7 @@ func (s Subversion) Detect() (Result, bool, error) {
 	}
 
 	// Find for .svn/wc.db file
-	svnConfigFile, ok := findFileOrDirectory(fp, ".svn", "wc.db")
+	svnConfigFile, ok := FindFileOrDirectory(fp, ".svn", "wc.db")
 	if !ok {
 		return Result{}, false, nil
 	}

--- a/pkg/project/testdata/.wakatime-project-other
+++ b/pkg/project/testdata/.wakatime-project-other
@@ -1,0 +1,1 @@
+Rough Surf 20

--- a/pkg/project/tfvc.go
+++ b/pkg/project/tfvc.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"runtime"
 
+	"github.com/wakatime/wakatime-cli/pkg/log"
+
 	"github.com/yookoala/realpath"
 )
 
@@ -16,6 +18,8 @@ type Tfvc struct {
 
 // Detect gets information about the tfvc project for a given file.
 func (t Tfvc) Detect() (Result, bool, error) {
+	log.Debugln("execute tfvc project detection")
+
 	fp, err := realpath.Realpath(t.Filepath)
 	if err != nil {
 		return Result{}, false,
@@ -33,7 +37,7 @@ func (t Tfvc) Detect() (Result, bool, error) {
 	}
 
 	// Find for tf/properties.tf1 file
-	tfDirectory, ok := findFileOrDirectory(fp, tfFolderName, "properties.tf1")
+	tfDirectory, ok := FindFileOrDirectory(fp, tfFolderName, "properties.tf1")
 	if !ok {
 		return Result{}, false, nil
 	}


### PR DESCRIPTION
This PR removes `FindFile` function in order to use `FindFileOrDirectory`. This change has been tested on both macOS and Windows.

- It also adds debug messages when running project detection which is useful to know where project and branch were detected.

Fixes #497 