### PR TITLE
Fix filepath assignment for git detector

### DIFF
--- a/cmd/params/params.go
+++ b/cmd/params/params.go
@@ -859,10 +859,13 @@ func (p ProjectParams) String() string {
 
 func (p SanitizeParams) String() string {
 	return fmt.Sprintf(
-		"hide branch names: '%s', hide file names: '%s', hide project names: '%s'",
+		"hide branch names: '%s', hide project folder: %t, hide file names: '%s',"+
+			" hide project names: '%s', project path override: '%s'",
 		p.HideBranchNames,
+		p.HideProjectFolder,
 		p.HideFileNames,
 		p.HideProjectNames,
+		p.ProjectPathOverride,
 	)
 }
 

--- a/pkg/project/git.go
+++ b/pkg/project/git.go
@@ -22,11 +22,11 @@ type Git struct {
 func (g Git) Detect() (Result, bool, error) {
 	log.Debugln("execute git project detection")
 
-	var fp string
+	fp := g.Filepath
 
 	// Take only the directory
-	if fileExists(g.Filepath) {
-		fp = filepath.Dir(g.Filepath)
+	if fileExists(fp) {
+		fp = filepath.Dir(fp)
 	}
 
 	// Find for submodule takes priority if enabled


### PR DESCRIPTION
This PR fixes the filepath assignment for git detector. If file doesn't exist filepath is always empty.