### PR TITLE
Log to default log file on config read errors

### DIFF
--- a/cmd/legacy/run.go
+++ b/cmd/legacy/run.go
@@ -40,6 +40,9 @@ func Run(cmd *cobra.Command, v *viper.Viper) {
 	if err := config.ReadInConfig(v, configFile); err != nil {
 		fmt.Fprintf(os.Stderr, "failed to load configuration file: %s", err)
 
+		SetupLogging(v)
+		log.Errorf("failed to load configuration file: %s", err)
+
 		os.Exit(exitcode.ErrConfigFileParse)
 	}
 
@@ -135,8 +138,6 @@ func SetupLogging(v *viper.Viper) *logfile.Params {
 	logFile := os.Stdout
 
 	if !logfileParams.ToStdout {
-		log.Debugf("log to file %s", logfileParams.File)
-
 		logFile, err = os.OpenFile(logfileParams.File, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0666)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error opening log file: %s", err)


### PR DESCRIPTION
Related to #577.

This PR writes a log to the default `~/.wakatime.log` file whenever wakatime-cli is unable to parse the config file. Previously, it would just exit printing to stdout which is ignored by most WakaTime IDE plugins unless the IDE plugin has debug mode enabled.

Also removes a debug log which did nothing, because logging wasn't setup yet.