### PR TITLE
Fix awk regex escape character

### DIFF
--- a/bin/prepare_changelog.sh
+++ b/bin/prepare_changelog.sh
@@ -51,7 +51,7 @@ parse_for_develop() {
 }
 
 parse_for_release() {
-    changelog=$(awk 'f;/Changelog\:/{f=1}' <<< "$changelog")
+    changelog=$(awk 'f;/Changelog:/{f=1}' <<< "$changelog")
 }
 
 case $branch in


### PR DESCRIPTION
This PR fixes regex escape character for awk command.

Fixes #476 