### PR TITLE
Add project folder obfuscation

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -17,6 +17,7 @@ api_url = https://api.wakatime.com/api/v1
 hide_file_names = false
 hide_project_names = false
 hide_branch_names =
+hide_project_folder = false
 exclude =
     ^COMMIT_EDITMSG$
     ^TAG_EDITMSG$
@@ -53,6 +54,7 @@ submodules_disabled = false
 | hide_file_names                | Obfuscate filenames. Will not send file names to api. | _bool_;_list_ | `false` |
 | hide_project_names             | Obfuscate project names. When a project folder is detected instead of using the folder name as the project, a `.wakatime-project file` is created with a random project name. | _bool_;_list_ | `false` |
 | hide_branch_names              | Obfuscate branch names. Will not send revision control branch names to api. | _bool_;_list_ | `false` |
+| hide_project_folder            | When set, send the file's path relative to the project folder. For ex: `/User/me/projects/bar/src/file.ts` is sent as `src/file.ts` so the server never sees the full path. When the project folder cannot be detected, only the file name is sent. For ex: `file.ts`. | _bool_ | `false` |
 | exclude                        | Filename patterns to exclude from logging. POSIX regex syntax. | _bool_;_list_ | |
 | include                        | Filename patterns to log. When used in combination with `exclude`, files matching `include` will still be logged. POSIX regex syntax | _bool_;_list_ | |
 | include_only_with_project_file | Disables tracking folders unless they contain a `.wakatime-project file`. | _bool_ | `false` |
@@ -64,7 +66,7 @@ submodules_disabled = false
 | proxy                          | Optional proxy configuration. Supports HTTPS, SOCKS and NTLM proxies. For ex: `https://user:pass@host:port`, `socks5://user:pass@host:port`, `domain\\user:pass` | _string_ | |
 | no_ssl_verify                  | Disables SSL certificate verification for HTTPS requests. By default, SSL certificates are verified. | _bool_ | `false` |
 | ssl_certs_file                 | Path to a CA certs file. By default, uses bundled Letsencrypt CA cert along with system ca certs. | _filepath_ | |
-| timeout                        | Connection timeout in seconds when communicating with the api. | _int_ | `60` |
+| timeout                        | Connection timeout in seconds when communicating with the api. | _int_ | `120` |
 | hostname                       | Optional name of local machine. By default, auto-detects the local machine’s hostname. | _string_ | |
 | log_file                       | Optional log file path. | _filepath_ | `~/.wakatime.log` |
 

--- a/cmd/heartbeat/heartbeat.go
+++ b/cmd/heartbeat/heartbeat.go
@@ -164,6 +164,7 @@ func buildHeartbeats(params params.Params) []heartbeat.Heartbeat {
 			params.Heartbeat.LocalFile,
 			params.Heartbeat.Project.Alternate,
 			params.Heartbeat.Project.Override,
+			params.Heartbeat.Sanitize.ProjectPathOverride,
 			params.Heartbeat.Time,
 			userAgent,
 		))
@@ -192,6 +193,7 @@ func buildHeartbeats(params params.Params) []heartbeat.Heartbeat {
 				h.LocalFile,
 				h.ProjectAlternate,
 				h.ProjectOverride,
+				h.ProjectPathOverride,
 				h.Time,
 				userAgent,
 			))
@@ -224,9 +226,10 @@ func initHandleOptions(params params.Params) []heartbeat.HandleOption {
 			SubmodulePatterns: params.Heartbeat.Project.DisableSubmodule,
 		}),
 		heartbeat.WithSanitization(heartbeat.SanitizeConfig{
-			BranchPatterns:  params.Heartbeat.Sanitize.HideBranchNames,
-			FilePatterns:    params.Heartbeat.Sanitize.HideFileNames,
-			ProjectPatterns: params.Heartbeat.Sanitize.HideProjectNames,
+			BranchPatterns:    params.Heartbeat.Sanitize.HideBranchNames,
+			FilePatterns:      params.Heartbeat.Sanitize.HideFileNames,
+			HideProjectFolder: params.Heartbeat.Sanitize.HideProjectFolder,
+			ProjectPatterns:   params.Heartbeat.Sanitize.HideProjectNames,
 		}),
 	}
 }

--- a/cmd/offline/offline.go
+++ b/cmd/offline/offline.go
@@ -86,6 +86,7 @@ func buildHeartbeats(params params.Params) []heartbeat.Heartbeat {
 			params.Heartbeat.LocalFile,
 			params.Heartbeat.Project.Alternate,
 			params.Heartbeat.Project.Override,
+			params.Heartbeat.Sanitize.ProjectPathOverride,
 			params.Heartbeat.Time,
 			userAgent,
 		))
@@ -114,6 +115,7 @@ func buildHeartbeats(params params.Params) []heartbeat.Heartbeat {
 				h.LocalFile,
 				h.ProjectAlternate,
 				h.ProjectOverride,
+				h.ProjectPathOverride,
 				h.Time,
 				userAgent,
 			))
@@ -164,9 +166,10 @@ func initHandleOptions(params params.Params) []heartbeat.HandleOption {
 			SubmodulePatterns: params.Heartbeat.Project.DisableSubmodule,
 		}),
 		heartbeat.WithSanitization(heartbeat.SanitizeConfig{
-			BranchPatterns:  params.Heartbeat.Sanitize.HideBranchNames,
-			FilePatterns:    params.Heartbeat.Sanitize.HideFileNames,
-			ProjectPatterns: params.Heartbeat.Sanitize.HideProjectNames,
+			BranchPatterns:    params.Heartbeat.Sanitize.HideBranchNames,
+			FilePatterns:      params.Heartbeat.Sanitize.HideFileNames,
+			HideProjectFolder: params.Heartbeat.Sanitize.HideProjectFolder,
+			ProjectPatterns:   params.Heartbeat.Sanitize.HideProjectNames,
 		}),
 	}
 }

--- a/cmd/params/params.go
+++ b/cmd/params/params.go
@@ -114,9 +114,11 @@ type (
 
 	// SanitizeParams params for heartbeat sanitization.
 	SanitizeParams struct {
-		HideBranchNames  []regex.Regex
-		HideFileNames    []regex.Regex
-		HideProjectNames []regex.Regex
+		HideBranchNames     []regex.Regex
+		HideFileNames       []regex.Regex
+		HideProjectFolder   bool
+		HideProjectNames    []regex.Regex
+		ProjectPathOverride string
 	}
 
 	// StatusBar contains status bar related parameters.
@@ -408,8 +410,6 @@ func loadFilterParams(v *viper.Viper) FilterParams {
 }
 
 func loadSanitizeParams(v *viper.Viper) (SanitizeParams, error) {
-	var params SanitizeParams
-
 	// hide branch names
 	hideBranchNamesStr, _ := vipertools.FirstNonEmptyString(
 		v,
@@ -428,8 +428,6 @@ func loadSanitizeParams(v *viper.Viper) (SanitizeParams, error) {
 		)
 	}
 
-	params.HideBranchNames = hideBranchNamesPatterns
-
 	// hide project names
 	hideProjectNamesStr, _ := vipertools.FirstNonEmptyString(
 		v,
@@ -447,8 +445,6 @@ func loadSanitizeParams(v *viper.Viper) (SanitizeParams, error) {
 			err,
 		)
 	}
-
-	params.HideProjectNames = hideProjectNamesPatterns
 
 	// hide file names
 	hideFileNamesStr, _ := vipertools.FirstNonEmptyString(
@@ -470,16 +466,16 @@ func loadSanitizeParams(v *viper.Viper) (SanitizeParams, error) {
 		)
 	}
 
-	params.HideFileNames = hideFileNamesPatterns
-
-	return params, nil
+	return SanitizeParams{
+		HideBranchNames:     hideBranchNamesPatterns,
+		HideFileNames:       hideFileNamesPatterns,
+		HideProjectFolder:   vipertools.FirstNonEmptyBool(v, "hide-project-folder", "settings.hide_project_folder"),
+		HideProjectNames:    hideProjectNamesPatterns,
+		ProjectPathOverride: vipertools.GetString(v, "project-folder"),
+	}, nil
 }
 
 func loadProjectParams(v *viper.Viper) (ProjectParams, error) {
-	if v == nil {
-		return ProjectParams{}, errors.New("viper instance unset")
-	}
-
 	disableSubmodule, err := parseBoolOrRegexList(vipertools.GetString(v, "git.submodules_disabled"))
 	if err != nil {
 		return ProjectParams{}, fmt.Errorf(

--- a/cmd/params/params_test.go
+++ b/cmd/params/params_test.go
@@ -1205,7 +1205,7 @@ func TestLoadParams_SanitizeParams_HideFileNames_False(t *testing.T) {
 	}
 }
 
-func TestLoadParams_SanitizeParams_HideFilehNames_List(t *testing.T) {
+func TestLoadParams_SanitizeParams_HideFileNames_List(t *testing.T) {
 	tests := map[string]struct {
 		ViperValue string
 		Expected   []regex.Regex
@@ -1364,6 +1364,51 @@ func TestLoadParams_SanitizeParams_HideFileNames_InvalidRegex(t *testing.T) {
 			" failed to parse regex hide file names param \".*secret.*\\n[0-9+\":"+
 			" failed to compile regex \"[0-9+\":",
 	))
+}
+
+func TestLoadParams_SanitizeParams_HideProjectFolder(t *testing.T) {
+	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
+	v.Set("key", "00000000-0000-4000-8000-000000000000")
+	v.Set("entity", "/path/to/file")
+	v.Set("hide-project-folder", true)
+
+	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+	require.NoError(t, err)
+
+	assert.Equal(t, paramscmd.SanitizeParams{
+		HideProjectFolder: true,
+	}, params.Heartbeat.Sanitize)
+}
+
+func TestLoadParams_SanitizeParams_HideProjectFolder_ConfigTakesPrecedence(t *testing.T) {
+	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
+	v.Set("key", "00000000-0000-4000-8000-000000000000")
+	v.Set("entity", "/path/to/file")
+	v.Set("settings.hide_project_folder", true)
+
+	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+	require.NoError(t, err)
+
+	assert.Equal(t, paramscmd.SanitizeParams{
+		HideProjectFolder: true,
+	}, params.Heartbeat.Sanitize)
+}
+
+func TestLoadParams_SanitizeParams_OverrideProjectPath(t *testing.T) {
+	v := viper.New()
+	v.SetDefault("sync-offline-activity", 1000)
+	v.Set("key", "00000000-0000-4000-8000-000000000000")
+	v.Set("entity", "/path/to/file")
+	v.Set("project-folder", "/custom-path")
+
+	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+	require.NoError(t, err)
+
+	assert.Equal(t, paramscmd.SanitizeParams{
+		ProjectPathOverride: "/custom-path",
+	}, params.Heartbeat.Sanitize)
 }
 
 func TestLoadParams_DisableSubmodule_True(t *testing.T) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -103,6 +103,12 @@ func setFlags(cmd *cobra.Command, v *viper.Viper) {
 	flags.String("hide-file-names", "", "Obfuscate filenames. Will not send file names to api.")
 	flags.String("hide-filenames", "", "(deprecated) Obfuscate filenames. Will not send file names to api.")
 	flags.String("hidefilenames", "", "(deprecated) Obfuscate filenames. Will not send file names to api.")
+	flags.Bool(
+		"hide-project-folder",
+		false,
+		"When set, send the file's path relative to the project folder."+
+			" For ex: /User/me/projects/bar/src/file.ts is sent as src/file.ts so the server never sees the full path."+
+			" When the project folder cannot be detected, only the file name is sent. For ex: file.ts.")
 	flags.String(
 		"hide-project-names",
 		"",
@@ -150,11 +156,16 @@ func setFlags(cmd *cobra.Command, v *viper.Viper) {
 	flags.String(
 		"offline-queue-file",
 		"",
-		"(internal) Specify a offline queue file, which will be used instead of the default one.",
+		"(internal) Specify an offline queue file, which will be used instead of the default one.",
 	)
 	flags.String("plugin", "", "Optional text editor plugin name and version for User-Agent header.")
 	flags.String("project", "", "Override auto-detected project."+
 		" Use --alternate-project to supply a fallback project if one can't be auto-detected.")
+	flags.String(
+		"project-folder",
+		"",
+		"Optional workspace path. Only used when hide_project_folder = true in the config file,"+
+			" or --hide-project-folder flag is present.")
 	flags.String(
 		"proxy",
 		"",

--- a/pkg/heartbeat/heartbeat.go
+++ b/pkg/heartbeat/heartbeat.go
@@ -17,23 +17,25 @@ import (
 
 // Heartbeat is a structure representing activity for a user on a some entity.
 type Heartbeat struct {
-	Branch            *string    `json:"branch"`
-	Category          Category   `json:"category"`
-	CursorPosition    *int       `json:"cursorpos"`
-	Dependencies      []string   `json:"dependencies"`
-	Entity            string     `json:"entity"`
-	EntityType        EntityType `json:"type"`
-	IsWrite           *bool      `json:"is_write"`
-	Language          *string    `json:"language"`
-	LanguageAlternate string     `json:"-"`
-	LineNumber        *int       `json:"lineno"`
-	Lines             *int       `json:"lines"`
-	LocalFile         string     `json:"-"`
-	Project           *string    `json:"project"`
-	ProjectAlternate  string     `json:"-"`
-	ProjectOverride   string     `json:"-"`
-	Time              float64    `json:"time"`
-	UserAgent         string     `json:"user_agent"`
+	Branch              *string    `json:"branch"`
+	Category            Category   `json:"category"`
+	CursorPosition      *int       `json:"cursorpos"`
+	Dependencies        []string   `json:"dependencies"`
+	Entity              string     `json:"entity"`
+	EntityType          EntityType `json:"type"`
+	IsWrite             *bool      `json:"is_write"`
+	Language            *string    `json:"language"`
+	LanguageAlternate   string     `json:"-"`
+	LineNumber          *int       `json:"lineno"`
+	Lines               *int       `json:"lines"`
+	LocalFile           string     `json:"-"`
+	Project             *string    `json:"project"`
+	ProjectAlternate    string     `json:"-"`
+	ProjectOverride     string     `json:"-"`
+	ProjectPath         string     `json:"-"`
+	ProjectPathOverride string     `json:"-"`
+	Time                float64    `json:"time"`
+	UserAgent           string     `json:"user_agent"`
 }
 
 // New creates a new instance of Heartbeat with formatted entity
@@ -50,6 +52,7 @@ func New(
 	localFile string,
 	projectAlternate string,
 	projectOverride string,
+	projectPathOverride string,
 	time float64,
 	userAgent string,
 ) Heartbeat {
@@ -84,20 +87,30 @@ func New(
 		}
 	}
 
+	if entityType == FileType && runtime.GOOS == "windows" && projectPathOverride != "" {
+		formatted, err := windows.FormatFilePath(projectPathOverride)
+		if err != nil {
+			log.Warnf("failed to format windows file path: %q: %s", projectPathOverride, err)
+		} else {
+			projectPathOverride = formatted
+		}
+	}
+
 	return Heartbeat{
-		Category:          category,
-		CursorPosition:    cursorPosition,
-		Entity:            entity,
-		EntityType:        entityType,
-		IsWrite:           isWrite,
-		Language:          language,
-		LanguageAlternate: languageAlternate,
-		LineNumber:        lineNumber,
-		LocalFile:         localFile,
-		ProjectAlternate:  projectAlternate,
-		ProjectOverride:   projectOverride,
-		Time:              time,
-		UserAgent:         userAgent,
+		Category:            category,
+		CursorPosition:      cursorPosition,
+		Entity:              entity,
+		EntityType:          entityType,
+		IsWrite:             isWrite,
+		Language:            language,
+		LanguageAlternate:   languageAlternate,
+		LineNumber:          lineNumber,
+		LocalFile:           localFile,
+		ProjectAlternate:    projectAlternate,
+		ProjectOverride:     projectOverride,
+		ProjectPathOverride: projectPathOverride,
+		Time:                time,
+		UserAgent:           userAgent,
 	}
 }
 

--- a/pkg/heartbeat/heartbeat_test.go
+++ b/pkg/heartbeat/heartbeat_test.go
@@ -30,6 +30,7 @@ func TestNew(t *testing.T) {
 		"/path/to/file",
 		"billing",
 		"pci",
+		"/custom-path",
 		1592868313.541149,
 		"wakatime/13.0.7",
 	)
@@ -37,19 +38,20 @@ func TestNew(t *testing.T) {
 	assert.True(t, strings.HasSuffix(h.Entity, "testdata/main.go"))
 
 	assert.Equal(t, heartbeat.Heartbeat{
-		Category:          heartbeat.CodingCategory,
-		CursorPosition:    heartbeat.Int(12),
-		EntityType:        heartbeat.FileType,
-		IsWrite:           heartbeat.Bool(true),
-		Language:          heartbeat.String("Go"),
-		LanguageAlternate: "Golang",
-		LineNumber:        heartbeat.Int(42),
-		LocalFile:         "/path/to/file",
-		ProjectAlternate:  "billing",
-		ProjectOverride:   "pci",
-		Time:              1592868313.541149,
-		UserAgent:         "wakatime/13.0.7",
-		Entity:            h.Entity,
+		Category:            heartbeat.CodingCategory,
+		CursorPosition:      heartbeat.Int(12),
+		EntityType:          heartbeat.FileType,
+		IsWrite:             heartbeat.Bool(true),
+		Language:            heartbeat.String("Go"),
+		LanguageAlternate:   "Golang",
+		LineNumber:          heartbeat.Int(42),
+		LocalFile:           "/path/to/file",
+		ProjectAlternate:    "billing",
+		ProjectOverride:     "pci",
+		ProjectPathOverride: "/custom-path",
+		Time:                1592868313.541149,
+		UserAgent:           "wakatime/13.0.7",
+		Entity:              h.Entity,
 	}, h)
 }
 
@@ -70,6 +72,7 @@ func TestNew_Windows(t *testing.T) {
 		"/path/to/file",
 		"billing",
 		"pci",
+		"C:/custom-path",
 		1592868313.541149,
 		"wakatime/13.0.7",
 	)
@@ -77,19 +80,20 @@ func TestNew_Windows(t *testing.T) {
 	assert.True(t, strings.HasSuffix(h.Entity, "testdata/main.go"))
 
 	assert.Equal(t, heartbeat.Heartbeat{
-		Category:          heartbeat.CodingCategory,
-		CursorPosition:    heartbeat.Int(12),
-		EntityType:        heartbeat.FileType,
-		IsWrite:           heartbeat.Bool(true),
-		Language:          heartbeat.String("Go"),
-		LanguageAlternate: "Golang",
-		LineNumber:        heartbeat.Int(42),
-		LocalFile:         "/path/to/file",
-		ProjectAlternate:  "billing",
-		ProjectOverride:   "pci",
-		Time:              1592868313.541149,
-		UserAgent:         "wakatime/13.0.7",
-		Entity:            h.Entity,
+		Category:            heartbeat.CodingCategory,
+		CursorPosition:      heartbeat.Int(12),
+		EntityType:          heartbeat.FileType,
+		IsWrite:             heartbeat.Bool(true),
+		Language:            heartbeat.String("Go"),
+		LanguageAlternate:   "Golang",
+		LineNumber:          heartbeat.Int(42),
+		LocalFile:           "/path/to/file",
+		ProjectAlternate:    "billing",
+		ProjectOverride:     "pci",
+		ProjectPathOverride: "C:/custom-path",
+		Time:                1592868313.541149,
+		UserAgent:           "wakatime/13.0.7",
+		Entity:              h.Entity,
 	}, h)
 }
 

--- a/pkg/heartbeat/sanitize_internal_test.go
+++ b/pkg/heartbeat/sanitize_internal_test.go
@@ -1,0 +1,40 @@
+package heartbeat
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHideProjectFolder(t *testing.T) {
+	tests := map[string]struct {
+		ProjectPath         string
+		ProjectPathOverride string
+		Entity              string
+		Expected            string
+	}{
+		"auto-detected": {
+			ProjectPath: "/usr/temp",
+			Entity:      "/usr/temp/project/main.go",
+			Expected:    "project/main.go",
+		},
+		"override": {
+			ProjectPath:         "/original/folder",
+			ProjectPathOverride: "/usr/temp",
+			Entity:              "/usr/temp/project/main.go",
+			Expected:            "project/main.go",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			h := hideProjectFolder(Heartbeat{
+				Entity:              test.Entity,
+				ProjectPath:         test.ProjectPath,
+				ProjectPathOverride: test.ProjectPathOverride,
+			}, true)
+
+			assert.Equal(t, h.Entity, test.Expected)
+		})
+	}
+}

--- a/pkg/heartbeat/sanitize_test.go
+++ b/pkg/heartbeat/sanitize_test.go
@@ -308,6 +308,62 @@ func TestSanitize_EmptyConfigDoNothing_EmptyDependencies(t *testing.T) {
 	}, r)
 }
 
+func TestSanitize_ObfuscateProjectFolder(t *testing.T) {
+	h := testHeartbeat()
+	h.Entity = "/path/to/project/main.go"
+	h.ProjectPath = "/path/to"
+
+	r := heartbeat.Sanitize(h, heartbeat.SanitizeConfig{
+		HideProjectFolder: true,
+	})
+
+	assert.Equal(t, heartbeat.Heartbeat{
+		Branch:         heartbeat.String("heartbeat"),
+		Category:       heartbeat.CodingCategory,
+		CursorPosition: heartbeat.Int(12),
+		Dependencies:   []string{"dep1", "dep2"},
+		Entity:         "project/main.go",
+		EntityType:     heartbeat.FileType,
+		IsWrite:        heartbeat.Bool(true),
+		Language:       heartbeat.String("Go"),
+		LineNumber:     heartbeat.Int(42),
+		Lines:          heartbeat.Int(100),
+		Project:        heartbeat.String("wakatime"),
+		ProjectPath:    "/path/to/",
+		Time:           1585598060,
+		UserAgent:      "wakatime/13.0.7",
+	}, r)
+}
+
+func TestSanitize_ObfuscateProjectFolder_Override(t *testing.T) {
+	h := testHeartbeat()
+	h.Entity = "/path/to/project/main.go"
+	h.ProjectPath = "/original/folder"
+	h.ProjectPathOverride = "/path/to"
+
+	r := heartbeat.Sanitize(h, heartbeat.SanitizeConfig{
+		HideProjectFolder: true,
+	})
+
+	assert.Equal(t, heartbeat.Heartbeat{
+		Branch:              heartbeat.String("heartbeat"),
+		Category:            heartbeat.CodingCategory,
+		CursorPosition:      heartbeat.Int(12),
+		Dependencies:        []string{"dep1", "dep2"},
+		Entity:              "project/main.go",
+		EntityType:          heartbeat.FileType,
+		IsWrite:             heartbeat.Bool(true),
+		Language:            heartbeat.String("Go"),
+		LineNumber:          heartbeat.Int(42),
+		Lines:               heartbeat.Int(100),
+		Project:             heartbeat.String("wakatime"),
+		ProjectPath:         "/original/folder/",
+		ProjectPathOverride: "/path/to/",
+		Time:                1585598060,
+		UserAgent:           "wakatime/13.0.7",
+	}, r)
+}
+
 func TestShouldSanitize(t *testing.T) {
 	tests := map[string]struct {
 		Subject  string

--- a/pkg/language/vim.go
+++ b/pkg/language/vim.go
@@ -38,7 +38,7 @@ func detectVimModeline(text string) (heartbeat.Language, float32, bool) {
 	return lang, analyser.AnalyseText(text), true
 }
 
-// nolint: gocyclo
+// nolint:gocyclo
 // parseVim parses the language from a vim plugin specific string.
 func parseVim(language string) (heartbeat.Language, bool) {
 	switch strings.ToLower(language) {

--- a/pkg/project/file.go
+++ b/pkg/project/file.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/wakatime/wakatime-cli/pkg/log"
@@ -27,11 +28,12 @@ func (f File) Detect() (Result, bool, error) {
 
 	lines, err := readFile(fp, 2)
 	if err != nil {
-		return Result{}, false,
-			Err(fmt.Sprintf("error reading file: %s", err))
+		return Result{}, false, Err(fmt.Sprintf("error reading file: %s", err))
 	}
 
-	result := Result{}
+	result := Result{
+		Folder: filepath.Dir(fp),
+	}
 
 	if len(lines) > 0 {
 		result.Project = strings.TrimSpace(lines[0])

--- a/pkg/project/git.go
+++ b/pkg/project/git.go
@@ -7,8 +7,6 @@ import (
 
 	"github.com/wakatime/wakatime-cli/pkg/log"
 	"github.com/wakatime/wakatime-cli/pkg/regex"
-
-	"github.com/yookoala/realpath"
 )
 
 // Git contains git data.
@@ -24,22 +22,17 @@ type Git struct {
 func (g Git) Detect() (Result, bool, error) {
 	log.Debugln("execute git project detection")
 
-	fp, err := realpath.Realpath(g.Filepath)
-	if err != nil {
-		return Result{}, false,
-			Err(fmt.Sprintf("failed to get the real path: %s", err))
-	}
+	var fp string
 
 	// Take only the directory
-	if fileExists(fp) {
-		fp = filepath.Dir(fp)
+	if fileExists(g.Filepath) {
+		fp = filepath.Dir(g.Filepath)
 	}
 
 	// Find for submodule takes priority if enabled
 	gitdirSubmodule, ok, err := findSubmodule(fp, g.SubmodulePatterns)
 	if err != nil {
-		return Result{}, false,
-			Err(fmt.Sprintf("failed to validate submodule: %s", err))
+		return Result{}, false, Err(fmt.Sprintf("failed to validate submodule: %s", err))
 	}
 
 	if ok {
@@ -93,16 +86,14 @@ func (g Git) Detect() (Result, bool, error) {
 	// Find for gitdir path
 	gitdir, err := findGitdir(gitConfigFile)
 	if err != nil {
-		return Result{}, false,
-			Err(fmt.Sprintf("error finding gitdir: %s", err))
+		return Result{}, false, Err(fmt.Sprintf("error finding gitdir: %s", err))
 	}
 
 	// Commonly .git file is present when it's a worktree
 	// Find for commondir file
 	commondir, ok, err := findCommondir(gitdir)
 	if err != nil {
-		return Result{}, false,
-			Err(fmt.Sprintf("error finding commondir: %s", err))
+		return Result{}, false, Err(fmt.Sprintf("error finding commondir: %s", err))
 	}
 
 	if ok {

--- a/pkg/project/git_test.go
+++ b/pkg/project/git_test.go
@@ -5,10 +5,13 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"testing"
 
 	"github.com/wakatime/wakatime-cli/pkg/project"
 	"github.com/wakatime/wakatime-cli/pkg/regex"
+	"github.com/wakatime/wakatime-cli/pkg/windows"
+	"github.com/yookoala/realpath"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -82,15 +85,15 @@ func TestGit_Detect_GitConfigFile_File(t *testing.T) {
 		Filepath string
 		Project  string
 	}{
-		"main_repo": {
+		"main repo": {
 			Filepath: filepath.Join(fp, "wakatime-cli/src/pkg/file.go"),
 			Project:  "wakatime-cli",
 		},
-		"relative_path": {
+		"relative path": {
 			Filepath: filepath.Join(fp, "feed/src/pkg/file.go"),
 			Project:  "feed",
 		},
-		"absolute_path": {
+		"absolute path": {
 			Filepath: filepath.Join(fp, "mobile/src/pkg/file.go"),
 			Project:  "mobile",
 		},
@@ -182,6 +185,14 @@ func setupTestGitBasic(t *testing.T) (fp string, tearDown func()) {
 	tmpDir, err := os.MkdirTemp(os.TempDir(), "wakatime-git")
 	require.NoError(t, err)
 
+	tmpDir, err = realpath.Realpath(tmpDir)
+	require.NoError(t, err)
+
+	if runtime.GOOS == "windows" {
+		tmpDir, err = windows.FormatFilePath(tmpDir)
+		require.NoError(t, err)
+	}
+
 	err = os.MkdirAll(filepath.Join(tmpDir, "wakatime-cli/src/pkg"), os.FileMode(int(0700)))
 	require.NoError(t, err)
 
@@ -202,6 +213,14 @@ func setupTestGitBasic(t *testing.T) (fp string, tearDown func()) {
 func setupTestGitBasicBranchWithSlash(t *testing.T) (fp string, tearDown func()) {
 	tmpDir, err := os.MkdirTemp(os.TempDir(), "wakatime-git")
 	require.NoError(t, err)
+
+	tmpDir, err = realpath.Realpath(tmpDir)
+	require.NoError(t, err)
+
+	if runtime.GOOS == "windows" {
+		tmpDir, err = windows.FormatFilePath(tmpDir)
+		require.NoError(t, err)
+	}
 
 	err = os.MkdirAll(filepath.Join(tmpDir, "wakatime-cli/src/pkg"), os.FileMode(int(0700)))
 	require.NoError(t, err)
@@ -224,6 +243,14 @@ func setupTestGitBasicDetachedHead(t *testing.T) (fp string, tearDown func()) {
 	tmpDir, err := os.MkdirTemp(os.TempDir(), "wakatime-git")
 	require.NoError(t, err)
 
+	tmpDir, err = realpath.Realpath(tmpDir)
+	require.NoError(t, err)
+
+	if runtime.GOOS == "windows" {
+		tmpDir, err = windows.FormatFilePath(tmpDir)
+		require.NoError(t, err)
+	}
+
 	err = os.MkdirAll(filepath.Join(tmpDir, "wakatime-cli/src/pkg"), os.FileMode(int(0700)))
 	require.NoError(t, err)
 
@@ -244,6 +271,14 @@ func setupTestGitBasicDetachedHead(t *testing.T) (fp string, tearDown func()) {
 func setupTestGitFile(t *testing.T) (fp string, tearDown func()) {
 	tmpDir, err := os.MkdirTemp(os.TempDir(), "wakatime-git")
 	require.NoError(t, err)
+
+	tmpDir, err = realpath.Realpath(tmpDir)
+	require.NoError(t, err)
+
+	if runtime.GOOS == "windows" {
+		tmpDir, err = windows.FormatFilePath(tmpDir)
+		require.NoError(t, err)
+	}
 
 	// Create directories
 	err = os.MkdirAll(filepath.Join(tmpDir, "wakatime-cli/src/pkg"), os.FileMode(int(0700)))
@@ -299,6 +334,14 @@ func setupTestGitWorktree(t *testing.T) (fp string, tearDown func()) {
 	tmpDir, err := os.MkdirTemp(os.TempDir(), "wakatime-git")
 	require.NoError(t, err)
 
+	tmpDir, err = realpath.Realpath(tmpDir)
+	require.NoError(t, err)
+
+	if runtime.GOOS == "windows" {
+		tmpDir, err = windows.FormatFilePath(tmpDir)
+		require.NoError(t, err)
+	}
+
 	// Create directories
 	err = os.MkdirAll(filepath.Join(tmpDir, "wakatime-cli/src/pkg"), os.FileMode(int(0700)))
 	require.NoError(t, err)
@@ -342,6 +385,14 @@ func setupTestGitWorktree(t *testing.T) (fp string, tearDown func()) {
 func setupTestGitSubmodule(t *testing.T) (fp string, tearDown func()) {
 	tmpDir, err := os.MkdirTemp(os.TempDir(), "wakatime-git")
 	require.NoError(t, err)
+
+	tmpDir, err = realpath.Realpath(tmpDir)
+	require.NoError(t, err)
+
+	if runtime.GOOS == "windows" {
+		tmpDir, err = windows.FormatFilePath(tmpDir)
+		require.NoError(t, err)
+	}
 
 	// Create directories
 	err = os.MkdirAll(filepath.Join(tmpDir, "wakatime-cli/.git/modules/lib/billing"), os.FileMode(int(0700)))

--- a/pkg/project/map_test.go
+++ b/pkg/project/map_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/wakatime/wakatime-cli/pkg/project"
+	"github.com/yookoala/realpath"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -16,8 +17,11 @@ func TestMap_Detect(t *testing.T) {
 	wd, err := os.Getwd()
 	require.NoError(t, err)
 
+	rp, err := realpath.Realpath(filepath.Join("testdata", "entity.any"))
+	require.NoError(t, err)
+
 	m := project.Map{
-		Filepath: "testdata/entity.any",
+		Filepath: rp,
 		Patterns: []project.MapPattern{
 			{
 				Name:  "my-project-1",
@@ -30,6 +34,8 @@ func TestMap_Detect(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.True(t, detected)
+
+	assert.Contains(t, result.Folder, "testdata")
 	assert.Equal(t, "my-project-1", result.Project)
 }
 
@@ -37,8 +43,11 @@ func TestMap_Detect_RegexReplace(t *testing.T) {
 	wd, err := os.Getwd()
 	require.NoError(t, err)
 
+	rp, err := realpath.Realpath(filepath.Join("testdata", "entity.any"))
+	require.NoError(t, err)
+
 	m := project.Map{
-		Filepath: filepath.Join("testdata", "entity.any"),
+		Filepath: rp,
 		Patterns: []project.MapPattern{
 			{
 				Name:  "my-project-1",
@@ -55,6 +64,8 @@ func TestMap_Detect_RegexReplace(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.True(t, detected)
+
+	assert.Contains(t, result.Folder, "testdata")
 	assert.Equal(t, "my-project-2-data", result.Project)
 }
 
@@ -80,6 +91,8 @@ func TestMap_Detect_NoMatch(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.False(t, detected)
+
+	assert.Empty(t, result.Folder)
 	assert.Empty(t, result.Project)
 }
 

--- a/pkg/project/mercurial.go
+++ b/pkg/project/mercurial.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 
 	"github.com/wakatime/wakatime-cli/pkg/log"
-
-	"github.com/yookoala/realpath"
 )
 
 // Mercurial contains mercurial data.
@@ -20,15 +18,11 @@ type Mercurial struct {
 func (m Mercurial) Detect() (Result, bool, error) {
 	log.Debugln("execute mercurial project detection")
 
-	fp, err := realpath.Realpath(m.Filepath)
-	if err != nil {
-		return Result{}, false,
-			Err(fmt.Sprintf("failed to get the real path: %s", err))
-	}
+	var fp string
 
 	// Take only the directory
-	if fileExists(fp) {
-		fp = filepath.Dir(fp)
+	if fileExists(m.Filepath) {
+		fp = filepath.Dir(m.Filepath)
 	}
 
 	// Find for .hg folder
@@ -37,7 +31,7 @@ func (m Mercurial) Detect() (Result, bool, error) {
 		return Result{}, false, nil
 	}
 
-	project := filepath.Base(filepath.Join(hgDirectory, ".."))
+	project := filepath.Base(filepath.Dir(hgDirectory))
 
 	branch, err := findHgBranch(hgDirectory)
 	if err != nil {
@@ -51,7 +45,7 @@ func (m Mercurial) Detect() (Result, bool, error) {
 	return Result{
 		Project: project,
 		Branch:  branch,
-		Folder:  filepath.Dir(filepath.Join(hgDirectory, "..")),
+		Folder:  filepath.Dir(filepath.Dir(hgDirectory)),
 	}, true, nil
 }
 

--- a/pkg/project/subversion.go
+++ b/pkg/project/subversion.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 
 	"github.com/wakatime/wakatime-cli/pkg/log"
-
-	"github.com/yookoala/realpath"
 )
 
 // Subversion contains svn data.
@@ -28,14 +26,11 @@ func (s Subversion) Detect() (Result, bool, error) {
 		return Result{}, false, nil
 	}
 
-	fp, err := realpath.Realpath(s.Filepath)
-	if err != nil {
-		return Result{}, false, Err(fmt.Errorf("failed to get the real path: %w", err).Error())
-	}
+	var fp string
 
 	// Take only the directory
-	if fileExists(fp) {
-		fp = filepath.Dir(fp)
+	if fileExists(s.Filepath) {
+		fp = filepath.Dir(s.Filepath)
 	}
 
 	// Find for .svn/wc.db file

--- a/pkg/project/tfvc.go
+++ b/pkg/project/tfvc.go
@@ -1,13 +1,10 @@
 package project
 
 import (
-	"fmt"
 	"path/filepath"
 	"runtime"
 
 	"github.com/wakatime/wakatime-cli/pkg/log"
-
-	"github.com/yookoala/realpath"
 )
 
 // Tfvc contains tfvc data.
@@ -20,15 +17,11 @@ type Tfvc struct {
 func (t Tfvc) Detect() (Result, bool, error) {
 	log.Debugln("execute tfvc project detection")
 
-	fp, err := realpath.Realpath(t.Filepath)
-	if err != nil {
-		return Result{}, false,
-			Err(fmt.Errorf("failed to get the real path: %w", err).Error())
-	}
+	var fp string
 
 	// Take only the directory
-	if fileExists(fp) {
-		fp = filepath.Dir(fp)
+	if fileExists(t.Filepath) {
+		fp = filepath.Dir(t.Filepath)
 	}
 
 	tfFolderName := ".tf"


### PR DESCRIPTION
This PR adds project folder obfuscation to not send to API the root directory and only track the project's folder.

* Because we can't exactly know the root folder on map detection then the entire entity path will be considered. Like `"/usr/tmp/project/folder/entity.any"` will become `"/usr/tmp/project/folder/"`.
* For others we can assume the auto-detected filepath.

Closes https://github.com/wakatime/wakatime-cli/issues/591