### PR TITLE
Save heartbeats to offline db on config parse error

### DIFF
--- a/cmd/legacy/heartbeat/params.go
+++ b/cmd/legacy/heartbeat/params.go
@@ -159,7 +159,13 @@ func (p SanitizeParams) String() string {
 // LoadParams loads heartbeat config params from viper.Viper instance. Returns ErrAuth
 // if failed to retrieve api key.
 func LoadParams(v *viper.Viper) (Params, error) {
-	params, err := legacyparams.Load(v)
+	return LoadParamsWithAPIKey(v, true)
+}
+
+// LoadParamsWithAPIKey loads heartbeat config params from viper.Viper instance.
+// When apiKeyRequired is true, returns ErrAuth if failed to retrieve api key.
+func LoadParamsWithAPIKey(v *viper.Viper, apiKeyRequired bool) (Params, error) {
+	params, err := legacyparams.Load(v, apiKeyRequired)
 	if err != nil {
 		return Params{}, err
 	}

--- a/cmd/legacy/legacyparams/params.go
+++ b/cmd/legacy/legacyparams/params.go
@@ -82,12 +82,12 @@ func (p API) String() string {
 
 // Load loads legacy params from viper.Viper instance. Returns ErrAuth
 // if failed to retrieve api key.
-func Load(v *viper.Viper) (Params, error) {
+func Load(v *viper.Viper, apiKeyRequired bool) (Params, error) {
 	if v == nil {
 		return Params{}, errors.New("viper instance unset")
 	}
 
-	apiParams, err := loadAPIParams(v)
+	apiParams, err := loadAPIParams(v, apiKeyRequired)
 	if err != nil {
 		return Params{}, fmt.Errorf("failed to load api params: %w", err)
 	}
@@ -131,13 +131,13 @@ func Load(v *viper.Viper) (Params, error) {
 	}, nil
 }
 
-func loadAPIParams(v *viper.Viper) (API, error) {
+func loadAPIParams(v *viper.Viper, apiKeyRequired bool) (API, error) {
 	apiKey, ok := vipertools.FirstNonEmptyString(v, "key", "settings.api_key", "settings.apikey")
-	if !ok {
+	if !ok && apiKeyRequired {
 		return API{}, api.ErrAuth("failed to load api key")
 	}
 
-	if !apiKeyRegex.Match([]byte(apiKey)) {
+	if apiKeyRequired && !apiKeyRegex.Match([]byte(apiKey)) {
 		return API{}, api.ErrAuth("invalid api key format")
 	}
 

--- a/cmd/legacy/legacyparams/params_test.go
+++ b/cmd/legacy/legacyparams/params_test.go
@@ -25,7 +25,7 @@ func TestLoad_OfflineDisabled_ConfigTakesPrecedence(t *testing.T) {
 	v.Set("disableoffline", false)
 	v.Set("settings.offline", false)
 
-	params, err := legacyparams.Load(v)
+	params, err := legacyparams.Load(v, true)
 	require.NoError(t, err)
 
 	assert.True(t, params.OfflineDisabled)
@@ -39,7 +39,7 @@ func TestLoad_OfflineDisabled_FlagDeprecatedTakesPrecedence(t *testing.T) {
 	v.Set("disable-offline", false)
 	v.Set("disableoffline", true)
 
-	params, err := legacyparams.Load(v)
+	params, err := legacyparams.Load(v, true)
 	require.NoError(t, err)
 
 	assert.True(t, params.OfflineDisabled)
@@ -52,7 +52,7 @@ func TestLoad_OfflineDisabled_FromFlag(t *testing.T) {
 	v.Set("entity", "/path/to/file")
 	v.Set("disable-offline", true)
 
-	params, err := legacyparams.Load(v)
+	params, err := legacyparams.Load(v, true)
 	require.NoError(t, err)
 
 	assert.True(t, params.OfflineDisabled)
@@ -65,7 +65,7 @@ func TestLoad_OfflineQueueFile(t *testing.T) {
 	v.Set("entity", "/path/to/file")
 	v.Set("offline-queue-file", "/path/to/file")
 
-	params, err := legacyparams.Load(v)
+	params, err := legacyparams.Load(v, true)
 	require.NoError(t, err)
 
 	assert.Equal(t, "/path/to/file", params.OfflineQueueFile)
@@ -78,7 +78,7 @@ func TestLoad_OfflineSyncMax(t *testing.T) {
 	v.Set("entity", "/path/to/file")
 	v.Set("sync-offline-activity", 42)
 
-	params, err := legacyparams.Load(v)
+	params, err := legacyparams.Load(v, true)
 	require.NoError(t, err)
 
 	assert.Equal(t, 42, params.OfflineSyncMax)
@@ -90,7 +90,7 @@ func TestLoad_OfflineSyncMax_NoEntity(t *testing.T) {
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("sync-offline-activity", 42)
 
-	params, err := legacyparams.Load(v)
+	params, err := legacyparams.Load(v, true)
 	require.NoError(t, err)
 
 	assert.Equal(t, 42, params.OfflineSyncMax)
@@ -103,7 +103,7 @@ func TestLoad_OfflineSyncMax_None(t *testing.T) {
 	v.Set("entity", "/path/to/file")
 	v.Set("sync-offline-activity", "none")
 
-	params, err := legacyparams.Load(v)
+	params, err := legacyparams.Load(v, true)
 	require.NoError(t, err)
 
 	assert.Equal(t, 0, params.OfflineSyncMax)
@@ -115,7 +115,7 @@ func TestLoad_OfflineSyncMax_Default(t *testing.T) {
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 
-	params, err := legacyparams.Load(v)
+	params, err := legacyparams.Load(v, true)
 	require.NoError(t, err)
 
 	assert.Equal(t, 1000, params.OfflineSyncMax)
@@ -128,7 +128,7 @@ func TestLoad_OfflineSyncMax_NegativeNumber(t *testing.T) {
 	v.Set("entity", "/path/to/file")
 	v.Set("sync-offline-activity", -1)
 
-	_, err := legacyparams.Load(v)
+	_, err := legacyparams.Load(v, true)
 	require.Error(t, err)
 
 	assert.Contains(t, err.Error(), "--sync-offline-activity")
@@ -141,7 +141,7 @@ func TestLoad_OfflineSyncMax_NonIntegerValue(t *testing.T) {
 	v.Set("entity", "/path/to/file")
 	v.Set("sync-offline-activity", "invalid")
 
-	_, err := legacyparams.Load(v)
+	_, err := legacyparams.Load(v, true)
 	require.Error(t, err)
 
 	assert.Contains(t, err.Error(), "--sync-offline-activity")
@@ -201,7 +201,7 @@ func TestLoad_API_APIKey(t *testing.T) {
 			v.Set("settings.apikey", test.ViperAPIKeyConfigOld)
 			v.Set("hostname", "my-computer")
 
-			params, err := legacyparams.Load(v)
+			params, err := legacyparams.Load(v, true)
 			require.NoError(t, err)
 
 			assert.Equal(t, test.Expected, params)
@@ -223,7 +223,7 @@ func TestLoad_API_APIKeyInvalid(t *testing.T) {
 			v.SetDefault("sync-offline-activity", 1000)
 			v.Set("key", value)
 
-			_, err := legacyparams.Load(v)
+			_, err := legacyparams.Load(v, true)
 			require.Error(t, err)
 
 			var errauth api.ErrAuth
@@ -320,7 +320,7 @@ func TestLoad_API_APIUrl(t *testing.T) {
 			v.Set("settings.api_url", test.ViperAPIUrlConfig)
 			v.Set("hostname", "my-computer")
 
-			params, err := legacyparams.Load(v)
+			params, err := legacyparams.Load(v, true)
 			require.NoError(t, err)
 
 			assert.Equal(t, test.Expected, params)
@@ -334,7 +334,7 @@ func TestLoad_APIUrl_Default(t *testing.T) {
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 
-	params, err := legacyparams.Load(v)
+	params, err := legacyparams.Load(v, true)
 	require.NoError(t, err)
 
 	assert.Equal(t, api.BaseURL, params.API.URL)
@@ -355,7 +355,7 @@ func TestLoad_API_BackoffAt(t *testing.T) {
 
 	copyFile(t, "testdata/internal-with-backoff.cfg", tmpFile.Name())
 
-	params, err := legacyparams.Load(v)
+	params, err := legacyparams.Load(v, true)
 	require.NoError(t, err)
 
 	backoffAt, err := time.Parse(config.DateFormat, "2021-08-30T18:50:42-03:00")
@@ -385,7 +385,7 @@ func TestLoad_API_BackoffAtErr(t *testing.T) {
 
 	copyFile(t, "testdata/internal-malformed-backoff.cfg", tmpFile.Name())
 
-	params, err := legacyparams.Load(v)
+	params, err := legacyparams.Load(v, true)
 	require.NoError(t, err)
 
 	assert.Equal(t, legacyparams.API{
@@ -404,7 +404,7 @@ func TestLoad_API_Plugin(t *testing.T) {
 	v.Set("plugin", "plugin/10.0.0")
 	v.Set("hostname", "my-computer")
 
-	params, err := legacyparams.Load(v)
+	params, err := legacyparams.Load(v, true)
 	require.NoError(t, err)
 
 	assert.Equal(t, legacyparams.API{
@@ -422,7 +422,7 @@ func TestLoad_API_Timeout_FlagTakesPreceedence(t *testing.T) {
 	v.Set("timeout", 5)
 	v.Set("settings.timeout", 10)
 
-	params, err := legacyparams.Load(v)
+	params, err := legacyparams.Load(v, true)
 	require.NoError(t, err)
 
 	assert.Equal(t, 5*time.Second, params.API.Timeout)
@@ -434,7 +434,7 @@ func TestLoad_API_Timeout_FromConfig(t *testing.T) {
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("settings.timeout", 10)
 
-	params, err := legacyparams.Load(v)
+	params, err := legacyparams.Load(v, true)
 	require.NoError(t, err)
 
 	assert.Equal(t, 10*time.Second, params.API.Timeout)
@@ -448,7 +448,7 @@ func TestLoad_API_DisableSSLVerify_FlagTakesPrecedence(t *testing.T) {
 	v.Set("no-ssl-verify", true)
 	v.Set("settings.no_ssl_verify", false)
 
-	params, err := legacyparams.Load(v)
+	params, err := legacyparams.Load(v, true)
 	require.NoError(t, err)
 
 	assert.True(t, params.API.DisableSSLVerify)
@@ -461,7 +461,7 @@ func TestLoad_API_DisableSSLVerify_FromConfig(t *testing.T) {
 	v.Set("entity", "/path/to/file")
 	v.Set("settings.no_ssl_verify", true)
 
-	params, err := legacyparams.Load(v)
+	params, err := legacyparams.Load(v, true)
 	require.NoError(t, err)
 
 	assert.True(t, params.API.DisableSSLVerify)
@@ -473,7 +473,7 @@ func TestLoad_API_DisableSSLVerify_Default(t *testing.T) {
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 
-	params, err := legacyparams.Load(v)
+	params, err := legacyparams.Load(v, true)
 	require.NoError(t, err)
 
 	assert.False(t, params.API.DisableSSLVerify)
@@ -495,7 +495,7 @@ func TestLoad_API_ProxyURL(t *testing.T) {
 			v.Set("entity", "/path/to/file")
 			v.Set("proxy", proxyURL)
 
-			params, err := legacyparams.Load(v)
+			params, err := legacyparams.Load(v, true)
 			require.NoError(t, err)
 
 			assert.Equal(t, proxyURL, params.API.ProxyURL)
@@ -511,7 +511,7 @@ func TestLoad_API_ProxyURL_FlagTakesPrecedence(t *testing.T) {
 	v.Set("proxy", "https://john:secret@example.org:8888")
 	v.Set("settings.proxy", "ignored")
 
-	params, err := legacyparams.Load(v)
+	params, err := legacyparams.Load(v, true)
 	require.NoError(t, err)
 
 	assert.Equal(t, "https://john:secret@example.org:8888", params.API.ProxyURL)
@@ -524,7 +524,7 @@ func TestLoad_API_ProxyURL_FromConfig(t *testing.T) {
 	v.Set("entity", "/path/to/file")
 	v.Set("settings.proxy", "https://john:secret@example.org:8888")
 
-	params, err := legacyparams.Load(v)
+	params, err := legacyparams.Load(v, true)
 	require.NoError(t, err)
 
 	assert.Equal(t, "https://john:secret@example.org:8888", params.API.ProxyURL)
@@ -539,7 +539,7 @@ func TestLoad_API_ProxyURL_InvalidFormat(t *testing.T) {
 	v.Set("entity", "/path/to/file")
 	v.Set("proxy", proxyURL)
 
-	_, err := legacyparams.Load(v)
+	_, err := legacyparams.Load(v, true)
 	require.Error(t, err)
 }
 
@@ -553,7 +553,7 @@ func TestLoad_API_SSLCertFilepath_FlagTakesPrecedence(t *testing.T) {
 	home, err := os.UserHomeDir()
 	require.NoError(t, err)
 
-	params, err := legacyparams.Load(v)
+	params, err := legacyparams.Load(v, true)
 	require.NoError(t, err)
 
 	assert.Equal(t, filepath.Join(home, "/path/to/cert.pem"), params.API.SSLCertFilepath)
@@ -566,7 +566,7 @@ func TestLoad_API_SSLCertFilepath_FromConfig(t *testing.T) {
 	v.Set("entity", "/path/to/file")
 	v.Set("settings.ssl_certs_file", "/path/to/cert.pem")
 
-	params, err := legacyparams.Load(v)
+	params, err := legacyparams.Load(v, true)
 	require.NoError(t, err)
 
 	assert.Equal(t, "/path/to/cert.pem", params.API.SSLCertFilepath)
@@ -579,7 +579,7 @@ func TestLoadParams_Hostname_FlagTakesPrecedence(t *testing.T) {
 	v.Set("hostname", "my-machine")
 	v.Set("settings.hostname", "ignored")
 
-	params, err := legacyparams.Load(v)
+	params, err := legacyparams.Load(v, true)
 	require.NoError(t, err)
 
 	assert.Equal(t, "my-machine", params.API.Hostname)
@@ -591,7 +591,7 @@ func TestLoadParams_Hostname_FromConfig(t *testing.T) {
 	v.Set("entity", "/path/to/file")
 	v.Set("settings.hostname", "my-machine")
 
-	params, err := legacyparams.Load(v)
+	params, err := legacyparams.Load(v, true)
 	require.NoError(t, err)
 
 	assert.Equal(t, "my-machine", params.API.Hostname)
@@ -602,7 +602,7 @@ func TestLoadParams_Hostname_DefaultFromSystem(t *testing.T) {
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 
-	params, err := legacyparams.Load(v)
+	params, err := legacyparams.Load(v, true)
 	require.NoError(t, err)
 
 	expected, err := os.Hostname()

--- a/cmd/legacy/offlinecount/offlinecount.go
+++ b/cmd/legacy/offlinecount/offlinecount.go
@@ -20,7 +20,7 @@ func Run(v *viper.Viper) (int, error) {
 		)
 	}
 
-	params, err := legacyparams.Load(v)
+	params, err := legacyparams.Load(v, true)
 	if err != nil {
 		return exitcode.ErrGeneric, fmt.Errorf("failed to load command parameters: %w", err)
 	}

--- a/cmd/legacy/offlinesync/offlinesync.go
+++ b/cmd/legacy/offlinesync/offlinesync.go
@@ -64,7 +64,7 @@ func Run(v *viper.Viper) (int, error) {
 // SyncOfflineActivity syncs offline activity by sending heartbeats
 // from the offline queue to the WakaTime API.
 func SyncOfflineActivity(v *viper.Viper, queueFilepath string) error {
-	params, err := legacyparams.Load(v)
+	params, err := legacyparams.Load(v, true)
 	if err != nil {
 		return fmt.Errorf("failed to load command parameters: %w", err)
 	}

--- a/cmd/legacy/run.go
+++ b/cmd/legacy/run.go
@@ -43,10 +43,14 @@ func Run(cmd *cobra.Command, v *viper.Viper) {
 		SetupLogging(v)
 		log.Errorf("failed to load configuration file: %s", err)
 
+		if v.IsSet("entity") {
+			RunCmd(v, false, heartbeatcmd.RunWithoutSending)
+		}
+
 		os.Exit(exitcode.ErrConfigFileParse)
 	}
 
-	logFileParms := SetupLogging(v)
+	logFileParams := SetupLogging(v)
 
 	if v.GetBool("useragent") {
 		log.Debugln("command: useragent")
@@ -65,49 +69,49 @@ func Run(cmd *cobra.Command, v *viper.Viper) {
 	if v.GetBool("version") {
 		log.Debugln("command: version")
 
-		RunCmd(v, logFileParms.Verbose, runVersion)
+		RunCmd(v, logFileParams.Verbose, runVersion)
 	}
 
 	if v.IsSet("config-read") {
 		log.Debugln("command: config-read")
 
-		RunCmd(v, logFileParms.Verbose, configread.Run)
+		RunCmd(v, logFileParams.Verbose, configread.Run)
 	}
 
 	if v.IsSet("config-write") {
 		log.Debugln("command: config-write")
 
-		RunCmd(v, logFileParms.Verbose, configwrite.Run)
+		RunCmd(v, logFileParams.Verbose, configwrite.Run)
 	}
 
 	if v.GetBool("today") {
 		log.Debugln("command: today")
 
-		RunCmd(v, logFileParms.Verbose, today.Run)
+		RunCmd(v, logFileParams.Verbose, today.Run)
 	}
 
 	if v.IsSet("today-goal") {
 		log.Debugln("command: today-goal")
 
-		RunCmd(v, logFileParms.Verbose, todaygoal.Run)
+		RunCmd(v, logFileParams.Verbose, todaygoal.Run)
 	}
 
 	if v.IsSet("entity") {
 		log.Debugln("command: heartbeat")
 
-		RunCmdWithOfflineSync(v, logFileParms.Verbose, heartbeatcmd.Run)
+		RunCmdWithOfflineSync(v, logFileParams.Verbose, heartbeatcmd.Run)
 	}
 
 	if v.IsSet("sync-offline-activity") {
 		log.Debugln("command: sync-offline-activity")
 
-		RunCmd(v, logFileParms.Verbose, offlinesync.Run)
+		RunCmd(v, logFileParams.Verbose, offlinesync.Run)
 	}
 
 	if v.GetBool("offline-count") {
 		log.Debugln("command: offline-count")
 
-		RunCmd(v, logFileParms.Verbose, offlinecount.Run)
+		RunCmd(v, logFileParams.Verbose, offlinecount.Run)
 	}
 
 	log.Warnf("one of the following parameters has to be provided: %s", strings.Join([]string{
@@ -210,7 +214,7 @@ func runCmd(v *viper.Viper, verbose bool, cmd cmdFn) int {
 }
 
 func sendDiagnostics(v *viper.Viper, logs, stack string) {
-	params, err := legacyparams.Load(v)
+	params, err := legacyparams.Load(v, true)
 	if err != nil {
 		log.Errorf("failed to load parameters for sending diagnostics: %s", err)
 

--- a/cmd/legacy/today/today.go
+++ b/cmd/legacy/today/today.go
@@ -56,7 +56,7 @@ func Run(v *viper.Viper) (int, error) {
 
 // Today returns a rendered summary of todays coding activity.
 func Today(v *viper.Viper) (string, error) {
-	params, err := legacyparams.Load(v)
+	params, err := legacyparams.Load(v, true)
 	if err != nil {
 		return "", fmt.Errorf("failed to load command parameters: %w", err)
 	}

--- a/cmd/legacy/todaygoal/todaygoal.go
+++ b/cmd/legacy/todaygoal/todaygoal.go
@@ -86,7 +86,7 @@ func Goal(v *viper.Viper) (string, error) {
 // LoadParams loads todaygoal config params from viper.Viper instance. Returns ErrAuth
 // if failed to retrieve api key.
 func LoadParams(v *viper.Viper) (Params, error) {
-	params, err := legacyparams.Load(v)
+	params, err := legacyparams.Load(v, true)
 	if err != nil {
 		return Params{}, fmt.Errorf("failed to load params: %w", err)
 	}

--- a/pkg/heartbeat/heartbeat.go
+++ b/pkg/heartbeat/heartbeat.go
@@ -149,13 +149,13 @@ type HandleOption func(next Handle) Handle
 // NewHandle creates a new Handle, which acts like a processing pipeline,
 // with a sender eventually sending the heartbeats.
 func NewHandle(sender Sender, opts ...HandleOption) Handle {
-	return func(hh []Heartbeat) ([]Result, error) {
-		var h Handle = sender.SendHeartbeats
+	return func(heartbeats []Heartbeat) ([]Result, error) {
+		var handle Handle = sender.SendHeartbeats
 		for i := len(opts) - 1; i >= 0; i-- {
-			h = opts[i](h)
+			handle = opts[i](handle)
 		}
 
-		return h(hh)
+		return handle(heartbeats)
 	}
 }
 

--- a/pkg/offline/offline_test.go
+++ b/pkg/offline/offline_test.go
@@ -76,7 +76,7 @@ func TestWithQueue(t *testing.T) {
 
 	db.Close()
 
-	opt, err := offline.WithQueue(f.Name(), 10)
+	opt, err := offline.WithQueue(f.Name())
 	require.NoError(t, err)
 
 	handle := opt(func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
@@ -149,7 +149,7 @@ func TestWithQueue_ApiError(t *testing.T) {
 
 	defer os.Remove(f.Name())
 
-	opt, err := offline.WithQueue(f.Name(), 10)
+	opt, err := offline.WithQueue(f.Name())
 	require.NoError(t, err)
 
 	handle := opt(func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
@@ -212,7 +212,7 @@ func TestWithQueue_InvalidResults(t *testing.T) {
 
 	defer os.Remove(f.Name())
 
-	opt, err := offline.WithQueue(f.Name(), 10)
+	opt, err := offline.WithQueue(f.Name())
 	require.NoError(t, err)
 
 	handle := opt(func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
@@ -298,7 +298,7 @@ func TestWithQueue_HandleLeftovers(t *testing.T) {
 
 	defer os.Remove(f.Name())
 
-	opt, err := offline.WithQueue(f.Name(), 10)
+	opt, err := offline.WithQueue(f.Name())
 	require.NoError(t, err)
 
 	handle := opt(func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {


### PR DESCRIPTION
When unable to parse `~/.wakatime.cfg`, save any heartbeats to the offline db at `~/.wakatime.bdb` before exiting.

Also fixes a bug where extra heartbeats not sent to API if the file from `--entity` does not exist on disk, even though extra heartbeats could be pointing to a different entity file that is on disk.

Fixes #577.