### PR TITLE
Trigger pipeline for forked branches

### DIFF
--- a/.github/workflows/on_pull_request_linter.yml
+++ b/.github/workflows/on_pull_request_linter.yml
@@ -1,4 +1,4 @@
-name: "Pull Request Linter"
+name: "Tests"
 
 on: pull_request
 

--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -1,11 +1,11 @@
 name: Tests
 
 on:
+  pull_request:
+    types: [opened, reopened, ready_for_review, synchronize]
   push:
-    branches:
-      - "**"
-    tags-ignore:
-      - "**"
+    branches: [develop, release]
+    tags-ignore: "**"
 
 env:
   GO_VERSION: "1.17"


### PR DESCRIPTION
This PR adds `pull_request` event alongside `push` to trigger the pipeline when a pr comes from a forked repo. Instead of listening to on push event for every single branch it now has changed to listen for events on pull request, which mainly covers its lifecycle, and also for push events on both develop and release branches.  

Fixes pipeline not being triggered for https://github.com/wakatime/wakatime-cli/pull/560