### PR TITLE
Fix finding for file or directory

### DIFF
--- a/pkg/project/file_test.go
+++ b/pkg/project/file_test.go
@@ -141,6 +141,16 @@ func TestFindFileOrDirectory(t *testing.T) {
 	}
 }
 
+func TestFindFileOrDirectory_RootPath(t *testing.T) {
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+
+	fp, ok := project.FindFileOrDirectory(wd, "non-file.any")
+	require.False(t, ok)
+
+	assert.Empty(t, fp)
+}
+
 func copyFile(t *testing.T, source, destination string) {
 	input, err := os.ReadFile(source)
 	require.NoError(t, err)

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -242,15 +242,14 @@ func generateProjectName() string {
 func FindFileOrDirectory(directory, filename string) (string, bool) {
 	i := 0
 	for i < maxRecursiveIteration {
-		if isRootPath(directory) {
-			return "", false
-		}
-
 		if fileExists(filepath.Join(directory, filename)) {
 			return filepath.Join(directory, filename), true
 		}
 
 		directory = filepath.Clean(filepath.Join(directory, ".."))
+		if isRootPath(directory) {
+			return "", false
+		}
 
 		i++
 	}
@@ -263,7 +262,6 @@ func FindFileOrDirectory(directory, filename string) (string, bool) {
 func isRootPath(directory string) bool {
 	return (directory == "." ||
 		directory == string(filepath.Separator) ||
-		directory == "" ||
 		driveLetterRegex.MatchString(directory) ||
 		filepath.VolumeName(directory) == directory)
 }


### PR DESCRIPTION
This PR fixes `FindFileOrDirectory` func which is not correctly detecting the root path and reaching max iterations of 500. I also added a single test to ensure root path is reached before 500 cycles.

Closes #600