### PR TITLE
Move from deprecated ioutil to os and io packages

### DIFF
--- a/cmd/legacy/configwrite/configwrite_test.go
+++ b/cmd/legacy/configwrite/configwrite_test.go
@@ -3,7 +3,6 @@ package configwrite_test
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -68,7 +67,7 @@ func TestLoadParamsErr(t *testing.T) {
 }
 
 func TestWrite(t *testing.T) {
-	tmpFile, err := ioutil.TempFile(os.TempDir(), "wakatime")
+	tmpFile, err := os.CreateTemp(os.TempDir(), "wakatime")
 	require.NoError(t, err)
 
 	defer os.Remove(tmpFile.Name())

--- a/cmd/legacy/heartbeat/heartbeat_test.go
+++ b/cmd/legacy/heartbeat/heartbeat_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -42,10 +41,10 @@ func TestSendHeartbeats(t *testing.T) {
 			plugin,
 		))
 
-		expectedBody, err := ioutil.ReadFile("testdata/api_heartbeats_request_template.json")
+		expectedBody, err := os.ReadFile("testdata/api_heartbeats_request_template.json")
 		require.NoError(t, err)
 
-		body, err := ioutil.ReadAll(req.Body)
+		body, err := io.ReadAll(req.Body)
 		require.NoError(t, err)
 
 		var entity struct {
@@ -92,7 +91,7 @@ func TestSendHeartbeats(t *testing.T) {
 	v.Set("timeout", 5)
 	v.Set("write", true)
 
-	f, err := ioutil.TempFile(os.TempDir(), "")
+	f, err := os.CreateTemp(os.TempDir(), "")
 	require.NoError(t, err)
 
 	defer os.Remove(f.Name())
@@ -128,7 +127,7 @@ func TestSendHeartbeats_WithFiltering_Exclude(t *testing.T) {
 	v.Set("timeout", 5)
 	v.Set("write", true)
 
-	f, err := ioutil.TempFile(os.TempDir(), "")
+	f, err := os.CreateTemp(os.TempDir(), "")
 	require.NoError(t, err)
 
 	defer os.Remove(f.Name())
@@ -150,10 +149,10 @@ func TestSendHeartbeats_ExtraHeartbeats(t *testing.T) {
 
 	router.HandleFunc("/users/current/heartbeats.bulk", func(w http.ResponseWriter, req *http.Request) {
 		// check request
-		expectedBody, err := ioutil.ReadFile("testdata/api_heartbeats_request_extra_heartbeats_template.json")
+		expectedBody, err := os.ReadFile("testdata/api_heartbeats_request_extra_heartbeats_template.json")
 		require.NoError(t, err)
 
-		body, err := ioutil.ReadAll(req.Body)
+		body, err := io.ReadAll(req.Body)
 		require.NoError(t, err)
 
 		var entities []struct {
@@ -206,7 +205,7 @@ func TestSendHeartbeats_ExtraHeartbeats(t *testing.T) {
 
 	os.Stdin = r
 
-	data, err := ioutil.ReadFile("testdata/extra_heartbeats.json")
+	data, err := os.ReadFile("testdata/extra_heartbeats.json")
 	require.NoError(t, err)
 
 	go func() {
@@ -235,7 +234,7 @@ func TestSendHeartbeats_ExtraHeartbeats(t *testing.T) {
 	v.Set("timeout", 5)
 	v.Set("write", true)
 
-	f, err := ioutil.TempFile(os.TempDir(), "")
+	f, err := os.CreateTemp(os.TempDir(), "")
 	require.NoError(t, err)
 
 	defer os.Remove(f.Name())
@@ -247,7 +246,7 @@ func TestSendHeartbeats_ExtraHeartbeats(t *testing.T) {
 }
 
 func TestSendHeartbeats_NonExistingEntity(t *testing.T) {
-	logFile, err := ioutil.TempFile(os.TempDir(), "")
+	logFile, err := os.CreateTemp(os.TempDir(), "")
 	require.NoError(t, err)
 
 	defer os.Remove(logFile.Name())
@@ -262,7 +261,7 @@ func TestSendHeartbeats_NonExistingEntity(t *testing.T) {
 
 	legacy.SetupLogging(v)
 
-	f, err := ioutil.TempFile(os.TempDir(), "")
+	f, err := os.CreateTemp(os.TempDir(), "")
 	require.NoError(t, err)
 
 	defer os.Remove(f.Name())
@@ -270,7 +269,7 @@ func TestSendHeartbeats_NonExistingEntity(t *testing.T) {
 	err = cmd.SendHeartbeats(v, f.Name())
 	require.NoError(t, err)
 
-	output, err := ioutil.ReadAll(logFile)
+	output, err := io.ReadAll(logFile)
 	require.NoError(t, err)
 
 	assert.Contains(t, string(output), "file 'nonexisting' does not exist. ignoring this heartbeat")
@@ -291,7 +290,7 @@ func TestSendHeartbeats_NonExistingExtraHeartbeatsEntity(t *testing.T) {
 
 	os.Stdin = inr
 
-	data, err := ioutil.ReadFile("testdata/extra_heartbeats_nonexisting_entity.json")
+	data, err := os.ReadFile("testdata/extra_heartbeats_nonexisting_entity.json")
 	require.NoError(t, err)
 
 	go func() {
@@ -301,7 +300,7 @@ func TestSendHeartbeats_NonExistingExtraHeartbeatsEntity(t *testing.T) {
 		inw.Close()
 	}()
 
-	logFile, err := ioutil.TempFile(os.TempDir(), "")
+	logFile, err := os.CreateTemp(os.TempDir(), "")
 	require.NoError(t, err)
 
 	defer os.Remove(logFile.Name())
@@ -318,7 +317,7 @@ func TestSendHeartbeats_NonExistingExtraHeartbeatsEntity(t *testing.T) {
 
 	legacy.SetupLogging(v)
 
-	f, err := ioutil.TempFile(os.TempDir(), "")
+	f, err := os.CreateTemp(os.TempDir(), "")
 	require.NoError(t, err)
 
 	defer os.Remove(f.Name())
@@ -326,7 +325,7 @@ func TestSendHeartbeats_NonExistingExtraHeartbeatsEntity(t *testing.T) {
 	err = cmd.SendHeartbeats(v, f.Name())
 	require.NoError(t, err)
 
-	output, err := ioutil.ReadAll(logFile)
+	output, err := io.ReadAll(logFile)
 	require.NoError(t, err)
 
 	assert.Contains(t, string(output), "file 'nonexisting' does not exist. ignoring this extra heartbeat")

--- a/cmd/legacy/heartbeat/params_test.go
+++ b/cmd/legacy/heartbeat/params_test.go
@@ -2,7 +2,6 @@ package heartbeat_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -241,7 +240,7 @@ func TestLoadParams_ExtraHeartbeats(t *testing.T) {
 
 	os.Stdin = r
 
-	data, err := ioutil.ReadFile("testdata/extra_heartbeats.json")
+	data, err := os.ReadFile("testdata/extra_heartbeats.json")
 	require.NoError(t, err)
 
 	go func() {
@@ -314,7 +313,7 @@ func TestLoadParams_ExtraHeartbeats_WithStringValues(t *testing.T) {
 
 	os.Stdin = r
 
-	data, err := ioutil.ReadFile("testdata/extra_heartbeats_with_string_values.json")
+	data, err := os.ReadFile("testdata/extra_heartbeats_with_string_values.json")
 	require.NoError(t, err)
 
 	go func() {

--- a/cmd/legacy/legacyparams/params_test.go
+++ b/cmd/legacy/legacyparams/params_test.go
@@ -2,7 +2,6 @@ package legacyparams_test
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -347,7 +346,7 @@ func TestLoad_API_BackoffAt(t *testing.T) {
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("hostname", "my-computer")
 
-	tmpFile, err := ioutil.TempFile(os.TempDir(), "wakatime")
+	tmpFile, err := os.CreateTemp(os.TempDir(), "wakatime")
 	require.NoError(t, err)
 
 	defer os.Remove(tmpFile.Name())
@@ -377,7 +376,7 @@ func TestLoad_API_BackoffAtErr(t *testing.T) {
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("hostname", "my-computer")
 
-	tmpFile, err := ioutil.TempFile(os.TempDir(), "wakatime")
+	tmpFile, err := os.CreateTemp(os.TempDir(), "wakatime")
 	require.NoError(t, err)
 
 	defer os.Remove(tmpFile.Name())
@@ -613,9 +612,9 @@ func TestLoadParams_Hostname_DefaultFromSystem(t *testing.T) {
 }
 
 func copyFile(t *testing.T, source, destination string) {
-	input, err := ioutil.ReadFile(source)
+	input, err := os.ReadFile(source)
 	require.NoError(t, err)
 
-	err = ioutil.WriteFile(destination, input, 0600)
+	err = os.WriteFile(destination, input, 0600)
 	require.NoError(t, err)
 }

--- a/cmd/legacy/logfile/logfile_test.go
+++ b/cmd/legacy/logfile/logfile_test.go
@@ -1,7 +1,6 @@
 package logfile_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -14,7 +13,7 @@ import (
 )
 
 func TestLoadParams(t *testing.T) {
-	tmpFile, err := ioutil.TempFile(os.TempDir(), "wakatime.log")
+	tmpFile, err := os.CreateTemp(os.TempDir(), "wakatime.log")
 	require.NoError(t, err)
 
 	defer os.Remove(tmpFile.Name())

--- a/cmd/legacy/offlinecount/offlinecount_test.go
+++ b/cmd/legacy/offlinecount/offlinecount_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -18,7 +17,7 @@ import (
 
 func TestOfflineCount_Empty(t *testing.T) {
 	// setup offline queue
-	f, err := ioutil.TempFile(os.TempDir(), "")
+	f, err := os.CreateTemp(os.TempDir(), "")
 	require.NoError(t, err)
 
 	defer os.Remove(f.Name())
@@ -64,7 +63,7 @@ func TestOfflineCount_Empty(t *testing.T) {
 
 func TestOfflineCount(t *testing.T) {
 	// setup offline queue
-	f, err := ioutil.TempFile(os.TempDir(), "")
+	f, err := os.CreateTemp(os.TempDir(), "")
 	require.NoError(t, err)
 
 	defer os.Remove(f.Name())
@@ -72,10 +71,10 @@ func TestOfflineCount(t *testing.T) {
 	db, err := bolt.Open(f.Name(), 0600, nil)
 	require.NoError(t, err)
 
-	dataGo, err := ioutil.ReadFile("../testdata/heartbeat_go.json")
+	dataGo, err := os.ReadFile("../testdata/heartbeat_go.json")
 	require.NoError(t, err)
 
-	dataPy, err := ioutil.ReadFile("../testdata/heartbeat_py.json")
+	dataPy, err := os.ReadFile("../testdata/heartbeat_py.json")
 	require.NoError(t, err)
 
 	insertHeartbeatRecords(t, db, "heartbeats", []heartbeatRecord{

--- a/cmd/legacy/offlinesync/offlinesync_test.go
+++ b/cmd/legacy/offlinesync/offlinesync_test.go
@@ -3,7 +3,6 @@ package offlinesync_test
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -42,10 +41,10 @@ func TestSyncOfflineActivity(t *testing.T) {
 			plugin,
 		))
 
-		expectedBody, err := ioutil.ReadFile("testdata/api_heartbeats_request_template.json")
+		expectedBody, err := os.ReadFile("testdata/api_heartbeats_request_template.json")
 		require.NoError(t, err)
 
-		body, err := ioutil.ReadAll(req.Body)
+		body, err := io.ReadAll(req.Body)
 		require.NoError(t, err)
 
 		assert.JSONEq(t, string(expectedBody), string(body))
@@ -62,7 +61,7 @@ func TestSyncOfflineActivity(t *testing.T) {
 	})
 
 	// setup offline queue
-	f, err := ioutil.TempFile(os.TempDir(), "")
+	f, err := os.CreateTemp(os.TempDir(), "")
 	require.NoError(t, err)
 
 	defer os.Remove(f.Name())
@@ -70,13 +69,13 @@ func TestSyncOfflineActivity(t *testing.T) {
 	db, err := bolt.Open(f.Name(), 0600, nil)
 	require.NoError(t, err)
 
-	dataGo, err := ioutil.ReadFile("testdata/heartbeat_go.json")
+	dataGo, err := os.ReadFile("testdata/heartbeat_go.json")
 	require.NoError(t, err)
 
-	dataPy, err := ioutil.ReadFile("testdata/heartbeat_py.json")
+	dataPy, err := os.ReadFile("testdata/heartbeat_py.json")
 	require.NoError(t, err)
 
-	dataJs, err := ioutil.ReadFile("testdata/heartbeat_js.json")
+	dataJs, err := os.ReadFile("testdata/heartbeat_js.json")
 	require.NoError(t, err)
 
 	insertHeartbeatRecords(t, db, "heartbeats", []heartbeatRecord{

--- a/cmd/legacy/run_internal_test.go
+++ b/cmd/legacy/run_internal_test.go
@@ -4,9 +4,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/wakatime/wakatime-cli/pkg/exitcode"
@@ -52,10 +53,10 @@ func TestRunCmd_ErrOfflineEnqueue(t *testing.T) {
 		assert.Nil(t, req.Header["Authorization"])
 		assert.Equal(t, []string{"application/json"}, req.Header["Content-Type"])
 
-		expectedBodyTpl, err := ioutil.ReadFile("testdata/diagnostics_request_template.json")
+		expectedBodyTpl, err := os.ReadFile("testdata/diagnostics_request_template.json")
 		require.NoError(t, err)
 
-		body, err := ioutil.ReadAll(req.Body)
+		body, err := io.ReadAll(req.Body)
 		require.NoError(t, err)
 
 		var diagnostics struct {

--- a/cmd/legacy/run_test.go
+++ b/cmd/legacy/run_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -29,12 +28,12 @@ func TestRunCmd_SendDiagnostics_Error(t *testing.T) {
 		version.Arch = "some architecture"
 		version.Version = "some version"
 
-		offlineQueueFile, err := ioutil.TempFile(os.TempDir(), "")
+		offlineQueueFile, err := os.CreateTemp(os.TempDir(), "")
 		require.NoError(t, err)
 
 		defer os.Remove(offlineQueueFile.Name())
 
-		logFile, err := ioutil.TempFile(os.TempDir(), "")
+		logFile, err := os.CreateTemp(os.TempDir(), "")
 		require.NoError(t, err)
 
 		defer os.Remove(logFile.Name())
@@ -64,10 +63,10 @@ func TestRunCmd_SendDiagnostics_Error(t *testing.T) {
 		assert.Nil(t, req.Header["Authorization"])
 		assert.Equal(t, []string{"application/json"}, req.Header["Content-Type"])
 
-		expectedBodyTpl, err := ioutil.ReadFile("testdata/diagnostics_request_template.json")
+		expectedBodyTpl, err := os.ReadFile("testdata/diagnostics_request_template.json")
 		require.NoError(t, err)
 
-		body, err := ioutil.ReadAll(req.Body)
+		body, err := io.ReadAll(req.Body)
 		require.NoError(t, err)
 
 		var diagnostics struct {
@@ -114,12 +113,12 @@ func TestRunCmd_SendDiagnostics_Panic(t *testing.T) {
 		version.Arch = "some architecture"
 		version.Version = "some version"
 
-		offlineQueueFile, err := ioutil.TempFile(os.TempDir(), "")
+		offlineQueueFile, err := os.CreateTemp(os.TempDir(), "")
 		require.NoError(t, err)
 
 		defer os.Remove(offlineQueueFile.Name())
 
-		logFile, err := ioutil.TempFile(os.TempDir(), "")
+		logFile, err := os.CreateTemp(os.TempDir(), "")
 		require.NoError(t, err)
 
 		defer os.Remove(logFile.Name())
@@ -149,10 +148,10 @@ func TestRunCmd_SendDiagnostics_Panic(t *testing.T) {
 		assert.Nil(t, req.Header["Authorization"])
 		assert.Equal(t, []string{"application/json"}, req.Header["Content-Type"])
 
-		expectedBodyTpl, err := ioutil.ReadFile("testdata/diagnostics_request_template_no_logs.json")
+		expectedBodyTpl, err := os.ReadFile("testdata/diagnostics_request_template_no_logs.json")
 		require.NoError(t, err)
 
-		body, err := ioutil.ReadAll(req.Body)
+		body, err := io.ReadAll(req.Body)
 		require.NoError(t, err)
 
 		var diagnostics struct {
@@ -198,7 +197,7 @@ func TestRunCmdWithOfflineSync(t *testing.T) {
 		version.Arch = "some architecture"
 		version.Version = "some version"
 
-		logFile, err := ioutil.TempFile(os.TempDir(), "")
+		logFile, err := os.CreateTemp(os.TempDir(), "")
 		require.NoError(t, err)
 
 		defer os.Remove(logFile.Name())
@@ -221,7 +220,7 @@ func TestRunCmdWithOfflineSync(t *testing.T) {
 	}
 
 	// setup test queue
-	offlineQueueFile, err := ioutil.TempFile(os.TempDir(), "")
+	offlineQueueFile, err := os.CreateTemp(os.TempDir(), "")
 	require.NoError(t, err)
 
 	defer os.RemoveAll(offlineQueueFile.Name())
@@ -229,10 +228,10 @@ func TestRunCmdWithOfflineSync(t *testing.T) {
 	db, err := bolt.Open(offlineQueueFile.Name(), 0600, nil)
 	require.NoError(t, err)
 
-	dataGo, err := ioutil.ReadFile("testdata/heartbeat_go.json")
+	dataGo, err := os.ReadFile("testdata/heartbeat_go.json")
 	require.NoError(t, err)
 
-	dataPy, err := ioutil.ReadFile("testdata/heartbeat_py.json")
+	dataPy, err := os.ReadFile("testdata/heartbeat_py.json")
 	require.NoError(t, err)
 
 	insertHeartbeatRecords(t, db, "heartbeats", []heartbeatRecord{
@@ -263,10 +262,10 @@ func TestRunCmdWithOfflineSync(t *testing.T) {
 		assert.Equal(t, []string{"application/json"}, req.Header["Content-Type"])
 
 		// check body
-		expectedBody, err := ioutil.ReadFile("testdata/api_heartbeats_request.json")
+		expectedBody, err := os.ReadFile("testdata/api_heartbeats_request.json")
 		require.NoError(t, err)
 
-		body, err := ioutil.ReadAll(req.Body)
+		body, err := io.ReadAll(req.Body)
 		require.NoError(t, err)
 
 		assert.JSONEq(t, string(expectedBody), string(body))

--- a/cmd/legacy/today/today_test.go
+++ b/cmd/legacy/today/today_test.go
@@ -3,9 +3,9 @@ package today_test
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -41,7 +41,7 @@ func TestToday(t *testing.T) {
 		))
 
 		// write response
-		data, err := ioutil.ReadFile("testdata/api_statusbar_today_response_template.json")
+		data, err := os.ReadFile("testdata/api_statusbar_today_response_template.json")
 		require.NoError(t, err)
 
 		_, err = w.Write([]byte(string(data)))

--- a/cmd/legacy/todaygoal/todaygoal_test.go
+++ b/cmd/legacy/todaygoal/todaygoal_test.go
@@ -3,9 +3,9 @@ package todaygoal_test
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -42,7 +42,7 @@ func TestGoal(t *testing.T) {
 			))
 
 			// write response
-			data, err := ioutil.ReadFile("testdata/api_goals_id_response.json")
+			data, err := os.ReadFile("testdata/api_goals_id_response.json")
 			require.NoError(t, err)
 
 			_, err = w.Write([]byte(string(data)))

--- a/main_test.go
+++ b/main_test.go
@@ -210,7 +210,7 @@ func TestTodayGoal(t *testing.T) {
 
 	var numCalls int
 
-	tmpFile, err := os.MkdirTemp(os.TempDir(), "wakatime.cfg")
+	tmpFile, err := os.CreateTemp(os.TempDir(), "wakatime.cfg")
 	require.NoError(t, err)
 
 	defer os.Remove(tmpFile.Name())

--- a/main_test.go
+++ b/main_test.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -76,7 +75,7 @@ func testSendHeartbeats(t *testing.T, entity, project string) {
 		assert.Equal(t, []string{heartbeat.UserAgentUnknownPlugin()}, req.Header["User-Agent"])
 
 		// check body
-		expectedBodyTpl, err := ioutil.ReadFile("testdata/api_heartbeats_request.json.tpl")
+		expectedBodyTpl, err := os.ReadFile("testdata/api_heartbeats_request.json.tpl")
 		require.NoError(t, err)
 
 		entityPath, err := realpath.Realpath(entity)
@@ -90,7 +89,7 @@ func testSendHeartbeats(t *testing.T, entity, project string) {
 			heartbeat.UserAgentUnknownPlugin(),
 		)
 
-		body, err := ioutil.ReadAll(req.Body)
+		body, err := io.ReadAll(req.Body)
 		require.NoError(t, err)
 
 		assert.JSONEq(t, string(expectedBody), string(body))
@@ -104,12 +103,12 @@ func testSendHeartbeats(t *testing.T, entity, project string) {
 		require.NoError(t, err)
 	})
 
-	offlineQueueFile, err := ioutil.TempFile(os.TempDir(), "")
+	offlineQueueFile, err := os.CreateTemp(os.TempDir(), "")
 	require.NoError(t, err)
 
 	defer os.Remove(offlineQueueFile.Name())
 
-	tmpFile, err := ioutil.TempFile(os.TempDir(), "wakatime.cfg")
+	tmpFile, err := os.CreateTemp(os.TempDir(), "wakatime.cfg")
 	require.NoError(t, err)
 
 	defer os.Remove(tmpFile.Name())
@@ -150,7 +149,7 @@ func TestSendHeartbeats_Err(t *testing.T) {
 		assert.Equal(t, []string{heartbeat.UserAgentUnknownPlugin()}, req.Header["User-Agent"])
 
 		// check body
-		expectedBodyTpl, err := ioutil.ReadFile("testdata/api_heartbeats_request.json.tpl")
+		expectedBodyTpl, err := os.ReadFile("testdata/api_heartbeats_request.json.tpl")
 		require.NoError(t, err)
 
 		entityPath, err := realpath.Realpath("testdata/main.go")
@@ -164,7 +163,7 @@ func TestSendHeartbeats_Err(t *testing.T) {
 			heartbeat.UserAgentUnknownPlugin(),
 		)
 
-		body, err := ioutil.ReadAll(req.Body)
+		body, err := io.ReadAll(req.Body)
 		require.NoError(t, err)
 
 		assert.JSONEq(t, string(expectedBody), string(body))
@@ -173,12 +172,12 @@ func TestSendHeartbeats_Err(t *testing.T) {
 		w.WriteHeader(http.StatusBadGateway)
 	})
 
-	offlineQueueFile, err := ioutil.TempFile(os.TempDir(), "")
+	offlineQueueFile, err := os.CreateTemp(os.TempDir(), "")
 	require.NoError(t, err)
 
 	defer os.Remove(offlineQueueFile.Name())
 
-	tmpFile, err := ioutil.TempFile(os.TempDir(), "wakatime.cfg")
+	tmpFile, err := os.CreateTemp(os.TempDir(), "wakatime.cfg")
 	require.NoError(t, err)
 
 	defer os.Remove(tmpFile.Name())
@@ -211,7 +210,7 @@ func TestTodayGoal(t *testing.T) {
 
 	var numCalls int
 
-	tmpFile, err := ioutil.TempFile(os.TempDir(), "wakatime.cfg")
+	tmpFile, err := os.MkdirTemp(os.TempDir(), "wakatime.cfg")
 	require.NoError(t, err)
 
 	defer os.Remove(tmpFile.Name())
@@ -255,7 +254,7 @@ func TestTodaySummary(t *testing.T) {
 
 	var numCalls int
 
-	tmpFile, err := ioutil.TempFile(os.TempDir(), "wakatime.cfg")
+	tmpFile, err := os.CreateTemp(os.TempDir(), "wakatime.cfg")
 	require.NoError(t, err)
 
 	defer os.Remove(tmpFile.Name())
@@ -293,7 +292,7 @@ func TestTodaySummary(t *testing.T) {
 }
 
 func TestOfflineCountEmpty(t *testing.T) {
-	offlineQueueFile, err := ioutil.TempFile(os.TempDir(), "")
+	offlineQueueFile, err := os.CreateTemp(os.TempDir(), "")
 	require.NoError(t, err)
 
 	defer os.Remove(offlineQueueFile.Name())
@@ -319,12 +318,12 @@ func TestOfflineCountWithOneHeartbeat(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	offlineQueueFile, err := ioutil.TempFile(os.TempDir(), "")
+	offlineQueueFile, err := os.CreateTemp(os.TempDir(), "")
 	require.NoError(t, err)
 
 	defer os.Remove(offlineQueueFile.Name())
 
-	tmpFile, err := ioutil.TempFile(os.TempDir(), "wakatime.cfg")
+	tmpFile, err := os.CreateTemp(os.TempDir(), "wakatime.cfg")
 	require.NoError(t, err)
 
 	defer os.Remove(tmpFile.Name())
@@ -388,12 +387,12 @@ func TestVersionVerbose(t *testing.T) {
 }
 
 func runWakatimeCli(t *testing.T, args ...string) string {
-	f, err := ioutil.TempFile(os.TempDir(), "")
+	f, err := os.CreateTemp(os.TempDir(), "")
 	require.NoError(t, err)
 
 	defer func() {
 		f.Close()
-		data, err := ioutil.ReadFile(f.Name())
+		data, err := os.ReadFile(f.Name())
 		require.NoError(t, err)
 
 		fmt.Printf("logs: %s\n", string(data))
@@ -407,12 +406,12 @@ func runWakatimeCli(t *testing.T, args ...string) string {
 }
 
 func runWakatimeCliExpectErr(t *testing.T, exitcode int, args ...string) string {
-	f, err := ioutil.TempFile(os.TempDir(), "")
+	f, err := os.CreateTemp(os.TempDir(), "")
 	require.NoError(t, err)
 
 	defer func() {
 		f.Close()
-		data, err := ioutil.ReadFile(f.Name())
+		data, err := os.ReadFile(f.Name())
 		require.NoError(t, err)
 
 		fmt.Printf("logs: %s\n", string(data))

--- a/pkg/api/diagnostic.go
+++ b/pkg/api/diagnostic.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/wakatime/wakatime-cli/pkg/diagnostic"
@@ -63,7 +63,7 @@ func (c *Client) SendDiagnostics(plugin string, diagnostics ...diagnostic.Diagno
 	}
 	defer resp.Body.Close()
 
-	respBody, err := ioutil.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return Err(fmt.Sprintf("failed reading response body from %q: %s", url, err))
 	}

--- a/pkg/api/diagnostic_test.go
+++ b/pkg/api/diagnostic_test.go
@@ -1,8 +1,9 @@
 package api_test
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
+	"os"
 	"testing"
 	"time"
 
@@ -29,10 +30,10 @@ func TestClient_SendDiagnostics(t *testing.T) {
 		assert.Nil(t, req.Header["Authorization"])
 
 		// check body
-		expectedBody, err := ioutil.ReadFile("testdata/diagnostics_request.json")
+		expectedBody, err := os.ReadFile("testdata/diagnostics_request.json")
 		require.NoError(t, err)
 
-		body, err := ioutil.ReadAll(req.Body)
+		body, err := io.ReadAll(req.Body)
 		require.NoError(t, err)
 
 		assert.JSONEq(t, string(expectedBody), string(body))

--- a/pkg/api/goal.go
+++ b/pkg/api/goal.go
@@ -3,7 +3,7 @@ package api
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/wakatime/wakatime-cli/pkg/goal"
@@ -28,7 +28,7 @@ func (c *Client) Goal(id string) (*goal.Goal, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, Err(fmt.Sprintf("failed to read response body from %q: %s", url, err))
 	}

--- a/pkg/api/heartbeat.go
+++ b/pkg/api/heartbeat.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -45,7 +45,7 @@ func (c *Client) SendHeartbeats(heartbeats []heartbeat.Heartbeat) ([]heartbeat.R
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, Err(fmt.Sprintf("failed reading response body from %q: %s", url, err))
 	}

--- a/pkg/api/heartbeat_test.go
+++ b/pkg/api/heartbeat_test.go
@@ -3,7 +3,6 @@ package api_test
 import (
 	"errors"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"testing"
@@ -38,10 +37,10 @@ func TestClient_SendHeartbeats(t *testing.T) {
 				assert.Equal(t, []string{"application/json"}, req.Header["Content-Type"])
 
 				// check body
-				expectedBody, err := ioutil.ReadFile("testdata/api_heartbeats_request.json")
+				expectedBody, err := os.ReadFile("testdata/api_heartbeats_request.json")
 				require.NoError(t, err)
 
-				body, err := ioutil.ReadAll(req.Body)
+				body, err := io.ReadAll(req.Body)
 				require.NoError(t, err)
 
 				assert.JSONEq(t, string(expectedBody), string(body))
@@ -177,7 +176,7 @@ func TestClient_SendHeartbeats_InvalidUrl(t *testing.T) {
 }
 
 func TestParseHeartbeatResponses(t *testing.T) {
-	data, err := ioutil.ReadFile("testdata/api_heartbeats_response.json")
+	data, err := os.ReadFile("testdata/api_heartbeats_response.json")
 	require.NoError(t, err)
 
 	results, err := api.ParseHeartbeatResponses(data)
@@ -225,7 +224,7 @@ func TestParseHeartbeatResponses(t *testing.T) {
 }
 
 func TestParseHeartbeatResponses_Error(t *testing.T) {
-	data, err := ioutil.ReadFile("testdata/api_heartbeats_response_error.json")
+	data, err := os.ReadFile("testdata/api_heartbeats_response_error.json")
 	require.NoError(t, err)
 
 	results, err := api.ParseHeartbeatResponses(data)
@@ -246,7 +245,7 @@ func TestParseHeartbeatResponses_Error(t *testing.T) {
 }
 
 func TestParseHeartbeatResponses_Errors(t *testing.T) {
-	data, err := ioutil.ReadFile("testdata/api_heartbeats_response_errors.json")
+	data, err := os.ReadFile("testdata/api_heartbeats_response_errors.json")
 	require.NoError(t, err)
 
 	results, err := api.ParseHeartbeatResponses(data)

--- a/pkg/api/option.go
+++ b/pkg/api/option.go
@@ -3,9 +3,9 @@ package api
 import (
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -129,7 +129,7 @@ func WithProxy(proxyURL string) (Option, error) {
 
 // WithSSLCertFile overrides the default CA certs file to trust specified cert file.
 func WithSSLCertFile(filepath string) (Option, error) {
-	caCert, err := ioutil.ReadFile(filepath)
+	caCert, err := os.ReadFile(filepath)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/api/summary.go
+++ b/pkg/api/summary.go
@@ -3,7 +3,7 @@ package api
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/wakatime/wakatime-cli/pkg/summary"
@@ -31,7 +31,7 @@ func (c *Client) Today() (*summary.Summary, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, Err(fmt.Sprintf("failed to read response body from %q: %s", url, err))
 	}

--- a/pkg/api/summary_test.go
+++ b/pkg/api/summary_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
@@ -191,7 +190,7 @@ func TestClient_Summary_InvalidUrl(t *testing.T) {
 }
 
 func TestParseSummaryResponse_DayTotal(t *testing.T) {
-	data, err := ioutil.ReadFile("testdata/api_statusbar_today_response.json")
+	data, err := os.ReadFile("testdata/api_statusbar_today_response.json")
 	require.NoError(t, err)
 
 	s, err := api.ParseSummaryResponse(data)
@@ -203,7 +202,7 @@ func TestParseSummaryResponse_DayTotal(t *testing.T) {
 }
 
 func TestParseSummaryResponse_TotalsByCategory(t *testing.T) {
-	data, err := ioutil.ReadFile("testdata/api_statusbar_today_by_category_response.json")
+	data, err := os.ReadFile("testdata/api_statusbar_today_by_category_response.json")
 	require.NoError(t, err)
 
 	s, err := api.ParseSummaryResponse(data)

--- a/pkg/backoff/backoff_internal_test.go
+++ b/pkg/backoff/backoff_internal_test.go
@@ -1,7 +1,6 @@
 package backoff
 
 import (
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -40,7 +39,7 @@ func TestShouldBackoff_NegateBackoff(t *testing.T) {
 func TestUpdateBackoffSettings(t *testing.T) {
 	v := viper.New()
 
-	tmpFile, err := ioutil.TempFile(os.TempDir(), "wakatime")
+	tmpFile, err := os.CreateTemp(os.TempDir(), "wakatime")
 	require.NoError(t, err)
 
 	defer os.Remove(tmpFile.Name())
@@ -68,7 +67,7 @@ func TestUpdateBackoffSettings(t *testing.T) {
 func TestUpdateBackoffSettings_NotInBackoff(t *testing.T) {
 	v := viper.New()
 
-	tmpFile, err := ioutil.TempFile(os.TempDir(), "wakatime")
+	tmpFile, err := os.CreateTemp(os.TempDir(), "wakatime")
 	require.NoError(t, err)
 
 	defer os.Remove(tmpFile.Name())
@@ -92,7 +91,7 @@ func TestUpdateBackoffSettings_NotInBackoff(t *testing.T) {
 func TestUpdateBackoffSettings_NoMultilineSideEffects(t *testing.T) {
 	v := viper.New()
 
-	tmpFile, err := ioutil.TempFile(os.TempDir(), "wakatime")
+	tmpFile, err := os.CreateTemp(os.TempDir(), "wakatime")
 	require.NoError(t, err)
 
 	defer os.Remove(tmpFile.Name())
@@ -118,19 +117,19 @@ func TestUpdateBackoffSettings_NoMultilineSideEffects(t *testing.T) {
 	value := ini.GetKey(tmpFile.Name(), ini.Key{Section: "settings", Name: "ignore"})
 	assert.Equal(t, "\n one\n two", value)
 
-	actual, err := ioutil.ReadFile(tmpFile.Name())
+	actual, err := os.ReadFile(tmpFile.Name())
 	require.NoError(t, err)
 
-	expected, err := ioutil.ReadFile("testdata/multiline_expected.cfg")
+	expected, err := os.ReadFile("testdata/multiline_expected.cfg")
 	require.NoError(t, err)
 
 	assert.Equal(t, strings.ReplaceAll(string(expected), "\r", ""), string(actual))
 }
 
 func copyFile(t *testing.T, source, destination string) {
-	input, err := ioutil.ReadFile(source)
+	input, err := os.ReadFile(source)
 	require.NoError(t, err)
 
-	err = ioutil.WriteFile(destination, input, 0600)
+	err = os.WriteFile(destination, input, 0600)
 	require.NoError(t, err)
 }

--- a/pkg/backoff/backoff_test.go
+++ b/pkg/backoff/backoff_test.go
@@ -2,7 +2,6 @@ package backoff_test
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -18,7 +17,7 @@ import (
 func TestWithRetry(t *testing.T) {
 	v := viper.New()
 
-	tmpFile, err := ioutil.TempFile(os.TempDir(), "wakatime")
+	tmpFile, err := os.CreateTemp(os.TempDir(), "wakatime")
 	require.NoError(t, err)
 
 	defer os.Remove(tmpFile.Name())
@@ -66,7 +65,7 @@ func TestWithRetry_BeforeNextBackoff(t *testing.T) {
 func TestWithRetry_ApiError(t *testing.T) {
 	v := viper.New()
 
-	tmpFile, err := ioutil.TempFile(os.TempDir(), "wakatime")
+	tmpFile, err := os.CreateTemp(os.TempDir(), "wakatime")
 	require.NoError(t, err)
 
 	defer os.Remove(tmpFile.Name())

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -2,7 +2,6 @@ package config_test
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -176,7 +175,7 @@ func TestNewIniWriterErr(t *testing.T) {
 }
 
 func TestWrite(t *testing.T) {
-	tmpFile, err := ioutil.TempFile(os.TempDir(), "wakatime")
+	tmpFile, err := os.CreateTemp(os.TempDir(), "wakatime")
 	require.NoError(t, err)
 
 	defer os.Remove(tmpFile.Name())

--- a/pkg/deps/c.go
+++ b/pkg/deps/c.go
@@ -2,7 +2,7 @@ package deps
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"regexp"
 	"strings"
@@ -42,7 +42,7 @@ func (p *ParserC) Parse(filepath string) ([]string, error) {
 	p.init()
 	defer p.init()
 
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read from reader: %s", err)
 	}

--- a/pkg/deps/csharp.go
+++ b/pkg/deps/csharp.go
@@ -2,7 +2,7 @@ package deps
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"regexp"
 	"strings"
@@ -43,7 +43,7 @@ func (p *ParserCSharp) Parse(filepath string) ([]string, error) {
 	p.init()
 	defer p.init()
 
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read from reader: %s", err)
 	}

--- a/pkg/deps/elm.go
+++ b/pkg/deps/elm.go
@@ -2,7 +2,7 @@ package deps
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 
@@ -39,7 +39,7 @@ func (p *ParserElm) Parse(filepath string) ([]string, error) {
 	p.init()
 	defer p.init()
 
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read from reader: %s", err)
 	}

--- a/pkg/deps/golang.go
+++ b/pkg/deps/golang.go
@@ -2,7 +2,7 @@ package deps
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"regexp"
 	"strings"
@@ -43,7 +43,7 @@ func (p *ParserGo) Parse(filepath string) ([]string, error) {
 	p.init()
 	defer p.init()
 
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read from reader: %s", err)
 	}

--- a/pkg/deps/haskell.go
+++ b/pkg/deps/haskell.go
@@ -2,7 +2,7 @@ package deps
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 
@@ -39,7 +39,7 @@ func (p *ParserHaskell) Parse(filepath string) ([]string, error) {
 	p.init()
 	defer p.init()
 
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read from reader: %s", err)
 	}

--- a/pkg/deps/haxe.go
+++ b/pkg/deps/haxe.go
@@ -2,7 +2,7 @@ package deps
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"regexp"
 	"strings"
@@ -43,7 +43,7 @@ func (p *ParserHaxe) Parse(filepath string) ([]string, error) {
 	p.init()
 	defer p.init()
 
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read from reader: %s", err)
 	}

--- a/pkg/deps/html.go
+++ b/pkg/deps/html.go
@@ -2,7 +2,7 @@ package deps
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"regexp"
 	"strings"
@@ -44,7 +44,7 @@ func (p *ParserHTML) Parse(filepath string) ([]string, error) {
 	p.init()
 	defer p.init()
 
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read from reader: %s", err)
 	}

--- a/pkg/deps/java.go
+++ b/pkg/deps/java.go
@@ -2,7 +2,7 @@ package deps
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"regexp"
 	"strings"
@@ -45,7 +45,7 @@ func (p *ParserJava) Parse(filepath string) ([]string, error) {
 	p.init()
 	defer p.init()
 
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read from reader: %s", err)
 	}

--- a/pkg/deps/javascript.go
+++ b/pkg/deps/javascript.go
@@ -2,7 +2,7 @@ package deps
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"regexp"
 	"strings"
@@ -43,7 +43,7 @@ func (p *ParserJavaScript) Parse(filepath string) ([]string, error) {
 	p.init()
 	defer p.init()
 
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read from reader: %s", err)
 	}

--- a/pkg/deps/json.go
+++ b/pkg/deps/json.go
@@ -2,7 +2,7 @@ package deps
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -54,7 +54,7 @@ func (p *ParserJSON) Parse(filepath string) ([]string, error) {
 	// detect dependencies via filename
 	p.processFilename(filepath)
 
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read from reader: %s", err)
 	}

--- a/pkg/deps/kotlin.go
+++ b/pkg/deps/kotlin.go
@@ -2,7 +2,7 @@ package deps
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"regexp"
 	"strings"
@@ -42,7 +42,7 @@ func (p *ParserKotlin) Parse(filepath string) ([]string, error) {
 	p.init()
 	defer p.init()
 
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read from reader: %s", err)
 	}

--- a/pkg/deps/objectivec.go
+++ b/pkg/deps/objectivec.go
@@ -2,7 +2,7 @@ package deps
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 
@@ -39,7 +39,7 @@ func (p *ParserObjectiveC) Parse(filepath string) ([]string, error) {
 	p.init()
 	defer p.init()
 
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read from reader: %s", err)
 	}

--- a/pkg/deps/php.go
+++ b/pkg/deps/php.go
@@ -2,7 +2,7 @@ package deps
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"regexp"
 	"strings"
@@ -49,7 +49,7 @@ func (p *ParserPHP) Parse(filepath string) ([]string, error) {
 	p.init()
 	defer p.init()
 
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read from reader: %s", err)
 	}

--- a/pkg/deps/python.go
+++ b/pkg/deps/python.go
@@ -2,7 +2,7 @@ package deps
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"regexp"
 	"strings"
@@ -46,7 +46,7 @@ func (p *ParserPython) Parse(filepath string) ([]string, error) {
 	p.init()
 	defer p.init()
 
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read from reader: %s", err)
 	}

--- a/pkg/deps/rust.go
+++ b/pkg/deps/rust.go
@@ -2,7 +2,7 @@ package deps
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 
@@ -41,7 +41,7 @@ func (p *ParserRust) Parse(filepath string) ([]string, error) {
 	p.init()
 	defer p.init()
 
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read from reader: %s", err)
 	}

--- a/pkg/deps/scala.go
+++ b/pkg/deps/scala.go
@@ -2,7 +2,7 @@ package deps
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 
@@ -39,7 +39,7 @@ func (p *ParserScala) Parse(filepath string) ([]string, error) {
 	p.init()
 	defer p.init()
 
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read from reader: %s", err)
 	}

--- a/pkg/deps/swift.go
+++ b/pkg/deps/swift.go
@@ -2,7 +2,7 @@ package deps
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"regexp"
 	"strings"
@@ -43,7 +43,7 @@ func (p *ParserSwift) Parse(filepath string) ([]string, error) {
 	p.init()
 	defer p.init()
 
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read from reader: %s", err)
 	}

--- a/pkg/deps/vbnet.go
+++ b/pkg/deps/vbnet.go
@@ -2,7 +2,7 @@ package deps
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"regexp"
 	"strings"
@@ -43,7 +43,7 @@ func (p *ParserVbNet) Parse(filepath string) ([]string, error) {
 	p.init()
 	defer p.init()
 
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read from reader: %s", err)
 	}

--- a/pkg/filestats/filestats_test.go
+++ b/pkg/filestats/filestats_test.go
@@ -2,7 +2,6 @@ package filestats_test
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -91,7 +90,7 @@ func TestWithDetection_LinesInFile(t *testing.T) {
 }
 
 func TestWithDetection_MaxFileSizeExceeded(t *testing.T) {
-	f, err := ioutil.TempFile(os.TempDir(), "")
+	f, err := os.CreateTemp(os.TempDir(), "")
 	require.NoError(t, err)
 
 	defer os.Remove(f.Name())

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -2,7 +2,6 @@ package filter_test
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -16,12 +15,12 @@ import (
 )
 
 func TestWithFiltering(t *testing.T) {
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "wakatime")
+	tmpDir, err := os.MkdirTemp(os.TempDir(), "wakatime")
 	require.NoError(t, err)
 
 	defer os.RemoveAll(tmpDir)
 
-	tmpFile, err := ioutil.TempFile(tmpDir, "")
+	tmpFile, err := os.CreateTemp(tmpDir, "")
 	require.NoError(t, err)
 
 	first := testHeartbeat()
@@ -79,12 +78,12 @@ func TestWithFiltering_AbortAllFiltered(t *testing.T) {
 }
 
 func TestFilter(t *testing.T) {
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "wakatime")
+	tmpDir, err := os.MkdirTemp(os.TempDir(), "wakatime")
 	require.NoError(t, err)
 
 	defer os.RemoveAll(tmpDir)
 
-	tmpFile, err := ioutil.TempFile(tmpDir, "")
+	tmpFile, err := os.CreateTemp(tmpDir, "")
 	require.NoError(t, err)
 
 	h := testHeartbeat()
@@ -106,12 +105,12 @@ func TestFilter_NonFileTypeEmptyEntity(t *testing.T) {
 }
 
 func TestFilter_IncludeMatchOverwritesExcludeMatch(t *testing.T) {
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "wakatime")
+	tmpDir, err := os.MkdirTemp(os.TempDir(), "wakatime")
 	require.NoError(t, err)
 
 	defer os.RemoveAll(tmpDir)
 
-	tmpFile, err := ioutil.TempFile(tmpDir, "")
+	tmpFile, err := os.CreateTemp(tmpDir, "")
 	require.NoError(t, err)
 
 	h := testHeartbeat()
@@ -129,12 +128,12 @@ func TestFilter_IncludeMatchOverwritesExcludeMatch(t *testing.T) {
 }
 
 func TestFilter_ErrMatchesExcludePattern(t *testing.T) {
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "wakatime")
+	tmpDir, err := os.MkdirTemp(os.TempDir(), "wakatime")
 	require.NoError(t, err)
 
 	defer os.RemoveAll(tmpDir)
 
-	tmpFile, err := ioutil.TempFile(tmpDir, "exclude-this-file")
+	tmpFile, err := os.CreateTemp(tmpDir, "exclude-this-file")
 	require.NoError(t, err)
 
 	h := testHeartbeat()
@@ -160,12 +159,12 @@ func TestFilter_ErrUnknownProject(t *testing.T) {
 
 	for name, projectValue := range tests {
 		t.Run(name, func(t *testing.T) {
-			tmpDir, err := ioutil.TempDir(os.TempDir(), "wakatime")
+			tmpDir, err := os.MkdirTemp(os.TempDir(), "wakatime")
 			require.NoError(t, err)
 
 			defer os.RemoveAll(tmpDir)
 
-			tmpFile, err := ioutil.TempFile(tmpDir, "")
+			tmpFile, err := os.CreateTemp(tmpDir, "")
 			require.NoError(t, err)
 
 			h := testHeartbeat()
@@ -195,12 +194,12 @@ func TestFilter_ErrNonExistingFile(t *testing.T) {
 }
 
 func TestFilter_ExistingProjectFile(t *testing.T) {
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "wakatime")
+	tmpDir, err := os.MkdirTemp(os.TempDir(), "wakatime")
 	require.NoError(t, err)
 
 	defer os.RemoveAll(tmpDir)
 
-	tmpFile, err := ioutil.TempFile(tmpDir, "")
+	tmpFile, err := os.CreateTemp(tmpDir, "")
 	require.NoError(t, err)
 
 	_, err = os.Create(filepath.Join(tmpDir, ".wakatime-project"))
@@ -216,12 +215,12 @@ func TestFilter_ExistingProjectFile(t *testing.T) {
 }
 
 func TestFilter_ErrNonExistingProjectFile(t *testing.T) {
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "wakatime")
+	tmpDir, err := os.MkdirTemp(os.TempDir(), "wakatime")
 	require.NoError(t, err)
 
 	defer os.RemoveAll(tmpDir)
 
-	tmpFile, err := ioutil.TempFile(tmpDir, "")
+	tmpFile, err := os.CreateTemp(tmpDir, "")
 	require.NoError(t, err)
 
 	h := testHeartbeat()

--- a/pkg/heartbeat/entity_modifier_internal_test.go
+++ b/pkg/heartbeat/entity_modifier_internal_test.go
@@ -1,7 +1,6 @@
 package heartbeat
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -45,7 +44,7 @@ func TestIsXCodePlayground(t *testing.T) {
 }
 
 func setupTestXCodePlayground(t *testing.T, dir string) string {
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "wakatime")
+	tmpDir, err := os.MkdirTemp(os.TempDir(), "wakatime")
 	require.NoError(t, err)
 
 	err = os.Mkdir(filepath.Join(tmpDir, dir), os.FileMode(int(0700)))

--- a/pkg/heartbeat/entity_modify_test.go
+++ b/pkg/heartbeat/entity_modify_test.go
@@ -1,7 +1,6 @@
 package heartbeat_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -13,7 +12,7 @@ import (
 )
 
 func TestWithEntityModifier_XCodePlayground(t *testing.T) {
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "wakatime")
+	tmpDir, err := os.MkdirTemp(os.TempDir(), "wakatime")
 	require.NoError(t, err)
 
 	defer os.RemoveAll(tmpDir)

--- a/pkg/heartbeat/heartbeat_test.go
+++ b/pkg/heartbeat/heartbeat_test.go
@@ -3,7 +3,7 @@ package heartbeat_test
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"runtime"
 	"strings"
@@ -142,7 +142,7 @@ func TestHeartbeat_JSON(t *testing.T) {
 
 	defer f.Close()
 
-	expected, err := ioutil.ReadAll(f)
+	expected, err := io.ReadAll(f)
 	require.NoError(t, err)
 
 	assert.JSONEq(t, string(expected), string(jsonEncoded))
@@ -165,7 +165,7 @@ func TestHeartbeat_JSON_NilFields(t *testing.T) {
 
 	defer f.Close()
 
-	expected, err := ioutil.ReadAll(f)
+	expected, err := io.ReadAll(f)
 	require.NoError(t, err)
 
 	assert.JSONEq(t, string(expected), string(jsonEncoded))

--- a/pkg/ini/ini.go
+++ b/pkg/ini/ini.go
@@ -3,7 +3,6 @@ package ini
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 )
@@ -197,7 +196,7 @@ func SetKeys(iniFile string, keys map[Key]string) error {
 
 	output := strings.Join(lines, "\n")
 
-	return ioutil.WriteFile(iniFile, []byte(output), 0644) // nolint:gosec
+	return os.WriteFile(iniFile, []byte(output), 0644) // nolint:gosec
 }
 
 func isSection(line string) bool {

--- a/pkg/language/language.go
+++ b/pkg/language/language.go
@@ -2,7 +2,6 @@ package language
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -178,7 +177,7 @@ func correspondingFileExists(fp string, extension string) bool {
 
 // loadFolderExtensions loads all existing from a folder.
 func loadFolderExtensions(dir string) ([]string, error) {
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read directory: %s", err)
 	}

--- a/pkg/offline/offline_test.go
+++ b/pkg/offline/offline_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -57,7 +56,7 @@ func TestQueueFilepath(t *testing.T) {
 
 func TestWithQueue(t *testing.T) {
 	// setup
-	f, err := ioutil.TempFile(os.TempDir(), "")
+	f, err := os.CreateTemp(os.TempDir(), "")
 	require.NoError(t, err)
 
 	defer os.Remove(f.Name())
@@ -65,7 +64,7 @@ func TestWithQueue(t *testing.T) {
 	db, err := bolt.Open(f.Name(), 0600, nil)
 	require.NoError(t, err)
 
-	dataJs, err := ioutil.ReadFile("testdata/heartbeat_js.json")
+	dataJs, err := os.ReadFile("testdata/heartbeat_js.json")
 	require.NoError(t, err)
 
 	insertHeartbeatRecords(t, db, "heartbeats", []heartbeatRecord{
@@ -145,7 +144,7 @@ func TestWithQueue(t *testing.T) {
 
 func TestWithQueue_ApiError(t *testing.T) {
 	// setup
-	f, err := ioutil.TempFile(os.TempDir(), "")
+	f, err := os.CreateTemp(os.TempDir(), "")
 	require.NoError(t, err)
 
 	defer os.Remove(f.Name())
@@ -191,10 +190,10 @@ func TestWithQueue_ApiError(t *testing.T) {
 
 	db.Close()
 
-	dataGo, err := ioutil.ReadFile("testdata/heartbeat_go.json")
+	dataGo, err := os.ReadFile("testdata/heartbeat_go.json")
 	require.NoError(t, err)
 
-	dataPy, err := ioutil.ReadFile("testdata/heartbeat_py.json")
+	dataPy, err := os.ReadFile("testdata/heartbeat_py.json")
 	require.NoError(t, err)
 
 	require.Len(t, stored, 2)
@@ -208,7 +207,7 @@ func TestWithQueue_ApiError(t *testing.T) {
 
 func TestWithQueue_InvalidResults(t *testing.T) {
 	// setup
-	f, err := ioutil.TempFile(os.TempDir(), "")
+	f, err := os.CreateTemp(os.TempDir(), "")
 	require.NoError(t, err)
 
 	defer os.Remove(f.Name())
@@ -277,10 +276,10 @@ func TestWithQueue_InvalidResults(t *testing.T) {
 
 	db.Close()
 
-	dataPy, err := ioutil.ReadFile("testdata/heartbeat_py.json")
+	dataPy, err := os.ReadFile("testdata/heartbeat_py.json")
 	require.NoError(t, err)
 
-	dataJs, err := ioutil.ReadFile("testdata/heartbeat_js.json")
+	dataJs, err := os.ReadFile("testdata/heartbeat_js.json")
 	require.NoError(t, err)
 
 	assert.Len(t, stored, 2)
@@ -294,7 +293,7 @@ func TestWithQueue_InvalidResults(t *testing.T) {
 
 func TestWithQueue_HandleLeftovers(t *testing.T) {
 	// setup
-	f, err := ioutil.TempFile(os.TempDir(), "")
+	f, err := os.CreateTemp(os.TempDir(), "")
 	require.NoError(t, err)
 
 	defer os.Remove(f.Name())
@@ -346,10 +345,10 @@ func TestWithQueue_HandleLeftovers(t *testing.T) {
 
 	db.Close()
 
-	dataPy, err := ioutil.ReadFile("testdata/heartbeat_py.json")
+	dataPy, err := os.ReadFile("testdata/heartbeat_py.json")
 	require.NoError(t, err)
 
-	dataJs, err := ioutil.ReadFile("testdata/heartbeat_js.json")
+	dataJs, err := os.ReadFile("testdata/heartbeat_js.json")
 	require.NoError(t, err)
 
 	require.Len(t, stored, 2)
@@ -363,7 +362,7 @@ func TestWithQueue_HandleLeftovers(t *testing.T) {
 
 func TestSync(t *testing.T) {
 	// setup
-	f, err := ioutil.TempFile(os.TempDir(), "")
+	f, err := os.CreateTemp(os.TempDir(), "")
 	require.NoError(t, err)
 
 	defer os.RemoveAll(f.Name())
@@ -371,10 +370,10 @@ func TestSync(t *testing.T) {
 	db, err := bolt.Open(f.Name(), 0600, nil)
 	require.NoError(t, err)
 
-	dataGo, err := ioutil.ReadFile("testdata/heartbeat_go.json")
+	dataGo, err := os.ReadFile("testdata/heartbeat_go.json")
 	require.NoError(t, err)
 
-	dataPy, err := ioutil.ReadFile("testdata/heartbeat_py.json")
+	dataPy, err := os.ReadFile("testdata/heartbeat_py.json")
 	require.NoError(t, err)
 
 	insertHeartbeatRecords(t, db, "heartbeats", []heartbeatRecord{
@@ -444,7 +443,7 @@ func TestSync(t *testing.T) {
 
 func TestSync_MultipleRequests(t *testing.T) {
 	// setup
-	f, err := ioutil.TempFile(os.TempDir(), "")
+	f, err := os.CreateTemp(os.TempDir(), "")
 	require.NoError(t, err)
 
 	defer os.RemoveAll(f.Name())
@@ -452,7 +451,7 @@ func TestSync_MultipleRequests(t *testing.T) {
 	db, err := bolt.Open(f.Name(), 0600, nil)
 	require.NoError(t, err)
 
-	dataGo, err := ioutil.ReadFile("testdata/heartbeat_go.json")
+	dataGo, err := os.ReadFile("testdata/heartbeat_go.json")
 	require.NoError(t, err)
 
 	for i := 0; i < 11; i++ {
@@ -531,7 +530,7 @@ func TestSync_MultipleRequests(t *testing.T) {
 
 func TestSync_APIError(t *testing.T) {
 	// setup
-	f, err := ioutil.TempFile(os.TempDir(), "")
+	f, err := os.CreateTemp(os.TempDir(), "")
 	require.NoError(t, err)
 
 	defer os.RemoveAll(f.Name())
@@ -539,10 +538,10 @@ func TestSync_APIError(t *testing.T) {
 	db, err := bolt.Open(f.Name(), 0600, nil)
 	require.NoError(t, err)
 
-	dataGo, err := ioutil.ReadFile("testdata/heartbeat_go.json")
+	dataGo, err := os.ReadFile("testdata/heartbeat_go.json")
 	require.NoError(t, err)
 
-	dataPy, err := ioutil.ReadFile("testdata/heartbeat_py.json")
+	dataPy, err := os.ReadFile("testdata/heartbeat_py.json")
 	require.NoError(t, err)
 
 	insertHeartbeatRecords(t, db, "heartbeats", []heartbeatRecord{
@@ -610,7 +609,7 @@ func TestSync_APIError(t *testing.T) {
 
 func TestSync_InvalidResults(t *testing.T) {
 	// setup
-	f, err := ioutil.TempFile(os.TempDir(), "")
+	f, err := os.CreateTemp(os.TempDir(), "")
 	require.NoError(t, err)
 
 	defer os.RemoveAll(f.Name())
@@ -618,13 +617,13 @@ func TestSync_InvalidResults(t *testing.T) {
 	db, err := bolt.Open(f.Name(), 0600, nil)
 	require.NoError(t, err)
 
-	dataGo, err := ioutil.ReadFile("testdata/heartbeat_go.json")
+	dataGo, err := os.ReadFile("testdata/heartbeat_go.json")
 	require.NoError(t, err)
 
-	dataPy, err := ioutil.ReadFile("testdata/heartbeat_py.json")
+	dataPy, err := os.ReadFile("testdata/heartbeat_py.json")
 	require.NoError(t, err)
 
-	dataJs, err := ioutil.ReadFile("testdata/heartbeat_js.json")
+	dataJs, err := os.ReadFile("testdata/heartbeat_js.json")
 	require.NoError(t, err)
 
 	insertHeartbeatRecords(t, db, "heartbeats", []heartbeatRecord{
@@ -724,7 +723,7 @@ func TestSync_InvalidResults(t *testing.T) {
 
 func TestSync_SyncLimit(t *testing.T) {
 	// setup
-	f, err := ioutil.TempFile(os.TempDir(), "")
+	f, err := os.CreateTemp(os.TempDir(), "")
 	require.NoError(t, err)
 
 	defer os.RemoveAll(f.Name())
@@ -732,10 +731,10 @@ func TestSync_SyncLimit(t *testing.T) {
 	db, err := bolt.Open(f.Name(), 0600, nil)
 	require.NoError(t, err)
 
-	dataGo, err := ioutil.ReadFile("testdata/heartbeat_go.json")
+	dataGo, err := os.ReadFile("testdata/heartbeat_go.json")
 	require.NoError(t, err)
 
-	dataPy, err := ioutil.ReadFile("testdata/heartbeat_py.json")
+	dataPy, err := os.ReadFile("testdata/heartbeat_py.json")
 	require.NoError(t, err)
 
 	insertHeartbeatRecords(t, db, "heartbeats", []heartbeatRecord{
@@ -802,7 +801,7 @@ func TestSync_SyncLimit(t *testing.T) {
 
 func TestQueue_PopMany(t *testing.T) {
 	// setup
-	f, err := ioutil.TempFile(os.TempDir(), "")
+	f, err := os.CreateTemp(os.TempDir(), "")
 	require.NoError(t, err)
 
 	defer os.Remove(f.Name())
@@ -810,13 +809,13 @@ func TestQueue_PopMany(t *testing.T) {
 	db, err := bolt.Open(f.Name(), 0600, nil)
 	require.NoError(t, err)
 
-	dataGo, err := ioutil.ReadFile("testdata/heartbeat_go.json")
+	dataGo, err := os.ReadFile("testdata/heartbeat_go.json")
 	require.NoError(t, err)
 
-	dataPy, err := ioutil.ReadFile("testdata/heartbeat_py.json")
+	dataPy, err := os.ReadFile("testdata/heartbeat_py.json")
 	require.NoError(t, err)
 
-	dataJs, err := ioutil.ReadFile("testdata/heartbeat_js.json")
+	dataJs, err := os.ReadFile("testdata/heartbeat_js.json")
 	require.NoError(t, err)
 
 	insertHeartbeatRecords(t, db, "test_bucket", []heartbeatRecord{
@@ -877,7 +876,7 @@ func TestQueue_PushMany(t *testing.T) {
 	db, cleanup := initDB(t)
 	defer cleanup()
 
-	dataGo, err := ioutil.ReadFile("testdata/heartbeat_go.json")
+	dataGo, err := os.ReadFile("testdata/heartbeat_go.json")
 	require.NoError(t, err)
 
 	insertHeartbeatRecord(t, db, "test_bucket", heartbeatRecord{
@@ -887,7 +886,7 @@ func TestQueue_PushMany(t *testing.T) {
 
 	var heartbeatPy heartbeat.Heartbeat
 
-	dataPy, err := ioutil.ReadFile("testdata/heartbeat_py.json")
+	dataPy, err := os.ReadFile("testdata/heartbeat_py.json")
 	require.NoError(t, err)
 
 	err = json.Unmarshal(dataPy, &heartbeatPy)
@@ -895,7 +894,7 @@ func TestQueue_PushMany(t *testing.T) {
 
 	var heartbeatJs heartbeat.Heartbeat
 
-	dataJs, err := ioutil.ReadFile("testdata/heartbeat_js.json")
+	dataJs, err := os.ReadFile("testdata/heartbeat_js.json")
 	require.NoError(t, err)
 
 	err = json.Unmarshal(dataJs, &heartbeatJs)
@@ -962,7 +961,7 @@ func TestQueue_Count(t *testing.T) {
 
 	var heartbeatPy heartbeat.Heartbeat
 
-	dataPy, err := ioutil.ReadFile("testdata/heartbeat_py.json")
+	dataPy, err := os.ReadFile("testdata/heartbeat_py.json")
 	require.NoError(t, err)
 
 	err = json.Unmarshal(dataPy, &heartbeatPy)
@@ -970,7 +969,7 @@ func TestQueue_Count(t *testing.T) {
 
 	var heartbeatJs heartbeat.Heartbeat
 
-	dataJs, err := ioutil.ReadFile("testdata/heartbeat_js.json")
+	dataJs, err := os.ReadFile("testdata/heartbeat_js.json")
 	require.NoError(t, err)
 
 	err = json.Unmarshal(dataJs, &heartbeatJs)
@@ -1004,7 +1003,7 @@ func TestQueue_Count(t *testing.T) {
 
 func initDB(t *testing.T) (*bolt.DB, func()) {
 	// create tmp file
-	f, err := ioutil.TempFile(os.TempDir(), "")
+	f, err := os.CreateTemp(os.TempDir(), "")
 	require.NoError(t, err)
 
 	// init db

--- a/pkg/project/file_test.go
+++ b/pkg/project/file_test.go
@@ -1,7 +1,6 @@
 package project_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -30,7 +29,7 @@ func TestFile_Detect_FileExists(t *testing.T) {
 }
 
 func TestFile_Detect_ParentFolderExists(t *testing.T) {
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "wakatime")
+	tmpDir, err := os.MkdirTemp(os.TempDir(), "wakatime")
 	require.NoError(t, err)
 
 	defer os.RemoveAll(tmpDir)
@@ -63,7 +62,7 @@ func TestFile_Detect_ParentFolderExists(t *testing.T) {
 }
 
 func TestFile_Detect_AnyFileFound(t *testing.T) {
-	tmpFile, err := ioutil.TempFile(os.TempDir(), "wakatime-project")
+	tmpFile, err := os.CreateTemp(os.TempDir(), "wakatime-project")
 	require.NoError(t, err)
 
 	defer os.Remove(tmpFile.Name())
@@ -99,7 +98,7 @@ func TestFile_String(t *testing.T) {
 }
 
 func TestFindFileOrDirectory(t *testing.T) {
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "wakatime")
+	tmpDir, err := os.MkdirTemp(os.TempDir(), "wakatime")
 	require.NoError(t, err)
 
 	defer os.RemoveAll(tmpDir)
@@ -144,9 +143,9 @@ func TestFindFileOrDirectory(t *testing.T) {
 }
 
 func copyFile(t *testing.T, source, destination string) {
-	input, err := ioutil.ReadFile(source)
+	input, err := os.ReadFile(source)
 	require.NoError(t, err)
 
-	err = ioutil.WriteFile(destination, input, 0600)
+	err = os.WriteFile(destination, input, 0600)
 	require.NoError(t, err)
 }

--- a/pkg/project/git_test.go
+++ b/pkg/project/git_test.go
@@ -2,7 +2,6 @@ package project_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -180,7 +179,7 @@ func TestGit_Detect_SubmoduleDisabled(t *testing.T) {
 }
 
 func setupTestGitBasic(t *testing.T) (fp string, tearDown func()) {
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "wakatime-git")
+	tmpDir, err := os.MkdirTemp(os.TempDir(), "wakatime-git")
 	require.NoError(t, err)
 
 	err = os.MkdirAll(filepath.Join(tmpDir, "wakatime-cli/src/pkg"), os.FileMode(int(0700)))
@@ -201,7 +200,7 @@ func setupTestGitBasic(t *testing.T) (fp string, tearDown func()) {
 }
 
 func setupTestGitBasicBranchWithSlash(t *testing.T) (fp string, tearDown func()) {
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "wakatime-git")
+	tmpDir, err := os.MkdirTemp(os.TempDir(), "wakatime-git")
 	require.NoError(t, err)
 
 	err = os.MkdirAll(filepath.Join(tmpDir, "wakatime-cli/src/pkg"), os.FileMode(int(0700)))
@@ -222,7 +221,7 @@ func setupTestGitBasicBranchWithSlash(t *testing.T) (fp string, tearDown func())
 }
 
 func setupTestGitBasicDetachedHead(t *testing.T) (fp string, tearDown func()) {
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "wakatime-git")
+	tmpDir, err := os.MkdirTemp(os.TempDir(), "wakatime-git")
 	require.NoError(t, err)
 
 	err = os.MkdirAll(filepath.Join(tmpDir, "wakatime-cli/src/pkg"), os.FileMode(int(0700)))
@@ -243,7 +242,7 @@ func setupTestGitBasicDetachedHead(t *testing.T) (fp string, tearDown func()) {
 }
 
 func setupTestGitFile(t *testing.T) (fp string, tearDown func()) {
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "wakatime-git")
+	tmpDir, err := os.MkdirTemp(os.TempDir(), "wakatime-git")
 	require.NoError(t, err)
 
 	// Create directories
@@ -297,7 +296,7 @@ func setupTestGitFile(t *testing.T) (fp string, tearDown func()) {
 }
 
 func setupTestGitWorktree(t *testing.T) (fp string, tearDown func()) {
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "wakatime-git")
+	tmpDir, err := os.MkdirTemp(os.TempDir(), "wakatime-git")
 	require.NoError(t, err)
 
 	// Create directories
@@ -341,7 +340,7 @@ func setupTestGitWorktree(t *testing.T) (fp string, tearDown func()) {
 }
 
 func setupTestGitSubmodule(t *testing.T) (fp string, tearDown func()) {
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "wakatime-git")
+	tmpDir, err := os.MkdirTemp(os.TempDir(), "wakatime-git")
 	require.NoError(t, err)
 
 	// Create directories

--- a/pkg/project/mercurial_test.go
+++ b/pkg/project/mercurial_test.go
@@ -1,7 +1,6 @@
 package project_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -73,7 +72,7 @@ func TestMercurial_Detect_NoBranch(t *testing.T) {
 }
 
 func setupTestMercurial(t *testing.T) (fp string, tearDown func()) {
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "wakatime-hg")
+	tmpDir, err := os.MkdirTemp(os.TempDir(), "wakatime-hg")
 	require.NoError(t, err)
 
 	err = os.MkdirAll(filepath.Join(tmpDir, "wakatime-cli/src/pkg"), os.FileMode(int(0700)))
@@ -93,7 +92,7 @@ func setupTestMercurial(t *testing.T) (fp string, tearDown func()) {
 }
 
 func setupTestMercurialBranchWithSlash(t *testing.T) (fp string, tearDown func()) {
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "wakatime-hg")
+	tmpDir, err := os.MkdirTemp(os.TempDir(), "wakatime-hg")
 	require.NoError(t, err)
 
 	err = os.MkdirAll(filepath.Join(tmpDir, "wakatime-cli/src/pkg"), os.FileMode(int(0700)))
@@ -113,7 +112,7 @@ func setupTestMercurialBranchWithSlash(t *testing.T) (fp string, tearDown func()
 }
 
 func setupTestMercurialNoBranch(t *testing.T) (fp string, tearDown func()) {
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "wakatime-hg")
+	tmpDir, err := os.MkdirTemp(os.TempDir(), "wakatime-hg")
 	require.NoError(t, err)
 
 	err = os.MkdirAll(filepath.Join(tmpDir, "wakatime-cli/src/pkg"), os.FileMode(int(0700)))

--- a/pkg/project/project_file_control.go
+++ b/pkg/project/project_file_control.go
@@ -2,13 +2,13 @@ package project
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 )
 
 // Write saves wakatime project file.
 func Write(folder, project string) error {
-	err := ioutil.WriteFile(filepath.Join(folder, defaultProjectFile), []byte(project+"\n"), 0600)
+	err := os.WriteFile(filepath.Join(folder, defaultProjectFile), []byte(project+"\n"), 0600)
 	if err != nil {
 		return fmt.Errorf("failed to save wakatime project file: %s", err)
 	}

--- a/pkg/project/project_file_control_test.go
+++ b/pkg/project/project_file_control_test.go
@@ -1,7 +1,6 @@
 package project_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -13,7 +12,7 @@ import (
 )
 
 func TestWrite(t *testing.T) {
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "wakatime-git")
+	tmpDir, err := os.MkdirTemp(os.TempDir(), "wakatime-git")
 	require.NoError(t, err)
 
 	defer os.RemoveAll(tmpDir)
@@ -21,7 +20,7 @@ func TestWrite(t *testing.T) {
 	err = project.Write(tmpDir, "billing")
 	require.NoError(t, err)
 
-	actual, err := ioutil.ReadFile(filepath.Join(tmpDir, ".wakatime-project"))
+	actual, err := os.ReadFile(filepath.Join(tmpDir, ".wakatime-project"))
 	require.NoError(t, err)
 
 	assert.Equal(t, string([]byte("billing\n")), string(actual))

--- a/pkg/project/project_test.go
+++ b/pkg/project/project_test.go
@@ -1,7 +1,6 @@
 package project_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -190,12 +189,12 @@ func TestDetect_FileDetected(t *testing.T) {
 }
 
 func TestDetect_MapDetected(t *testing.T) {
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "wakatime")
+	tmpDir, err := os.MkdirTemp(os.TempDir(), "wakatime")
 	require.NoError(t, err)
 
 	defer os.RemoveAll(tmpDir)
 
-	tmpFile, err := ioutil.TempFile(tmpDir, "waka-billing")
+	tmpFile, err := os.CreateTemp(tmpDir, "waka-billing")
 	require.NoError(t, err)
 
 	patterns := []project.MapPattern{
@@ -234,7 +233,7 @@ func TestDetectWithRevControl_GitDetected(t *testing.T) {
 }
 
 func TestDetect_NoProjectDetected(t *testing.T) {
-	tmpFile, err := ioutil.TempFile(os.TempDir(), "wakatime")
+	tmpFile, err := os.CreateTemp(os.TempDir(), "wakatime")
 	require.NoError(t, err)
 
 	defer os.Remove(tmpFile.Name())

--- a/pkg/project/subversion_test.go
+++ b/pkg/project/subversion_test.go
@@ -1,7 +1,6 @@
 package project_test
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -56,7 +55,7 @@ func TestSubversion_Detect_Branch(t *testing.T) {
 }
 
 func setupTestSvn(t *testing.T) (fp string, tearDown func()) {
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "wakatime-svn")
+	tmpDir, err := os.MkdirTemp(os.TempDir(), "wakatime-svn")
 	require.NoError(t, err)
 
 	err = os.MkdirAll(filepath.Join(tmpDir, "wakatime-cli/src/pkg"), os.FileMode(int(0700)))
@@ -73,7 +72,7 @@ func setupTestSvn(t *testing.T) (fp string, tearDown func()) {
 }
 
 func setupTestSvnBranch(t *testing.T) (fp string, tearDown func()) {
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "wakatime-svn")
+	tmpDir, err := os.MkdirTemp(os.TempDir(), "wakatime-svn")
 	require.NoError(t, err)
 
 	err = os.MkdirAll(filepath.Join(tmpDir, "wakatime-cli/src/pkg"), os.FileMode(int(0700)))
@@ -112,7 +111,7 @@ func copyDir(t *testing.T, src string, dst string) {
 	err = os.MkdirAll(dst, si.Mode())
 	require.NoError(t, err)
 
-	entries, err := ioutil.ReadDir(src)
+	entries, err := os.ReadDir(src)
 	require.NoError(t, err)
 
 	for _, entry := range entries {
@@ -123,7 +122,9 @@ func copyDir(t *testing.T, src string, dst string) {
 			copyDir(t, srcPath, dstPath)
 		} else {
 			// Skip symlinks.
-			if entry.Mode()&os.ModeSymlink != 0 {
+			info, err := entry.Info()
+			require.NoError(t, err)
+			if info.Mode()&os.ModeSymlink != 0 {
 				continue
 			}
 

--- a/pkg/project/tfvc_test.go
+++ b/pkg/project/tfvc_test.go
@@ -2,7 +2,6 @@ package project_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -61,7 +60,7 @@ func TestTfvc_Detect_Windows(t *testing.T) {
 }
 
 func setupTestTfvc(t *testing.T, tfFolderName string) (fp string, tearDown func()) {
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "wakatime-tfvc")
+	tmpDir, err := os.MkdirTemp(os.TempDir(), "wakatime-tfvc")
 	require.NoError(t, err)
 
 	err = os.MkdirAll(filepath.Join(tmpDir, "wakatime-cli/src/pkg"), os.FileMode(int(0700)))

--- a/pkg/windows/windows_internal_test.go
+++ b/pkg/windows/windows_internal_test.go
@@ -2,7 +2,6 @@ package windows
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"testing"
@@ -68,7 +67,7 @@ func TestFormatLocalFilePath(t *testing.T) {
 }
 
 func TestFormatLocalFilePath_LocalFileExists(t *testing.T) {
-	tmpFile, err := ioutil.TempFile(os.TempDir(), "")
+	tmpFile, err := os.CreateTemp(os.TempDir(), "")
 	require.NoError(t, err)
 
 	defer os.Remove(tmpFile.Name())
@@ -81,7 +80,7 @@ func TestFormatLocalFilePath_LocalFileExists(t *testing.T) {
 }
 
 func TestFormatLocalFilePath_EntityExists(t *testing.T) {
-	tmpFile, err := ioutil.TempFile(os.TempDir(), "")
+	tmpFile, err := os.CreateTemp(os.TempDir(), "")
 	require.NoError(t, err)
 
 	defer os.Remove(tmpFile.Name())


### PR DESCRIPTION
Since wakatime-cli is currently using Go 1.17, so it is safe to remove deprecated `ioutil` package, ref https://golang.org/doc/go1.16#ioutil.

Associated with wakatime/wakatime-cli#559.