### PR TITLE
Internal config parse

### DIFF
--- a/cmd/legacy/heartbeat/heartbeat.go
+++ b/cmd/legacy/heartbeat/heartbeat.go
@@ -92,6 +92,10 @@ func RunWithoutSending(v *viper.Viper) (int, error) {
 	handleOpts := initHandleOptions(params)
 
 	if !params.OfflineDisabled {
+		if params.OfflineQueueFile != "" {
+			queueFilepath = params.OfflineQueueFile
+		}
+
 		offlineHandleOpt, err := offline.WithQueue(queueFilepath)
 		if err != nil {
 			return exitcode.ErrConfigFileParse, fmt.Errorf("failed to initialize offline queue handle option: %w", err)

--- a/cmd/legacy/legacyparams/params.go
+++ b/cmd/legacy/legacyparams/params.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/wakatime/wakatime-cli/pkg/api"
 	"github.com/wakatime/wakatime-cli/pkg/config"
-	"github.com/wakatime/wakatime-cli/pkg/ini"
 	"github.com/wakatime/wakatime-cli/pkg/log"
 	"github.com/wakatime/wakatime-cli/pkg/vipertools"
 
@@ -154,22 +153,9 @@ func loadAPIParams(v *viper.Viper, apiKeyRequired bool) (API, error) {
 	apiURL = strings.TrimSuffix(apiURL, "/heartbeats")
 	apiURL = strings.TrimSuffix(apiURL, "/heartbeat")
 
-	internalConfig, err := config.InternalFilePath(v)
-	if err != nil {
-		return API{}, fmt.Errorf("failed parsing backoff configs: %s", err)
-	}
+	var backoffAt time.Time
 
-	internalKeys := ini.GetKeys(internalConfig, []ini.Key{
-		{Section: "internal", Name: "backoff_at"},
-		{Section: "internal", Name: "backoff_retries"},
-	})
-
-	var (
-		backoffAt      time.Time
-		backoffRetries int
-	)
-
-	backoffAtStr := internalKeys[ini.Key{Section: "internal", Name: "backoff_at"}]
+	backoffAtStr := vipertools.GetString(v, "internal.backoff_at")
 	if backoffAtStr != "" {
 		parsed, err := time.Parse(config.DateFormat, backoffAtStr)
 		if err != nil {
@@ -179,16 +165,11 @@ func loadAPIParams(v *viper.Viper, apiKeyRequired bool) (API, error) {
 		}
 	}
 
-	backoffRetriesStr := internalKeys[ini.Key{Section: "internal", Name: "backoff_retries"}]
-	if backoffRetriesStr != "" {
-		backoffRetries, err = strconv.Atoi(backoffRetriesStr)
-		if err != nil {
-			log.Warnf("failed to parse backoff_retries: %s", err)
-		}
-	}
+	backoffRetries, _ := vipertools.FirstNonEmptyInt(v, "internal.backoff_retries")
 
 	var (
 		hostname string
+		err      error
 	)
 
 	hostname, ok = vipertools.FirstNonEmptyString(v, "hostname", "settings.hostname")

--- a/cmd/legacy/legacyparams/params_test.go
+++ b/cmd/legacy/legacyparams/params_test.go
@@ -345,15 +345,8 @@ func TestLoad_API_BackoffAt(t *testing.T) {
 	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("hostname", "my-computer")
-
-	tmpFile, err := os.CreateTemp(os.TempDir(), "wakatime")
-	require.NoError(t, err)
-
-	defer os.Remove(tmpFile.Name())
-
-	v.Set("internal-config", tmpFile.Name())
-
-	copyFile(t, "testdata/internal-with-backoff.cfg", tmpFile.Name())
+	v.Set("internal.backoff_at", "2021-08-30T18:50:42-03:00")
+	v.Set("internal.backoff_retries", "3")
 
 	params, err := legacyparams.Load(v, true)
 	require.NoError(t, err)
@@ -375,15 +368,8 @@ func TestLoad_API_BackoffAtErr(t *testing.T) {
 	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("hostname", "my-computer")
-
-	tmpFile, err := os.CreateTemp(os.TempDir(), "wakatime")
-	require.NoError(t, err)
-
-	defer os.Remove(tmpFile.Name())
-
-	v.Set("internal-config", tmpFile.Name())
-
-	copyFile(t, "testdata/internal-malformed-backoff.cfg", tmpFile.Name())
+	v.Set("internal.backoff_at", "2021-08-30")
+	v.Set("internal.backoff_retries", "2")
 
 	params, err := legacyparams.Load(v, true)
 	require.NoError(t, err)
@@ -609,12 +595,4 @@ func TestLoadParams_Hostname_DefaultFromSystem(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, expected, params.API.Hostname)
-}
-
-func copyFile(t *testing.T, source, destination string) {
-	input, err := os.ReadFile(source)
-	require.NoError(t, err)
-
-	err = os.WriteFile(destination, input, 0600)
-	require.NoError(t, err)
 }

--- a/cmd/legacy/legacyparams/testdata/internal-malformed-backoff.cfg
+++ b/cmd/legacy/legacyparams/testdata/internal-malformed-backoff.cfg
@@ -1,3 +1,0 @@
-[internal]
-backoff_at = 2021-08-30
-backoff_retries = 2

--- a/cmd/legacy/legacyparams/testdata/internal-with-backoff.cfg
+++ b/cmd/legacy/legacyparams/testdata/internal-with-backoff.cfg
@@ -1,3 +1,0 @@
-[internal]
-backoff_at = 2021-08-30T18:50:42-03:00
-backoff_retries = 3

--- a/cmd/legacy/run.go
+++ b/cmd/legacy/run.go
@@ -37,8 +37,26 @@ func Run(cmd *cobra.Command, v *viper.Viper) {
 		fmt.Fprintf(os.Stderr, "error getting config file path: %s", err)
 	}
 
+	internalConfigFile, err := config.InternalFilePath(v)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error getting internal config file path: %s", err)
+	}
+
 	if err := config.ReadInConfig(v, configFile); err != nil {
 		fmt.Fprintf(os.Stderr, "failed to load configuration file: %s", err)
+
+		SetupLogging(v)
+		log.Errorf("failed to load configuration file: %s", err)
+
+		if v.IsSet("entity") {
+			RunCmd(v, false, heartbeatcmd.RunWithoutSending)
+		}
+
+		os.Exit(exitcode.ErrConfigFileParse)
+	}
+
+	if err := config.ReadInConfig(v, internalConfigFile); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to load internal configuration file: %s", err)
 
 		SetupLogging(v)
 		log.Errorf("failed to load configuration file: %s", err)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -84,7 +84,7 @@ func ReadInConfig(v *viper.Viper, configFilePath string) error {
 		return nil
 	}
 
-	if err := v.ReadInConfig(); err != nil {
+	if err := v.MergeInConfig(); err != nil {
 		return fmt.Errorf("error parsing config file: %s", err)
 	}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -26,7 +26,7 @@ func TestReadInConfig(t *testing.T) {
 
 	assert.Equal(t, "b9485572-74bf-419a-916b-22056ca3a24c", vipertools.GetString(v, "settings.api_key"))
 	assert.Equal(t, "true", vipertools.GetString(v, "settings.debug"))
-	assert.Equal(t, "true", vipertools.GetString(v, "test.pandemia"))
+	assert.Equal(t, "us", vipertools.GetString(v, "other.country"))
 }
 
 func TestReadInConfig_Multiline(t *testing.T) {
@@ -45,6 +45,31 @@ func TestReadInConfig_Multiline(t *testing.T) {
 	assert.Equal(t, "\n.*secret.*\nfix.*", gitConfig)
 }
 
+func TestReadInConfig_Multiple(t *testing.T) {
+	v := viper.New()
+
+	v.Set("config", "./testdata/wakatime.cfg")
+	v.Set("internal-config", "./testdata/wakatime-internal.cfg")
+
+	filePath, err := config.FilePath(v)
+	require.NoError(t, err)
+
+	internalFilePath, err := config.InternalFilePath(v)
+	require.NoError(t, err)
+
+	err = config.ReadInConfig(v, filePath)
+	require.NoError(t, err)
+
+	err = config.ReadInConfig(v, internalFilePath)
+	require.NoError(t, err)
+
+	assert.Equal(t, "b9485572-74bf-419a-916b-22056ca3a24c", vipertools.GetString(v, "settings.api_key"))
+	assert.Equal(t, "true", vipertools.GetString(v, "settings.debug"))
+	assert.Equal(t, "us", vipertools.GetString(v, "other.country"))
+	assert.Equal(t, "2021-11-25T12:17:21-07:00", vipertools.GetString(v, "internal.backoff_at"))
+	assert.Equal(t, "3", vipertools.GetString(v, "internal.backoff_retries"))
+}
+
 func TestReadInConfig_DoesNotExit_NoError(t *testing.T) {
 	v := viper.New()
 	v.Set("config", "./testdata/any.cfg")
@@ -57,7 +82,7 @@ func TestReadInConfig_DoesNotExit_NoError(t *testing.T) {
 func TestReadInConfigMissing(t *testing.T) {
 	v := viper.New()
 	err := config.ReadInConfig(v, "not-exists")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestReadInConfigMalformed(t *testing.T) {
@@ -66,7 +91,7 @@ func TestReadInConfigMalformed(t *testing.T) {
 	filePath, err := config.FilePath(v)
 	require.NoError(t, err)
 	err = config.ReadInConfig(v, filePath)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestFilePath(t *testing.T) {

--- a/pkg/config/testdata/wakatime-internal.cfg
+++ b/pkg/config/testdata/wakatime-internal.cfg
@@ -1,0 +1,3 @@
+[internal]
+backoff_at                = 2021-11-25T12:17:21-07:00
+backoff_retries           = 3

--- a/pkg/config/testdata/wakatime.cfg
+++ b/pkg/config/testdata/wakatime.cfg
@@ -2,5 +2,5 @@
 api_key = b9485572-74bf-419a-916b-22056ca3a24c
 debug = true
 
-[test]
-pandemia = true
+[other]
+country = us

--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -65,14 +65,14 @@ func Filter(h heartbeat.Heartbeat, config Config) error {
 
 	// filter by pattern
 	if err := filterByPattern(h.Entity, config.Include, config.Exclude); err != nil {
-		return fmt.Errorf("filter by pattern: %w", err)
+		return Err(fmt.Sprintf("filter by pattern: %s", err))
 	}
 
 	// filter file
 	if h.EntityType == heartbeat.FileType {
 		err := filterFileEntity(h.Entity, config.IncludeOnlyWithProjectFile)
 		if err != nil {
-			return fmt.Errorf("filter file: %w", err)
+			return Err(fmt.Sprintf("filter file: %s", err))
 		}
 	}
 

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -148,7 +148,8 @@ func TestFilter_ErrMatchesExcludePattern(t *testing.T) {
 	var errv filter.Err
 
 	assert.True(t, errors.As(err, &errv))
-	assert.Equal(t, filter.Err("skipping because matches exclude pattern \"^.*exclude-this-file.*$\""), errv)
+	assert.Equal(t,
+		filter.Err("filter by pattern: skipping because matches exclude pattern \"^.*exclude-this-file.*$\""), errv)
 }
 
 func TestFilter_ErrUnknownProject(t *testing.T) {
@@ -190,7 +191,7 @@ func TestFilter_ErrNonExistingFile(t *testing.T) {
 	var errv filter.Err
 
 	assert.True(t, errors.As(err, &errv))
-	assert.Equal(t, filter.Err("skipping because of non-existing file \"/tmp/main.go\""), errv)
+	assert.Equal(t, filter.Err("filter file: skipping because of non-existing file \"/tmp/main.go\""), errv)
 }
 
 func TestFilter_ExistingProjectFile(t *testing.T) {
@@ -233,7 +234,7 @@ func TestFilter_ErrNonExistingProjectFile(t *testing.T) {
 	var errv filter.Err
 
 	assert.True(t, errors.As(err, &errv))
-	assert.Equal(t, filter.Err("skipping because of missing .wakatime-project file in parent path"), errv)
+	assert.Equal(t, filter.Err("filter file: skipping because of missing .wakatime-project file in parent path"), errv)
 }
 
 func testHeartbeat() heartbeat.Heartbeat {

--- a/pkg/offline/offline.go
+++ b/pkg/offline/offline.go
@@ -145,8 +145,7 @@ func Sync(filepath string, syncLimit int) func(next heartbeat.Handle) error {
 }
 
 // Sender is a noop api client, used by heartbeat.RunWithoutSending.
-type Sender struct {
-}
+type Sender struct{}
 
 // SendHeartbeats always returns an error.
 func (s *Sender) SendHeartbeats(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {

--- a/testdata/internal-malformed.cfg
+++ b/testdata/internal-malformed.cfg
@@ -1,0 +1,2 @@
+[internal
+backoff_at = 

--- a/testdata/malformed.cfg
+++ b/testdata/malformed.cfg
@@ -1,0 +1,5 @@
+[settings
+debug = true
+
+[other]
+key = 1


### PR DESCRIPTION
This PR moves the responsability of loading `internal-config` file to the main entry likewise for reading the regular config file and also gives back the initial approach of reading any param using Viper. It was also breaking tests on my side because there was backoff set at my waka config file. In addition it also includes a fix for filtering heartbeat where the error message was truncated. 