### PR TITLE
Add entity modifier middleware

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -8,7 +8,7 @@ on:
       - "**"
 
 env:
-  GO_VERSION: "1.16"
+  GO_VERSION: "1.17"
   TEST_VERSION: "<local-build>"
 
 jobs:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Prerequisites:
 
 - We use `make` to build and run tests
 - We use `bats` to test shell scripts. Documentation can be found [here](https://bats-core.readthedocs.io/en/latest/installation.html)
-- [Go 1.16](https://golang.org/doc/install)
+- [Go 1.17](https://golang.org/doc/install)
 
 After cloning, install dependencies with `make install`.
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/wakatime/wakatime-cli
 
-go 1.16
+go 1.17
 
 require (
 	github.com/Azure/go-ntlmssp v0.0.0-20200615164410-66371956d46c
@@ -18,6 +18,26 @@ require (
 	github.com/yookoala/realpath v1.0.0
 	go.etcd.io/bbolt v1.3.5
 	gopkg.in/ini.v1 v1.62.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/fsnotify/fsnotify v1.4.9 // indirect
+	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/magiconair/properties v1.8.5 // indirect
+	github.com/mitchellh/mapstructure v1.4.1 // indirect
+	github.com/pelletier/go-toml v1.9.3 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/spf13/afero v1.6.0 // indirect
+	github.com/spf13/cast v1.3.1 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/subosito/gotenv v1.2.0 // indirect
+	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 // indirect
+	golang.org/x/sys v0.0.0-20210510120138-977fb7262007 // indirect
+	golang.org/x/text v0.3.5 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
 
 replace github.com/alecthomas/chroma => github.com/wakatime/chroma v0.8.2-wakatime.7

--- a/go.sum
+++ b/go.sum
@@ -320,14 +320,6 @@ github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/wakatime/chroma v0.8.2-wakatime.7 h1:2fXUt39QsD9HwI0X8vMs6hU3lHLGSnsJDj5ZxWW49oM=
 github.com/wakatime/chroma v0.8.2-wakatime.7/go.mod h1:Mldbmbb8NHiOz8oC1HKR8xUQ0EPvAjZpKDyQl2nGrnQ=
-github.com/wakatime/goInfo v0.1.0-wakatime.2 h1:CaPbE4l8yv6s2Oj+yAEkYHfMY6BJ09tNjdGboUvZu4g=
-github.com/wakatime/goInfo v0.1.0-wakatime.2/go.mod h1:aEt7p9Rvh67BYApmZwNDPpgircTO2kgdmDUoF/1QmwA=
-github.com/wakatime/goInfo v0.1.0-wakatime.3 h1:pw+w/781qONIHDVZIgJo7DBeWSXwRGbbM/TT1+kPt3w=
-github.com/wakatime/goInfo v0.1.0-wakatime.3/go.mod h1:aEt7p9Rvh67BYApmZwNDPpgircTO2kgdmDUoF/1QmwA=
-github.com/wakatime/goInfo v0.1.0-wakatime.4 h1:dB8Zr30MsB7nnJYQJrCoXiExK5F31MKM2pBtpUkqxeg=
-github.com/wakatime/goInfo v0.1.0-wakatime.4/go.mod h1:aEt7p9Rvh67BYApmZwNDPpgircTO2kgdmDUoF/1QmwA=
-github.com/wakatime/goInfo v0.1.0-wakatime.5 h1:UHJH3F1xLtheV0YCwfeVhN4HPHU3tsz8UkHyNxuZUbM=
-github.com/wakatime/goInfo v0.1.0-wakatime.5/go.mod h1:aEt7p9Rvh67BYApmZwNDPpgircTO2kgdmDUoF/1QmwA=
 github.com/wakatime/goInfo v0.1.0-wakatime.6 h1:90ikk7UzuEaO4dpXzOIlL+NdGgij7Bo3DsPh/XGODqA=
 github.com/wakatime/goInfo v0.1.0-wakatime.6/go.mod h1:aEt7p9Rvh67BYApmZwNDPpgircTO2kgdmDUoF/1QmwA=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=

--- a/main_test.go
+++ b/main_test.go
@@ -1,4 +1,4 @@
-// +build integration
+//go:build integration
 
 package main_test
 

--- a/pkg/api/transport_other.go
+++ b/pkg/api/transport_other.go
@@ -1,4 +1,4 @@
-// +build !windows
+//go:build !windows
 
 package api
 

--- a/pkg/heartbeat/entity_modifier_internal_test.go
+++ b/pkg/heartbeat/entity_modifier_internal_test.go
@@ -1,0 +1,55 @@
+package heartbeat
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsXCodePlayground(t *testing.T) {
+	tests := map[string]struct {
+		Dir      string
+		Expected bool
+	}{
+		"playground directory": {
+			Dir:      setupTestXCodePlayground(t, "wakatime.playground"),
+			Expected: true,
+		},
+		"xcplayground directory": {
+			Dir:      setupTestXCodePlayground(t, "wakatime.xcplayground"),
+			Expected: true,
+		},
+		"xcplaygroundpage directory": {
+			Dir:      setupTestXCodePlayground(t, "wakatime.xcplaygroundpage"),
+			Expected: true,
+		},
+		"not playground": {
+			Dir:      setupTestXCodePlayground(t, "wakatime"),
+			Expected: false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			defer os.RemoveAll(test.Dir)
+
+			ret := isXCodePlayground(test.Dir)
+
+			assert.Equal(t, test.Expected, ret)
+		})
+	}
+}
+
+func setupTestXCodePlayground(t *testing.T, dir string) string {
+	tmpDir, err := ioutil.TempDir(os.TempDir(), "wakatime")
+	require.NoError(t, err)
+
+	err = os.Mkdir(filepath.Join(tmpDir, dir), os.FileMode(int(0700)))
+	require.NoError(t, err)
+
+	return filepath.Join(tmpDir, dir)
+}

--- a/pkg/heartbeat/entity_modify.go
+++ b/pkg/heartbeat/entity_modify.go
@@ -1,0 +1,37 @@
+package heartbeat
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/wakatime/wakatime-cli/pkg/log"
+)
+
+// WithEntityModifer initializes and returns a heartbeat handle option, which
+// can be used in a heartbeat processing pipeline to change an entity path.
+func WithEntityModifer() HandleOption {
+	return func(next Handle) Handle {
+		return func(hh []Heartbeat) ([]Result, error) {
+			log.Debugln("execute heartbeat entity modifier")
+
+			for n, h := range hh {
+				// Support XCode playgrounds
+				if h.EntityType == FileType && isXCodePlayground(h.Entity) {
+					hh[n].Entity = filepath.Join(h.Entity, "Contents.swift")
+				}
+			}
+
+			return next(hh)
+		}
+	}
+}
+
+func isXCodePlayground(fp string) bool {
+	if !(strings.HasSuffix(fp, ".playground") ||
+		strings.HasSuffix(fp, ".xcplayground") ||
+		strings.HasSuffix(fp, ".xcplaygroundpage")) {
+		return false
+	}
+
+	return isDir(fp)
+}

--- a/pkg/heartbeat/entity_modify_test.go
+++ b/pkg/heartbeat/entity_modify_test.go
@@ -1,0 +1,54 @@
+package heartbeat_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithEntityModifier_XCodePlayground(t *testing.T) {
+	tmpDir, err := ioutil.TempDir(os.TempDir(), "wakatime")
+	require.NoError(t, err)
+
+	defer os.RemoveAll(tmpDir)
+
+	err = os.Mkdir(filepath.Join(tmpDir, "wakatime.playground"), os.FileMode(int(0700)))
+	require.NoError(t, err)
+
+	opt := heartbeat.WithEntityModifer()
+
+	handle := opt(func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+		assert.Equal(t, []heartbeat.Heartbeat{
+			{
+				Entity:     filepath.Join(tmpDir, "wakatime.playground", "Contents.swift"),
+				EntityType: heartbeat.FileType,
+			},
+		}, hh)
+
+		return []heartbeat.Result{
+			{
+				Status: 201,
+			},
+		}, nil
+	})
+
+	result, err := handle([]heartbeat.Heartbeat{
+		{
+			Entity:     filepath.Join(tmpDir, "wakatime.playground"),
+			EntityType: heartbeat.FileType,
+		},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, []heartbeat.Result{
+		{
+			Status: 201,
+		},
+	}, result)
+}

--- a/pkg/heartbeat/heartbeat.go
+++ b/pkg/heartbeat/heartbeat.go
@@ -2,6 +2,7 @@ package heartbeat
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -205,4 +206,9 @@ func Int(v int) *int {
 // String returns a pointer to the string value passed in.
 func String(v string) *string {
 	return &v
+}
+
+func isDir(filepath string) bool {
+	info, _ := os.Stat(filepath)
+	return info.IsDir()
 }


### PR DESCRIPTION
This PR replaces the conditional validation for XCode Playground to a more flexible and testable function. It adds a new middleware called `Entity Modifier` that is intended to be used when changes are required to Entity's path.

In addition this PR bumps Go to 1.17.