### PR TITLE
Add backoff algorithm

### DIFF
--- a/cmd/legacy/heartbeat/heartbeat.go
+++ b/cmd/legacy/heartbeat/heartbeat.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/wakatime/wakatime-cli/cmd/legacy/legacyapi"
 	"github.com/wakatime/wakatime-cli/pkg/api"
+	"github.com/wakatime/wakatime-cli/pkg/backoff"
 	"github.com/wakatime/wakatime-cli/pkg/deps"
 	"github.com/wakatime/wakatime-cli/pkg/exitcode"
 	"github.com/wakatime/wakatime-cli/pkg/filestats"
@@ -171,6 +172,12 @@ func SendHeartbeats(v *viper.Viper, queueFilepath string) error {
 
 		handleOpts = append(handleOpts, offlineHandleOpt)
 	}
+
+	handleOpts = append(handleOpts, backoff.WithBackoff(backoff.Config{
+		V:       v,
+		At:      params.API.BackoffAt,
+		Retries: params.API.BackoffRetries,
+	}))
 
 	apiClient, err := legacyapi.NewClient(params.API)
 	if err != nil {

--- a/cmd/legacy/legacyparams/params_test.go
+++ b/cmd/legacy/legacyparams/params_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/wakatime/wakatime-cli/cmd/legacy/legacyparams"
 	"github.com/wakatime/wakatime-cli/pkg/api"
+	"github.com/wakatime/wakatime-cli/pkg/config"
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
@@ -159,6 +160,7 @@ func TestLoad_API_APIKey(t *testing.T) {
 			ViperAPIKeyConfigOld: "20000000-0000-4000-8000-000000000000",
 			Expected: legacyparams.Params{
 				API: legacyparams.API{
+
 					Key:      "00000000-0000-4000-8000-000000000000",
 					URL:      "https://api.wakatime.com/api/v1",
 					Hostname: "my-computer",
@@ -170,6 +172,7 @@ func TestLoad_API_APIKey(t *testing.T) {
 			ViperAPIKeyConfigOld: "10000000-0000-4000-8000-000000000000",
 			Expected: legacyparams.Params{
 				API: legacyparams.API{
+
 					Key:      "00000000-0000-4000-8000-000000000000",
 					URL:      "https://api.wakatime.com/api/v1",
 					Hostname: "my-computer",
@@ -180,6 +183,7 @@ func TestLoad_API_APIKey(t *testing.T) {
 			ViperAPIKeyConfigOld: "00000000-0000-4000-8000-000000000000",
 			Expected: legacyparams.Params{
 				API: legacyparams.API{
+
 					Key:      "00000000-0000-4000-8000-000000000000",
 					URL:      "https://api.wakatime.com/api/v1",
 					Hostname: "my-computer",
@@ -241,6 +245,7 @@ func TestLoad_API_APIUrl(t *testing.T) {
 			ViperAPIUrlOld:    "http://localhost:8082",
 			Expected: legacyparams.Params{
 				API: legacyparams.API{
+
 					Key:      "00000000-0000-4000-8000-000000000000",
 					URL:      "http://localhost:8080",
 					Hostname: "my-computer",
@@ -252,6 +257,7 @@ func TestLoad_API_APIUrl(t *testing.T) {
 			ViperAPIUrlOld:    "http://localhost:8082",
 			Expected: legacyparams.Params{
 				API: legacyparams.API{
+
 					Key:      "00000000-0000-4000-8000-000000000000",
 					URL:      "http://localhost:8082",
 					Hostname: "my-computer",
@@ -262,6 +268,7 @@ func TestLoad_API_APIUrl(t *testing.T) {
 			ViperAPIUrlConfig: "http://localhost:8081",
 			Expected: legacyparams.Params{
 				API: legacyparams.API{
+
 					Key:      "00000000-0000-4000-8000-000000000000",
 					URL:      "http://localhost:8081",
 					Hostname: "my-computer",
@@ -272,6 +279,7 @@ func TestLoad_API_APIUrl(t *testing.T) {
 			ViperAPIUrl: "http://localhost:8080/api/v1/heartbeats.bulk",
 			Expected: legacyparams.Params{
 				API: legacyparams.API{
+
 					Key:      "00000000-0000-4000-8000-000000000000",
 					URL:      "http://localhost:8080/api/v1",
 					Hostname: "my-computer",
@@ -282,6 +290,7 @@ func TestLoad_API_APIUrl(t *testing.T) {
 			ViperAPIUrl: "http://localhost:8080/api/",
 			Expected: legacyparams.Params{
 				API: legacyparams.API{
+
 					Key:      "00000000-0000-4000-8000-000000000000",
 					URL:      "http://localhost:8080/api",
 					Hostname: "my-computer",
@@ -292,6 +301,7 @@ func TestLoad_API_APIUrl(t *testing.T) {
 			ViperAPIUrl: "http://localhost:8080/api/heartbeat",
 			Expected: legacyparams.Params{
 				API: legacyparams.API{
+
 					Key:      "00000000-0000-4000-8000-000000000000",
 					URL:      "http://localhost:8080/api",
 					Hostname: "my-computer",
@@ -328,6 +338,63 @@ func TestLoad_APIUrl_Default(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, api.BaseURL, params.API.URL)
+}
+
+func TestLoad_API_BackoffAt(t *testing.T) {
+	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
+	v.Set("key", "00000000-0000-4000-8000-000000000000")
+	v.Set("hostname", "my-computer")
+	v.Set("internal.backoff_at", "2021-08-30T18:50:42-03:00")
+
+	params, err := legacyparams.Load(v)
+	require.NoError(t, err)
+
+	backoffAt, err := time.Parse(config.DateFormat, "2021-08-30T18:50:42-03:00")
+	require.NoError(t, err)
+
+	assert.Equal(t, legacyparams.API{
+		BackoffAt: backoffAt,
+		Key:       "00000000-0000-4000-8000-000000000000",
+		URL:       "https://api.wakatime.com/api/v1",
+		Hostname:  "my-computer",
+	}, params.API)
+}
+
+func TestLoad_API_BackoffAtErr(t *testing.T) {
+	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
+	v.Set("key", "00000000-0000-4000-8000-000000000000")
+	v.Set("hostname", "my-computer")
+	v.Set("internal.backoff_at", "2021-08-30")
+
+	params, err := legacyparams.Load(v)
+	require.NoError(t, err)
+
+	assert.Equal(t, legacyparams.API{
+		BackoffAt: time.Time{},
+		Key:       "00000000-0000-4000-8000-000000000000",
+		URL:       "https://api.wakatime.com/api/v1",
+		Hostname:  "my-computer",
+	}, params.API)
+}
+
+func TestLoad_API_BackoffRetries(t *testing.T) {
+	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
+	v.Set("key", "00000000-0000-4000-8000-000000000000")
+	v.Set("hostname", "my-computer")
+	v.Set("internal.backoff_retries", "3")
+
+	params, err := legacyparams.Load(v)
+	require.NoError(t, err)
+
+	assert.Equal(t, legacyparams.API{
+		BackoffRetries: 3,
+		Key:            "00000000-0000-4000-8000-000000000000",
+		URL:            "https://api.wakatime.com/api/v1",
+		Hostname:       "my-computer",
+	}, params.API)
 }
 
 func TestLoad_API_Plugin(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -108,11 +108,16 @@ func testSendHeartbeats(t *testing.T, entity, project string) {
 
 	defer os.Remove(offlineQueueFile.Name())
 
+	tmpFile, err := ioutil.TempFile(os.TempDir(), "wakatime.cfg")
+	require.NoError(t, err)
+
+	defer os.Remove(tmpFile.Name())
+
 	runWakatimeCli(
 		t,
 		"--api-url", apiURL,
 		"--key", "00000000-0000-4000-8000-000000000000",
-		"--config", "testdata/wakatime.cfg",
+		"--config", tmpFile.Name(),
 		"--entity", entity,
 		"--cursorpos", "12",
 		"--offline-queue-file", offlineQueueFile.Name(),
@@ -132,6 +137,11 @@ func TestTodayGoal(t *testing.T) {
 	defer close()
 
 	var numCalls int
+
+	tmpFile, err := ioutil.TempFile(os.TempDir(), "wakatime.cfg")
+	require.NoError(t, err)
+
+	defer os.Remove(tmpFile.Name())
 
 	router.HandleFunc("/users/current/goals/11111111-1111-4111-8111-111111111111",
 		func(w http.ResponseWriter, req *http.Request) {
@@ -156,7 +166,7 @@ func TestTodayGoal(t *testing.T) {
 		t,
 		"--api-url", apiURL,
 		"--key", "00000000-0000-4000-8000-000000000000",
-		"--config", "testdata/wakatime.cfg",
+		"--config", tmpFile.Name(),
 		"--today-goal", "11111111-1111-4111-8111-111111111111",
 		"--verbose",
 	)
@@ -171,6 +181,11 @@ func TestTodaySummary(t *testing.T) {
 	defer close()
 
 	var numCalls int
+
+	tmpFile, err := ioutil.TempFile(os.TempDir(), "wakatime.cfg")
+	require.NoError(t, err)
+
+	defer os.Remove(tmpFile.Name())
 
 	router.HandleFunc("/users/current/statusbar/today", func(w http.ResponseWriter, req *http.Request) {
 		numCalls++
@@ -194,7 +209,7 @@ func TestTodaySummary(t *testing.T) {
 		t,
 		"--api-url", apiURL,
 		"--key", "00000000-0000-4000-8000-000000000000",
-		"--config", "testdata/wakatime.cfg",
+		"--config", tmpFile.Name(),
 		"--today",
 		"--verbose",
 	)
@@ -236,11 +251,16 @@ func TestOfflineCountWithOneHeartbeat(t *testing.T) {
 
 	defer os.Remove(offlineQueueFile.Name())
 
+	tmpFile, err := ioutil.TempFile(os.TempDir(), "wakatime.cfg")
+	require.NoError(t, err)
+
+	defer os.Remove(tmpFile.Name())
+
 	runWakatimeCliExpectErr(
 		t,
 		"--api-url", apiURL,
 		"--key", "00000000-0000-4000-8000-000000000000",
-		"--config", "testdata/wakatime.cfg",
+		"--config", tmpFile.Name(),
 		"--entity", "testdata/main.go",
 		"--cursorpos", "12",
 		"--offline-queue-file", offlineQueueFile.Name(),

--- a/pkg/backoff/backoff.go
+++ b/pkg/backoff/backoff.go
@@ -1,0 +1,107 @@
+package backoff
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"time"
+
+	ini "github.com/wakatime/wakatime-cli/pkg/config"
+	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
+	"github.com/wakatime/wakatime-cli/pkg/log"
+
+	"github.com/spf13/viper"
+)
+
+const (
+	// resetAfter sets the total seconds a backoff will last.
+	resetAfter = 3600
+	// factor is the total seconds to be multiplied by.
+	factor = 15
+)
+
+// Config defines backoff data.
+type Config struct {
+	// At is the time when the first failure happened.
+	At time.Time
+	// Retries is the number of attempts to connect.
+	Retries int
+	// V is an instance of Viper.
+	V *viper.Viper
+}
+
+// WithBackoff initializes and returns a heartbeat handle option, which
+// can be used in a heartbeat processing pipeline to prevent trying to send
+// a heartbeat when the api is unresponsive.
+func WithBackoff(config Config) heartbeat.HandleOption {
+	return func(next heartbeat.Handle) heartbeat.Handle {
+		return func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+			log.Debugln("execute heartbeat backoff algorithm")
+
+			if shouldBackoff(config.Retries, config.At) {
+				return nil, fmt.Errorf("won't send heartbeat due to backoff")
+			}
+
+			results, err := next(hh)
+			if err != nil {
+				log.Debugf("incrementing backoff due to error")
+
+				// error response, increment backoff
+				if updateErr := updateBackoffSettings(config.V, config.Retries+1, time.Now()); updateErr != nil {
+					log.Warnf("failed to update backoff settings: %s", updateErr)
+				}
+
+				return nil, err
+			}
+
+			if !config.At.IsZero() {
+				// success response, reset backoff
+				if resetErr := updateBackoffSettings(config.V, 0, time.Time{}); resetErr != nil {
+					log.Warnf("failed to reset backoff settings: %s", resetErr)
+				}
+			}
+
+			return results, nil
+		}
+	}
+}
+
+func shouldBackoff(retries int, at time.Time) bool {
+	if retries < 1 || at.IsZero() {
+		return false
+	}
+
+	now := time.Now()
+	duration := time.Duration(float64(factor)*math.Pow(2, float64(retries))) * time.Second
+
+	log.Debugf(
+		"exponential backoff tried %s times since %s, will retry at %s",
+		retries,
+		at.Format(time.Stamp),
+		at.Add(duration).Format(time.Stamp),
+	)
+
+	return now.Before(at.Add(duration)) && now.Before(at.Add(resetAfter*time.Second))
+}
+
+func updateBackoffSettings(v *viper.Viper, retries int, at time.Time) error {
+	w, err := ini.NewIniWriter(v, ini.FilePath)
+	if err != nil {
+		return fmt.Errorf("failed to parse config file: %s", err)
+	}
+
+	keyValue := map[string]string{
+		"backoff_retries": strconv.Itoa(retries),
+		"backoff_at":      "",
+	}
+
+	if !at.IsZero() {
+		keyValue["backoff_at"] = at.Format(ini.DateFormat)
+	}
+
+	if err := w.Write("internal", keyValue); err != nil {
+		return fmt.Errorf("failed to write to config file: %s", err)
+	}
+
+	return nil
+}

--- a/pkg/backoff/backoff_internal_test.go
+++ b/pkg/backoff/backoff_internal_test.go
@@ -1,0 +1,86 @@
+package backoff
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/wakatime/wakatime-cli/pkg/config"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShouldBackoff(t *testing.T) {
+	at := time.Now().Add(time.Second * -1)
+
+	should := shouldBackoff(1, at)
+
+	assert.True(t, should)
+}
+
+func TestShouldBackoff_AfterResetTime(t *testing.T) {
+	at := time.Now().Add((resetAfter + 1) * time.Second)
+
+	should := shouldBackoff(0, at)
+
+	assert.False(t, should)
+}
+
+func TestShouldBackoff_NegateBackoff(t *testing.T) {
+	should := shouldBackoff(0, time.Time{})
+
+	assert.False(t, should)
+}
+
+func TestUpdateBackoffSettings(t *testing.T) {
+	v := viper.New()
+
+	tmpFile, err := ioutil.TempFile(os.TempDir(), "wakatime")
+	require.NoError(t, err)
+
+	defer os.Remove(tmpFile.Name())
+
+	v.Set("config", tmpFile.Name())
+
+	at := time.Now().Add(time.Second * -1)
+
+	err = updateBackoffSettings(v, 2, at)
+	require.NoError(t, err)
+
+	ini, err := config.NewIniWriter(v, func(vp *viper.Viper) (string, error) {
+		assert.Equal(t, v, vp)
+		return tmpFile.Name(), nil
+	})
+	require.NoError(t, err)
+
+	backoffAt := ini.File.Section("internal").Key("backoff_at").MustTimeFormat(config.DateFormat)
+
+	assert.WithinDuration(t, time.Now(), backoffAt, 15*time.Second)
+	assert.Equal(t, "2", ini.File.Section("internal").Key("backoff_retries").String())
+}
+
+func TestUpdateBackoffSettings_NotInBackoff(t *testing.T) {
+	v := viper.New()
+
+	tmpFile, err := ioutil.TempFile(os.TempDir(), "wakatime")
+	require.NoError(t, err)
+
+	defer os.Remove(tmpFile.Name())
+
+	v.Set("config", tmpFile.Name())
+
+	err = updateBackoffSettings(v, 0, time.Time{})
+	require.NoError(t, err)
+
+	ini, err := config.NewIniWriter(v, func(vp *viper.Viper) (string, error) {
+		assert.Equal(t, v, vp)
+		return tmpFile.Name(), nil
+	})
+	require.NoError(t, err)
+
+	assert.Empty(t, ini.File.Section("internal").Key("backoff_at").String())
+	assert.Equal(t, "0", ini.File.Section("internal").Key("backoff_retries").String())
+}

--- a/pkg/backoff/backoff_test.go
+++ b/pkg/backoff/backoff_test.go
@@ -1,0 +1,88 @@
+package backoff_test
+
+import (
+	"errors"
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/spf13/viper"
+	"github.com/wakatime/wakatime-cli/pkg/backoff"
+	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithRetry(t *testing.T) {
+	v := viper.New()
+
+	tmpFile, err := ioutil.TempFile(os.TempDir(), "wakatime")
+	require.NoError(t, err)
+
+	defer os.Remove(tmpFile.Name())
+
+	v.Set("config", tmpFile.Name())
+
+	opt := backoff.WithBackoff(backoff.Config{
+		V: v,
+	})
+
+	handle := opt(func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+		return []heartbeat.Result{
+			{
+				Status: 201,
+			},
+		}, nil
+	})
+
+	_, err = handle([]heartbeat.Heartbeat{})
+	require.NoError(t, err)
+}
+
+func TestWithRetry_BeforeNextBackoff(t *testing.T) {
+	backoffAt := time.Now().Add(time.Second * -1)
+
+	opt := backoff.WithBackoff(backoff.Config{
+		At:      backoffAt,
+		Retries: 1,
+	})
+
+	handle := opt(func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+		return []heartbeat.Result{
+			{
+				Status: 201,
+			},
+		}, nil
+	})
+
+	_, err := handle([]heartbeat.Heartbeat{})
+	require.Error(t, err)
+
+	assert.Equal(t, "won't send heartbeat due to backoff", err.Error())
+}
+
+func TestWithRetry_ApiError(t *testing.T) {
+	v := viper.New()
+
+	tmpFile, err := ioutil.TempFile(os.TempDir(), "wakatime")
+	require.NoError(t, err)
+
+	defer os.Remove(tmpFile.Name())
+
+	v.Set("config", tmpFile.Name())
+
+	opt := backoff.WithBackoff(backoff.Config{
+		V: v,
+	})
+
+	handle := opt(func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+		return []heartbeat.Result{}, errors.New("error")
+	})
+
+	_, err = handle([]heartbeat.Heartbeat{})
+	require.Error(t, err)
+
+	assert.Equal(t, "error", err.Error())
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/wakatime/wakatime-cli/pkg/log"
 	"github.com/wakatime/wakatime-cli/pkg/vipertools"
@@ -14,8 +15,12 @@ import (
 	"gopkg.in/ini.v1"
 )
 
-// defaultFile is the name of the default wakatime config file.
-const defaultFile = ".wakatime.cfg"
+const (
+	// defaultFile is the name of the default wakatime config file.
+	defaultFile = ".wakatime.cfg"
+	// DateFormat is the default format for date in config file.
+	DateFormat = time.RFC3339
+)
 
 // Writer defines the methods to write to config file.
 type Writer interface {
@@ -35,7 +40,7 @@ func NewIniWriter(v *viper.Viper, filepathFn func(v *viper.Viper) (string, error
 		return nil, fmt.Errorf("error getting filepath: %s", err)
 	}
 
-	ini, err := ini.Load(configFilepath)
+	ini, err := ini.LoadSources(ini.LoadOptions{AllowPythonMultilineValues: true}, configFilepath)
 	if err != nil {
 		return nil, fmt.Errorf("error loading config file: %s", err)
 	}

--- a/pkg/heartbeat/sanitize.go
+++ b/pkg/heartbeat/sanitize.go
@@ -20,7 +20,7 @@ type SanitizeConfig struct {
 }
 
 // WithSanitization initializes and returns a heartbeat handle option, which
-// can be used in a heartbeat processing pipeline.
+// can be used in a heartbeat processing pipeline to hide sensitive data.
 func WithSanitization(config SanitizeConfig) HandleOption {
 	return func(next Handle) Handle {
 		return func(hh []Heartbeat) ([]Result, error) {

--- a/pkg/heartbeat/sanitize_test.go
+++ b/pkg/heartbeat/sanitize_test.go
@@ -308,7 +308,7 @@ func TestSanitize_EmptyConfigDoNothing_EmptyDependencies(t *testing.T) {
 	}, r)
 }
 
-func TestSouldSanitize(t *testing.T) {
+func TestShouldSanitize(t *testing.T) {
 	tests := map[string]struct {
 		Subject  string
 		Regex    []regex.Regex
@@ -341,9 +341,9 @@ func TestSouldSanitize(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			souldSanitize := heartbeat.ShouldSanitize(test.Subject, test.Regex)
+			shouldSanitize := heartbeat.ShouldSanitize(test.Subject, test.Regex)
 
-			assert.Equal(t, test.Expected, souldSanitize)
+			assert.Equal(t, test.Expected, shouldSanitize)
 		})
 	}
 }


### PR DESCRIPTION
This PR adds exponential backoff algorithm to prevent trying to send heartbeats during backoff period. It will act in the pipeline after offline step and before calling the API. If any error returns from the API, the backoff step will decide to either increment retry or reset it after `reset time` of 3600 seconds. If no error returns from the API and in backoff then reset its settings.

Default values used:
* **3600** seconds is the maximum time backoff will last for.
* **15** is the factor to multiply by retries.

Closes #510 