### PR TITLE
Stop using cgo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ build-all: build-darwin build-freebsd build-linux build-netbsd build-openbsd bui
 build-darwin: build-darwin-amd64 build-darwin-arm64
 
 build-darwin-amd64:
-	GOOS=darwin GOARCH=amd64 make build-binary-with-cgo
+	GOOS=darwin GOARCH=amd64 make build-binary
 
 build-darwin-arm64:
 	GOOS=darwin GOARCH=arm64 make build-binary
@@ -57,10 +57,10 @@ build-freebsd-arm:
 build-linux: build-linux-386 build-linux-amd64 build-linux-arm build-linux-arm64
 
 build-linux-386:
-	GOOS=linux GOARCH=386 make build-binary-with-cgo
+	GOOS=linux GOARCH=386 make build-binary
 
 build-linux-amd64:
-	GOOS=linux GOARCH=amd64 make build-binary-with-cgo
+	GOOS=linux GOARCH=amd64 make build-binary
 
 build-linux-arm:
 	GOOS=linux GOARCH=arm make build-binary
@@ -103,11 +103,6 @@ build-windows-amd64:
 
 build-binary:
 	CGO_ENABLED="0" GOOS=$(GOOS) GOARCH=$(GOARCH) $(GOBUILD) -v \
-		-ldflags "${LD_FLAGS} -X ${REPO}/pkg/version.OS=$(GOOS) -X ${REPO}/pkg/version.Arch=$(GOARCH)" \
-		-o ${BUILD_DIR}/$(BINARY_NAME)-$(GOOS)-$(GOARCH)
-
-build-binary-with-cgo:
-	CGO_ENABLED="1" GOOS=$(GOOS) GOARCH=$(GOARCH) $(GOBUILD) -v \
 		-ldflags "${LD_FLAGS} -X ${REPO}/pkg/version.OS=$(GOOS) -X ${REPO}/pkg/version.Arch=$(GOARCH)" \
 		-o ${BUILD_DIR}/$(BINARY_NAME)-$(GOOS)-$(GOARCH)
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	"github.com/wakatime/wakatime-cli/pkg/log"
@@ -128,10 +129,14 @@ func WakaHomeDir() (string, error) {
 		return home, nil
 	}
 
-	user, err := user.Current()
-	if err != nil {
-		return "", err
+	var allerrs error = err
+
+	u, err := user.LookupId(strconv.Itoa(os.Getuid()))
+	if err == nil && u.HomeDir != "" {
+		return u.HomeDir, nil
 	}
 
-	return user.HomeDir, nil
+	allerrs = fmt.Errorf("%s: %s", allerrs, err)
+
+	return "", allerrs
 }


### PR DESCRIPTION
This should still fix https://github.com/wakatime/vscode-wakatime/pull/238, except on Windows and Linux platforms.

Previous fix tried using CGO with #547, which would have been the more reliable way to detect a user's home folder except it caused build errors in other dependencies.