### PR TITLE
Fix windows network mount regex

### DIFF
--- a/pkg/heartbeat/heartbeat.go
+++ b/pkg/heartbeat/heartbeat.go
@@ -56,7 +56,7 @@ func New(
 	time float64,
 	userAgent string,
 ) Heartbeat {
-	if entityType == FileType {
+	if entityType == FileType && !windows.IsWindowsNetworkMount(entity) {
 		formatted, err := filepath.Abs(entity)
 		if err != nil {
 			log.Warnf("failed to resolve the absolute path of %q: %s", entity, err)

--- a/pkg/windows/windows.go
+++ b/pkg/windows/windows.go
@@ -166,15 +166,22 @@ func parseNetUseOutput(text string) (remoteDrives, error) {
 
 		local := line[cols.Local.Start : cols.Local.Start+cols.Remote.Width]
 		local = strings.ToUpper(strings.TrimSpace(local))
-		letter := strings.Split(local, ":")[0][0]
 
+		if len(strings.Split(local, ":")) == 0 || strings.Split(local, ":")[0] == "" {
+			continue
+		}
+
+		letter := strings.Split(local, ":")[0][0]
 		if !unicode.IsLetter(rune(letter)) {
 			continue
 		}
 
-		remote := line[cols.Remote.Start : cols.Remote.Start+cols.Remote.Width]
+		remote := strings.TrimSpace(line[cols.Remote.Start : cols.Remote.Start+cols.Remote.Width])
+		if remote == "" {
+			continue
+		}
 
-		drives[driveLetter(letter)] = remoteDrive(strings.TrimSpace(remote))
+		drives[driveLetter(letter)] = remoteDrive(remote)
 	}
 
 	return drives, nil

--- a/pkg/windows/windows.go
+++ b/pkg/windows/windows.go
@@ -17,20 +17,21 @@ var (
 	ipv4Address           = fmt.Sprintf(`(%s\.){3,3}%s`, ipv4seg, ipv4seg)
 	ipv6seg               = "[0-9a-fA-F]{1,4}"
 	ipv6Address           = fmt.Sprintf("("+
-		"(%s:){7,7}%s|"+
-		"(%s:){1,7}:|"+
-		"(%s:){1,6}:%s|"+
-		"(%s:){1,5}(:%s){1,2}|"+
-		"(%s:){1,4}(:%s){1,3}|"+
-		"(%s:){1,3}(:%s){1,4}|"+
-		"(%s:){1,2}(:%s){1,5}|"+
-		"%s:((:%s){1,6})|"+
-		":((:%s){1,7}|:)|"+
-		"fe80:(:%s){0,4}%%[0-9a-zA-Z]{1,}|"+
-		"::(ffff(:0{1,4}){0,1}:){0,1}%s|"+
-		"(%s:){1,4}:%s)", ipv6seg, ipv6seg, ipv6seg, ipv6seg, ipv6seg, ipv6seg, ipv6seg, ipv6seg,
+		"(%s:){7,7}%s|"+ // 1:2:3:4:5:6:7:8
+		"(%s:){1,7}:|"+ // 1:: or 1:2:3:4:5:6:7::
+		"(%s:){1,6}:%s|"+ // 1::8 or 1:2:3:4:5:6::8 or 1:2:3:4:5:6::8
+		"(%s:){1,5}(:%s){1,2}|"+ // 1::7:8 or 1:2:3:4:5::7:8 or 1:2:3:4:5::8
+		"(%s:){1,4}(:%s){1,3}|"+ // 1::6:7:8 or 1:2:3:4::6:7:8 or 1:2:3:4::8
+		"(%s:){1,3}(:%s){1,4}|"+ // 1::5:6:7:8 or 1:2:3::5:6:7:8 or 1:2:3::8
+		"(%s:){1,2}(:%s){1,5}|"+ // 1::4:5:6:7:8 or 1:2::4:5:6:7:8 or 1:2::8
+		"%s:((:%s){1,6})|"+ // 1::3:4:5:6:7:8 or 1::3:4:5:6:7:8 or 1::8
+		":((:%s){1,7}|:)|"+ // ::2:3:4:5:6:7:8 or ::2:3:4:5:6:7:8 or ::8 or ::
+		"fe80:(:%s){0,4}%%[0-9a-zA-Z]{1,}|"+ // fe80::7:8%eth0 or fe80::7:8%1 (link-local IPv6 addresses with zone index)
+		"::(ffff(:0{1,4}){0,1}:){0,1}%s|"+ // ::255.255.255.255 or ::ffff:255.255.255.255 or ::ffff:0:255.255.255.255 (IPv4-mapped IPv6 addresses and IPv4-translated addresses)
+		"(%s:){1,4}:%s)", // 2001:db8:3:4::192.0.2.33 or 64:ff9b::192.0.2.33 (IPv4-Embedded IPv6 Address)
 		ipv6seg, ipv6seg, ipv6seg, ipv6seg, ipv6seg, ipv6seg, ipv6seg, ipv6seg,
-		ipv6seg, ipv4Address, ipv6seg, ipv4Address)
+		ipv6seg, ipv6seg, ipv6seg, ipv6seg, ipv6seg, ipv6seg, ipv6seg, ipv6seg, ipv6seg, ipv4Address,
+		ipv6seg, ipv4Address)
 	windowsDriveRegex        = regexp.MustCompile("^[a-z]:/")
 	windowsNetworkMountRegex = regexp.MustCompile(fmt.Sprintf(`(?i)^\\\\([a-z]|%s|%s)+`, ipv4Address, ipv6Address))
 )
@@ -47,9 +48,9 @@ func FormatFilePath(fp string) (string, error) {
 	}
 
 	if isWindowsNetworkMount {
-		// Add back a / to the front, since the previous modifications
+		// Replace the first single slash with double backslash, since the previous modifications
 		// will have replaced any double slashes with single
-		fp = "/" + fp
+		fp = `\\` + fp[1:]
 	}
 
 	return fp, nil

--- a/pkg/windows/windows_internal_test.go
+++ b/pkg/windows/windows_internal_test.go
@@ -16,16 +16,16 @@ const (
 Status       Local     Remote                    Network
 
 -------------------------------------------------------------------------------
-             Z:        \\remotepc\share          Microsoft Windows Network
+OK           Z:        \\remotepc\share          Microsoft Windows Network
 The command completed successfully.`
 	netUseOutputMultiple = `New connections will be remembered.
 
 Status       Local     Remote                    Network
 
 -------------------------------------------------------------------------------
-             S:        \\tower\Movies            Microsoft Windows Network
+OK           S:        \\tower\Movies            Microsoft Windows Network
              T:        \\tower\Music             Microsoft Windows Network
-             U:        \\tower\Pictures          Microsoft Windows Network
+Unavailable  U:        \\tower\Pictures          Microsoft Windows Network
 The command completed successfully.`
 )
 
@@ -124,7 +124,6 @@ func TestParseNetUseOutput(t *testing.T) {
 			Expected: remoteDrives{
 				"S": `\\tower\Movies`,
 				"T": `\\tower\Music`,
-				"U": `\\tower\Pictures`,
 			},
 		},
 	}

--- a/pkg/windows/windows_internal_test.go
+++ b/pkg/windows/windows_internal_test.go
@@ -24,6 +24,7 @@ Status       Local     Remote                    Network
 
 -------------------------------------------------------------------------------
 OK           S:        \\tower\Movies            Microsoft Windows Network
+OK                     \\tower\Buildings         Microsoft Windows Network
              T:        \\tower\Music             Microsoft Windows Network
 Unavailable  U:        \\tower\Pictures          Microsoft Windows Network
 The command completed successfully.`
@@ -124,6 +125,7 @@ func TestParseNetUseOutput(t *testing.T) {
 			Expected: remoteDrives{
 				"S": `\\tower\Movies`,
 				"T": `\\tower\Music`,
+				"U": `\\tower\Pictures`,
 			},
 		},
 	}

--- a/pkg/windows/windows_test.go
+++ b/pkg/windows/windows_test.go
@@ -26,9 +26,13 @@ func TestFormatFilePath(t *testing.T) {
 			FilePath: `\\Projects\apilibrary.sl`,
 			Expected: `//Projects/apilibrary.sl`,
 		},
-		"windows remote ip address": {
+		"windows remote ip address v4": {
 			FilePath: `\\192.168.1.1\apilibrary.sl`,
 			Expected: `//192.168.1.1/apilibrary.sl`,
+		},
+		"windows remote ip address v6": {
+			FilePath: `\\fe80::cdaf:f1ac:9c4d:6303%7\apilibrary.sl`,
+			Expected: `//fe80::cdaf:f1ac:9c4d:6303%7/apilibrary.sl`,
 		},
 	}
 

--- a/pkg/windows/windows_test.go
+++ b/pkg/windows/windows_test.go
@@ -26,6 +26,10 @@ func TestFormatFilePath(t *testing.T) {
 			FilePath: `\\Projects\apilibrary.sl`,
 			Expected: `//Projects/apilibrary.sl`,
 		},
+		"windows remote ip address": {
+			FilePath: `\\192.168.1.1\apilibrary.sl`,
+			Expected: `//192.168.1.1/apilibrary.sl`,
+		},
 	}
 
 	for name, test := range tests {

--- a/pkg/windows/windows_test.go
+++ b/pkg/windows/windows_test.go
@@ -24,15 +24,15 @@ func TestFormatFilePath(t *testing.T) {
 		},
 		"windows remote filepath": {
 			FilePath: `\\Projects\apilibrary.sl`,
-			Expected: `//Projects/apilibrary.sl`,
+			Expected: `\\Projects/apilibrary.sl`,
 		},
 		"windows remote ip address v4": {
 			FilePath: `\\192.168.1.1\apilibrary.sl`,
-			Expected: `//192.168.1.1/apilibrary.sl`,
+			Expected: `\\192.168.1.1/apilibrary.sl`,
 		},
 		"windows remote ip address v6": {
 			FilePath: `\\fe80::cdaf:f1ac:9c4d:6303%7\apilibrary.sl`,
-			Expected: `//fe80::cdaf:f1ac:9c4d:6303%7/apilibrary.sl`,
+			Expected: `\\fe80::cdaf:f1ac:9c4d:6303%7/apilibrary.sl`,
 		},
 	}
 


### PR DESCRIPTION
This PR fixes windows network mount regex to also support ip addresses. For ex: `\\192.168.1.1\some\project\folder\entity.any`. 

In addition it fixes `parseNetUseOutput` func to ignore statuses different of `OK` or string empty (_might happen and can be considered "OK" as well_). And also skip getting absolute and real path for network drives.

Example of `net use`
```
New connections will be remembered.


Status       Local     Remote                    Network

-------------------------------------------------------------------------------
Unavailable  I:        \\192.168.0.10\Documentos Microsoft Windows Network
OK           J:        \\192.168.68.110\Desenvolvimento
                                                Microsoft Windows Network
The command completed successfully.
```