### PR TITLE
Separate INI file for internal configs

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -86,6 +86,7 @@ projects/foo = new project name
 
 For commonly used configuration options, see examples in the [FAQ](https://wakatime.com/faq).
 
-### Internal Section
+## Internal INI Config File
 
-This section is reserved for internal plugin configs, like caching GitHub API requests when checking for wakatime-cli updates.
+The plugins and waktime-cli use a separate internal INI file for things like caching auto-update requests to the GitHub releases API, and exponential backoff to the WakaTime API.
+The default internal INI config file location is `$WAKATIME_HOME/.wakatime-internal.cfg`.

--- a/cmd/legacy/legacyparams/testdata/internal-malformed-backoff.cfg
+++ b/cmd/legacy/legacyparams/testdata/internal-malformed-backoff.cfg
@@ -1,0 +1,3 @@
+[internal]
+backoff_at = 2021-08-30
+backoff_retries = 2

--- a/cmd/legacy/legacyparams/testdata/internal-with-backoff.cfg
+++ b/cmd/legacy/legacyparams/testdata/internal-with-backoff.cfg
@@ -1,0 +1,3 @@
+[internal]
+backoff_at = 2021-08-30T18:50:42-03:00
+backoff_retries = 3

--- a/cmd/legacy/run.go
+++ b/cmd/legacy/run.go
@@ -32,7 +32,12 @@ import (
 
 // Run executes legacy commands following the interface of the old python implementation of the WakaTime script.
 func Run(cmd *cobra.Command, v *viper.Viper) {
-	if err := config.ReadInConfig(v, config.FilePath); err != nil {
+	configFile, err := config.FilePath(v)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error getting config file path: %s", err)
+	}
+
+	if err := config.ReadInConfig(v, configFile); err != nil {
 		fmt.Fprintf(os.Stderr, "failed to load configuration file: %s", err)
 
 		os.Exit(exitcode.ErrConfigFileParse)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -58,6 +58,7 @@ func setFlags(cmd *cobra.Command, v *viper.Viper) {
 			" \"browsing\", or \"designing\". Defaults to \"coding\".",
 	)
 	flags.String("config", "", "Optional config file. Defaults to '~/.wakatime.cfg'.")
+	flags.String("internal-config", "", "Optional internal config file. Defaults to '~/.wakatime-internal.cfg'.")
 	flags.String("config-read", "", "Prints value for the given config key, then exits.")
 	flags.String(
 		"config-section",

--- a/pkg/backoff/backoff.go
+++ b/pkg/backoff/backoff.go
@@ -87,38 +87,28 @@ func shouldBackoff(retries int, at time.Time) bool {
 }
 
 func updateBackoffSettings(v *viper.Viper, retries int, at time.Time) error {
-	values := []ini.Item{}
-
-	values = append(values, ini.Item{
-		Key: ini.Key{
+	keys := map[ini.Key]string{
+		{
 			Section: "internal",
 			Name:    "backoff_retries",
-		},
-		Value: strconv.Itoa(retries),
-	})
-
-	if !at.IsZero() {
-		values = append(values, ini.Item{
-			Key: ini.Key{
-				Section: "internal",
-				Name:    "backoff_at",
-			},
-			Value: at.Format(config.DateFormat),
-		})
-	} else {
-		values = append(values, ini.Item{
-			Key: ini.Key{
-				Section: "internal",
-				Name:    "backoff_at",
-			},
-			Value: "",
-		})
+		}: strconv.Itoa(retries),
+		{
+			Section: "internal",
+			Name:    "backoff_at",
+		}: "",
 	}
 
-	iniFile, err := config.FilePath(v)
+	if !at.IsZero() {
+		keys[ini.Key{
+			Section: "internal",
+			Name:    "backoff_at",
+		}] = at.Format(config.DateFormat)
+	}
+
+	iniFile, err := config.InternalFilePath(v)
 	if err != nil {
 		return fmt.Errorf("error getting filepath: %s", err)
 	}
 
-	return ini.SetKeys(iniFile, values)
+	return ini.SetKeys(iniFile, keys)
 }

--- a/pkg/backoff/backoff_internal_test.go
+++ b/pkg/backoff/backoff_internal_test.go
@@ -46,6 +46,7 @@ func TestUpdateBackoffSettings(t *testing.T) {
 	defer os.Remove(tmpFile.Name())
 
 	v.Set("config", tmpFile.Name())
+	v.Set("internal-config", tmpFile.Name())
 
 	at := time.Now().Add(time.Second * -1)
 
@@ -73,6 +74,7 @@ func TestUpdateBackoffSettings_NotInBackoff(t *testing.T) {
 	defer os.Remove(tmpFile.Name())
 
 	v.Set("config", tmpFile.Name())
+	v.Set("internal-config", tmpFile.Name())
 
 	err = updateBackoffSettings(v, 0, time.Time{})
 	require.NoError(t, err)
@@ -96,6 +98,7 @@ func TestUpdateBackoffSettings_NoMultilineSideEffects(t *testing.T) {
 	defer os.Remove(tmpFile.Name())
 
 	v.Set("config", tmpFile.Name())
+	v.Set("internal-config", tmpFile.Name())
 
 	copyFile(t, "testdata/multiline.cfg", tmpFile.Name())
 
@@ -112,10 +115,8 @@ func TestUpdateBackoffSettings_NoMultilineSideEffects(t *testing.T) {
 	assert.Empty(t, writer.File.Section("internal").Key("backoff_at").String())
 	assert.Equal(t, "0", writer.File.Section("internal").Key("backoff_retries").String())
 
-	item, err := ini.GetKey(tmpFile.Name(), ini.Key{Section: "settings", Name: "ignore"})
-	require.NoError(t, err)
-
-	assert.Equal(t, "\n one\n two", item.Value)
+	value := ini.GetKey(tmpFile.Name(), ini.Key{Section: "settings", Name: "ignore"})
+	assert.Equal(t, "\n one\n two", value)
 
 	actual, err := ioutil.ReadFile(tmpFile.Name())
 	require.NoError(t, err)

--- a/pkg/config/testdata/malformed.cfg
+++ b/pkg/config/testdata/malformed.cfg
@@ -1,0 +1,5 @@
+[settings
+debug = true
+
+[test]
+this = that


### PR DESCRIPTION
Fixes #535.

Defaults to using `~/.wakatime-internal.cfg` for all internal configs.