### PR TITLE
All api errors except 400 and 401 should exit with 102 exit code

### DIFF
--- a/cmd/legacy/configwrite/configwrite.go
+++ b/cmd/legacy/configwrite/configwrite.go
@@ -29,7 +29,7 @@ func Run(v *viper.Viper) (int, error) {
 	}
 
 	if err := Write(v, w); err != nil {
-		return exitcode.ErrDefault, fmt.Errorf(
+		return exitcode.ErrGeneric, fmt.Errorf(
 			"failed to write to config file: %s",
 			err,
 		)

--- a/cmd/legacy/heartbeat/heartbeat.go
+++ b/cmd/legacy/heartbeat/heartbeat.go
@@ -26,7 +26,7 @@ import (
 func Run(v *viper.Viper) (int, error) {
 	queueFilepath, err := offline.QueueFilepath()
 	if err != nil {
-		return exitcode.ErrDefault, fmt.Errorf(
+		return exitcode.ErrGeneric, fmt.Errorf(
 			"failed to load offline queue filepath: %s",
 			err,
 		)
@@ -37,29 +37,21 @@ func Run(v *viper.Viper) (int, error) {
 		var errauth api.ErrAuth
 		if errors.As(err, &errauth) {
 			return exitcode.ErrAuth, fmt.Errorf(
-				"failed to send heartbeat: %s. Find your api key from wakatime.com/settings/api-key",
-				errauth,
-			)
-		}
-
-		var errbadRequest api.ErrBadRequest
-		if errors.As(err, &errbadRequest) {
-			return exitcode.ErrDefault, fmt.Errorf(
-				"failed to send heartbeat(s) due to api error: %s",
-				errbadRequest,
+				"invalid api key... find yours at wakatime.com/settings/api-key. %w",
+				err,
 			)
 		}
 
 		var errapi api.Err
 		if errors.As(err, &errapi) {
 			return exitcode.ErrAPI, fmt.Errorf(
-				"failed to send heartbeat(s) due to api error: %s",
-				errbadRequest,
+				"sending heartbeat(s) later due to api error: %w",
+				err,
 			)
 		}
 
-		return exitcode.ErrDefault, fmt.Errorf(
-			"failed to send heartbeat(s): %s",
+		return exitcode.ErrGeneric, fmt.Errorf(
+			"failed to send heartbeat(s): %w",
 			err,
 		)
 	}
@@ -192,7 +184,7 @@ func SendHeartbeats(v *viper.Viper, queueFilepath string) error {
 
 	results, err := handle(heartbeats)
 	if err != nil {
-		return fmt.Errorf("failed to send heartbeats via api client: %w", err)
+		return err
 	}
 
 	for _, result := range results {

--- a/cmd/legacy/offlinecount/offlinecount.go
+++ b/cmd/legacy/offlinecount/offlinecount.go
@@ -14,7 +14,7 @@ import (
 func Run(v *viper.Viper) (int, error) {
 	queueFilepath, err := offline.QueueFilepath()
 	if err != nil {
-		return exitcode.ErrDefault, fmt.Errorf(
+		return exitcode.ErrGeneric, fmt.Errorf(
 			"failed to load offline queue filepath: %s",
 			err,
 		)
@@ -22,7 +22,7 @@ func Run(v *viper.Viper) (int, error) {
 
 	params, err := legacyparams.Load(v)
 	if err != nil {
-		return exitcode.ErrDefault, fmt.Errorf("failed to load command parameters: %w", err)
+		return exitcode.ErrGeneric, fmt.Errorf("failed to load command parameters: %w", err)
 	}
 
 	if params.OfflineQueueFile != "" {
@@ -32,7 +32,7 @@ func Run(v *viper.Viper) (int, error) {
 	count, err := offline.CountHeartbeats(queueFilepath)
 	if err != nil {
 		fmt.Println(err)
-		return exitcode.ErrDefault, fmt.Errorf("failed to count offline heartbeats: %w", err)
+		return exitcode.ErrGeneric, fmt.Errorf("failed to count offline heartbeats: %w", err)
 	}
 
 	fmt.Println(count)

--- a/cmd/legacy/offlinesync/offlinesync.go
+++ b/cmd/legacy/offlinesync/offlinesync.go
@@ -18,7 +18,7 @@ import (
 func Run(v *viper.Viper) (int, error) {
 	queueFilepath, err := offline.QueueFilepath()
 	if err != nil {
-		return exitcode.ErrDefault, fmt.Errorf(
+		return exitcode.ErrGeneric, fmt.Errorf(
 			"failed to load offline queue filepath: %s",
 			err,
 		)
@@ -29,15 +29,15 @@ func Run(v *viper.Viper) (int, error) {
 		var errauth api.ErrAuth
 		if errors.As(err, &errauth) {
 			return exitcode.ErrAuth, fmt.Errorf(
-				"failed to sync offline activity: %s. Find your api key from wakatime.com/settings/api-key",
+				"invalid api key... find yours at wakatime.com/settings/api-key. %s",
 				errauth,
 			)
 		}
 
-		var errbadRequest api.ErrBadRequest
+		var errbadRequest api.Err
 		if errors.As(err, &errbadRequest) {
-			return exitcode.ErrDefault, fmt.Errorf(
-				"failed to sync offline activity due to api error: %s",
+			return exitcode.ErrGeneric, fmt.Errorf(
+				"unable to sync offline activity due to api error: %s",
 				err,
 			)
 		}
@@ -45,13 +45,13 @@ func Run(v *viper.Viper) (int, error) {
 		var errapi api.Err
 		if errors.As(err, &errapi) {
 			return exitcode.ErrAPI, fmt.Errorf(
-				"failed to sync offline activity due to api error: %s",
+				"unable to sync offline activity due to api error: %s",
 				err,
 			)
 		}
 
-		return exitcode.ErrDefault, fmt.Errorf(
-			"failed to sync offline activity: %s",
+		return exitcode.ErrGeneric, fmt.Errorf(
+			"unable to sync offline activity: %s",
 			err,
 		)
 	}
@@ -80,10 +80,5 @@ func SyncOfflineActivity(v *viper.Viper, queueFilepath string) error {
 
 	syncFn := offline.Sync(queueFilepath, params.OfflineSyncMax)
 
-	err = syncFn(apiClient.SendHeartbeats)
-	if err != nil {
-		return fmt.Errorf("failed to sync offline activity via api client: %w", err)
-	}
-
-	return nil
+	return syncFn(apiClient.SendHeartbeats)
 }

--- a/cmd/legacy/run.go
+++ b/cmd/legacy/run.go
@@ -116,7 +116,7 @@ func Run(cmd *cobra.Command, v *viper.Viper) {
 
 	_ = cmd.Help()
 
-	os.Exit(exitcode.ErrDefault)
+	os.Exit(exitcode.ErrGeneric)
 }
 
 // SetupLogging uses the --log-file param to configure logging to file or stdout.
@@ -184,7 +184,7 @@ func runCmd(v *viper.Viper, verbose bool, cmd cmdFn) int {
 				sendDiagnostics(v, logs.String(), string(debug.Stack()))
 			}
 
-			os.Exit(exitcode.ErrDefault)
+			os.Exit(exitcode.ErrGeneric)
 		}
 	}()
 

--- a/cmd/legacy/run_internal_test.go
+++ b/cmd/legacy/run_internal_test.go
@@ -32,10 +32,10 @@ func TestRunCmd_Err(t *testing.T) {
 	v := viper.New()
 
 	ret := runCmd(v, false, func(v *viper.Viper) (int, error) {
-		return exitcode.ErrDefault, errors.New("fail")
+		return exitcode.ErrGeneric, errors.New("fail")
 	})
 
-	assert.Equal(t, exitcode.ErrDefault, ret)
+	assert.Equal(t, exitcode.ErrGeneric, ret)
 }
 
 func TestRunCmd_ErrOfflineEnqueue(t *testing.T) {
@@ -89,10 +89,10 @@ func TestRunCmd_ErrOfflineEnqueue(t *testing.T) {
 	v.Set("plugin", "vim")
 
 	ret := runCmd(v, true, func(v *viper.Viper) (int, error) {
-		return exitcode.ErrDefault, offline.ErrOfflineEnqueue("fail")
+		return exitcode.ErrGeneric, offline.ErrOfflineEnqueue("fail")
 	})
 
-	assert.Equal(t, exitcode.ErrDefault, ret)
+	assert.Equal(t, exitcode.ErrGeneric, ret)
 }
 
 func jsonEscape(t *testing.T, i string) string {

--- a/cmd/legacy/today/today.go
+++ b/cmd/legacy/today/today.go
@@ -21,28 +21,28 @@ func Run(v *viper.Viper) (int, error) {
 		var errauth api.ErrAuth
 		if errors.As(err, &errauth) {
 			return exitcode.ErrAuth, fmt.Errorf(
-				"failed to fetch today: %s. Find your api key from wakatime.com/settings/api-key",
+				"invalid api key... find yours at wakatime.com/settings/api-key. %s",
 				errauth,
-			)
-		}
-
-		var errbadRequest api.ErrBadRequest
-		if errors.As(err, &errbadRequest) {
-			return exitcode.ErrDefault, fmt.Errorf(
-				"failed to fetch today due to api error: %s",
-				err,
 			)
 		}
 
 		var errapi api.Err
 		if errors.As(err, &errapi) {
 			return exitcode.ErrAPI, fmt.Errorf(
-				"failed to fetch today due to api error: %s",
+				"unable to fetch today due to api error: %s",
 				err,
 			)
 		}
 
-		return exitcode.ErrDefault, fmt.Errorf(
+		var errbadRequest api.ErrBadRequest
+		if errors.As(err, &errbadRequest) {
+			return exitcode.ErrGeneric, fmt.Errorf(
+				"failed to fetch today due to bad request: %s",
+				err,
+			)
+		}
+
+		return exitcode.ErrGeneric, fmt.Errorf(
 			"failed to fetch today: %s",
 			err,
 		)

--- a/cmd/legacy/todaygoal/todaygoal.go
+++ b/cmd/legacy/todaygoal/todaygoal.go
@@ -30,28 +30,28 @@ func Run(v *viper.Viper) (int, error) {
 		var errauth api.ErrAuth
 		if errors.As(err, &errauth) {
 			return exitcode.ErrAuth, fmt.Errorf(
-				"failed to fetch today goal: %s. Find your api key from wakatime.com/settings/api-key",
+				"invalid api key... find yours at wakatime.com/settings/api-key. %s",
 				errauth,
-			)
-		}
-
-		var errbadRequest api.ErrBadRequest
-		if errors.As(err, &errbadRequest) {
-			return exitcode.ErrDefault, fmt.Errorf(
-				"failed to fetch today goal due to api error: %s",
-				err,
 			)
 		}
 
 		var errapi api.Err
 		if errors.As(err, &errapi) {
 			return exitcode.ErrAPI, fmt.Errorf(
-				"failed to fetch today goal due to api error: %s",
+				"unable to fetch today goal due to api error: %s",
 				err,
 			)
 		}
 
-		return exitcode.ErrDefault, fmt.Errorf(
+		var errbadRequest api.ErrBadRequest
+		if errors.As(err, &errbadRequest) {
+			return exitcode.ErrGeneric, fmt.Errorf(
+				"failed to fetch today goal due to bad request: %s",
+				err,
+			)
+		}
+
+		return exitcode.ErrGeneric, fmt.Errorf(
 			"failed to fetch today goal: %s",
 			err,
 		)

--- a/main_test.go
+++ b/main_test.go
@@ -170,7 +170,7 @@ func TestSendHeartbeats_Err(t *testing.T) {
 		assert.JSONEq(t, string(expectedBody), string(body))
 
 		// write response
-		w.WriteHeader(http.StatusBadRequest)
+		w.WriteHeader(http.StatusBadGateway)
 	})
 
 	offlineQueueFile, err := ioutil.TempFile(os.TempDir(), "")
@@ -185,7 +185,7 @@ func TestSendHeartbeats_Err(t *testing.T) {
 
 	out := runWakatimeCliExpectErr(
 		t,
-		exitcode.ErrDefault,
+		exitcode.ErrAPI,
 		"--api-url", apiURL,
 		"--key", "00000000-0000-4000-8000-000000000000",
 		"--config", tmpFile.Name(),

--- a/pkg/api/diagnostic.go
+++ b/pkg/api/diagnostic.go
@@ -59,7 +59,7 @@ func (c *Client) SendDiagnostics(plugin string, diagnostics ...diagnostic.Diagno
 
 	resp, err := c.Do(req)
 	if err != nil {
-		return ErrRequest(fmt.Sprintf("failed making request to %q: %s", url, err))
+		return Err(fmt.Sprintf("failed making request to %q: %s", url, err))
 	}
 	defer resp.Body.Close()
 

--- a/pkg/api/error.go
+++ b/pkg/api/error.go
@@ -16,18 +16,10 @@ func (e ErrAuth) Error() string {
 	return string(e)
 }
 
-// ErrBadRequest represents a bad request error.
+// ErrBadRequest represents a 400 response from the API.
 type ErrBadRequest string
 
 // Error method to implement error interface.
 func (e ErrBadRequest) Error() string {
-	return string(e)
-}
-
-// ErrRequest represents a request failure, where no response was received from the api.
-type ErrRequest string
-
-// Error method to implement error interface.
-func (e ErrRequest) Error() string {
 	return string(e)
 }

--- a/pkg/api/goal.go
+++ b/pkg/api/goal.go
@@ -24,7 +24,7 @@ func (c *Client) Goal(id string) (*goal.Goal, error) {
 
 	resp, err := c.Do(req)
 	if err != nil {
-		return nil, ErrRequest(fmt.Sprintf("failed to make request to %q: %s", url, err))
+		return nil, Err(fmt.Sprintf("failed to make request to %q: %s", url, err))
 	}
 	defer resp.Body.Close()
 

--- a/pkg/api/goal_test.go
+++ b/pkg/api/goal_test.go
@@ -144,11 +144,11 @@ func TestClient_Goal_ErrBadRequest(t *testing.T) {
 	assert.Eventually(t, func() bool { return numCalls == 1 }, time.Second, 50*time.Millisecond)
 }
 
-func TestClient_Goal_ErrRequest(t *testing.T) {
+func TestClient_Goal_ErrInvalidUrl(t *testing.T) {
 	c := api.NewClient("invalid-url")
 	_, err := c.Goal("00000000-0000-4000-8000-000000000000")
 
-	var reqerr api.ErrRequest
+	var apierr api.Err
 
-	assert.True(t, errors.As(err, &reqerr))
+	assert.True(t, errors.As(err, &apierr))
 }

--- a/pkg/api/heartbeat.go
+++ b/pkg/api/heartbeat.go
@@ -41,7 +41,7 @@ func (c *Client) SendHeartbeats(heartbeats []heartbeat.Heartbeat) ([]heartbeat.R
 
 	resp, err := c.Do(req)
 	if err != nil {
-		return nil, ErrRequest(fmt.Sprintf("failed making request to %q: %s", url, err))
+		return nil, Err(fmt.Sprintf("failed making request to %q: %s", url, err))
 	}
 	defer resp.Body.Close()
 

--- a/pkg/api/heartbeat_test.go
+++ b/pkg/api/heartbeat_test.go
@@ -167,13 +167,13 @@ func TestClient_SendHeartbeats_ErrBadRequest(t *testing.T) {
 	assert.Eventually(t, func() bool { return numCalls == 1 }, time.Second, 50*time.Millisecond)
 }
 
-func TestClient_SendHeartbeats_ErrRequest(t *testing.T) {
+func TestClient_SendHeartbeats_InvalidUrl(t *testing.T) {
 	c := api.NewClient("invalid-url")
 	_, err := c.SendHeartbeats(testHeartbeats())
 
-	var errreq api.ErrRequest
+	var apierr api.Err
 
-	assert.True(t, errors.As(err, &errreq))
+	assert.True(t, errors.As(err, &apierr))
 }
 
 func TestParseHeartbeatResponses(t *testing.T) {

--- a/pkg/api/summary.go
+++ b/pkg/api/summary.go
@@ -19,7 +19,7 @@ func (c *Client) Today() (*summary.Summary, error) {
 
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %s", err)
+		return nil, Err(fmt.Sprintf("failed to create request: %s", err))
 	}
 
 	q := req.URL.Query()
@@ -27,7 +27,7 @@ func (c *Client) Today() (*summary.Summary, error) {
 
 	resp, err := c.Do(req)
 	if err != nil {
-		return nil, ErrRequest(fmt.Sprintf("failed to make request to %q: %s", url, err))
+		return nil, Err(fmt.Sprintf("failed to make request to %q: %s", url, err))
 	}
 	defer resp.Body.Close()
 

--- a/pkg/api/summary_test.go
+++ b/pkg/api/summary_test.go
@@ -181,13 +181,13 @@ func TestClient_Summary_ErrBadRequest(t *testing.T) {
 	assert.Eventually(t, func() bool { return numCalls == 1 }, time.Second, 50*time.Millisecond)
 }
 
-func TestClient_Summary_ErrRequest(t *testing.T) {
+func TestClient_Summary_InvalidUrl(t *testing.T) {
 	c := api.NewClient("invalid-url")
 	_, err := c.Today()
 
-	var reqerr api.ErrRequest
+	var apierr api.Err
 
-	assert.True(t, errors.As(err, &reqerr))
+	assert.True(t, errors.As(err, &apierr))
 }
 
 func TestParseSummaryResponse_DayTotal(t *testing.T) {

--- a/pkg/backoff/backoff.go
+++ b/pkg/backoff/backoff.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/wakatime/wakatime-cli/pkg/api"
 	"github.com/wakatime/wakatime-cli/pkg/config"
 	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 	"github.com/wakatime/wakatime-cli/pkg/ini"
@@ -40,7 +41,7 @@ func WithBackoff(c Config) heartbeat.HandleOption {
 			log.Debugln("execute heartbeat backoff algorithm")
 
 			if shouldBackoff(c.Retries, c.At) {
-				return nil, fmt.Errorf("won't send heartbeat due to backoff")
+				return nil, api.Err("won't send heartbeat due to backoff")
 			}
 
 			results, err := next(hh)
@@ -76,7 +77,7 @@ func shouldBackoff(retries int, at time.Time) bool {
 	duration := time.Duration(float64(factor)*math.Pow(2, float64(retries))) * time.Second
 
 	log.Debugf(
-		"exponential backoff tried %s times since %s, will retry at %s",
+		"exponential backoff tried %d times since %s, will retry at %s",
 		retries,
 		at.Format(time.Stamp),
 		at.Add(duration).Format(time.Stamp),

--- a/pkg/exitcode/exitcode.go
+++ b/pkg/exitcode/exitcode.go
@@ -3,8 +3,8 @@ package exitcode
 const (
 	// Success is used when a heartbeat was sent successfully.
 	Success = 0
-	// ErrDefault is used for general errors.
-	ErrDefault = 1
+	// ErrGeneric is used for general errors.
+	ErrGeneric = 1
 	// ErrAPI is when the WakaTime API returned an error.
 	ErrAPI = 102
 	// ErrAuth is used when the api key is invalid.


### PR DESCRIPTION
This prevents the IDE's status bar from showing `WakaTime Error` when working offline or having temporary connection issues, as long as the heartbeat was saved to the local offline db.