### PR TITLE
Fix windows network mount regex

### DIFF
--- a/pkg/heartbeat/heartbeat.go
+++ b/pkg/heartbeat/heartbeat.go
@@ -56,7 +56,7 @@ func New(
 	time float64,
 	userAgent string,
 ) Heartbeat {
-	if entityType == FileType {
+	if entityType == FileType && !windows.IsWindowsNetworkMount(entity) {
 		formatted, err := filepath.Abs(entity)
 		if err != nil {
 			log.Warnf("failed to resolve the absolute path of %q: %s", entity, err)

--- a/pkg/windows/windows_internal_test.go
+++ b/pkg/windows/windows_internal_test.go
@@ -16,16 +16,17 @@ const (
 Status       Local     Remote                    Network
 
 -------------------------------------------------------------------------------
-             Z:        \\remotepc\share          Microsoft Windows Network
+OK           Z:        \\remotepc\share          Microsoft Windows Network
 The command completed successfully.`
 	netUseOutputMultiple = `New connections will be remembered.
 
 Status       Local     Remote                    Network
 
 -------------------------------------------------------------------------------
-             S:        \\tower\Movies            Microsoft Windows Network
+OK           S:        \\tower\Movies            Microsoft Windows Network
+OK                     \\tower\Buildings         Microsoft Windows Network
              T:        \\tower\Music             Microsoft Windows Network
-             U:        \\tower\Pictures          Microsoft Windows Network
+Unavailable  U:        \\tower\Pictures          Microsoft Windows Network
 The command completed successfully.`
 )
 

--- a/pkg/windows/windows_test.go
+++ b/pkg/windows/windows_test.go
@@ -24,7 +24,15 @@ func TestFormatFilePath(t *testing.T) {
 		},
 		"windows remote filepath": {
 			FilePath: `\\Projects\apilibrary.sl`,
-			Expected: `//Projects/apilibrary.sl`,
+			Expected: `\\Projects/apilibrary.sl`,
+		},
+		"windows remote ip address v4": {
+			FilePath: `\\192.168.1.1\apilibrary.sl`,
+			Expected: `\\192.168.1.1/apilibrary.sl`,
+		},
+		"windows remote ip address v6": {
+			FilePath: `\\fe80::cdaf:f1ac:9c4d:6303%7\apilibrary.sl`,
+			Expected: `\\fe80::cdaf:f1ac:9c4d:6303%7/apilibrary.sl`,
 		},
 	}
 


### PR DESCRIPTION
This PR fixes windows network mount regex to also support ip addresses. For ex: `\\192.168.1.1\some\project\folder\entity.any`. 

In addition it fixes `parseNetUseOutput` func to ignore statuses different of `OK` or string empty (_might happen and can be considered "OK" as well_). And also skip getting absolute and real path for network drives.

Example of `net use`
```
New connections will be remembered.


Status       Local     Remote                    Network

-------------------------------------------------------------------------------
Unavailable  I:        \\192.168.0.10\Documentos Microsoft Windows Network
OK           J:        \\192.168.68.110\Desenvolvimento
                                                Microsoft Windows Network
The command completed successfully.
```

In replace of #618 