### PR TITLE
Remove duplicated validation for file exists

### DIFF
--- a/cmd/heartbeat/heartbeat.go
+++ b/cmd/heartbeat/heartbeat.go
@@ -3,7 +3,6 @@ package heartbeat
 import (
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 
 	apicmd "github.com/wakatime/wakatime-cli/cmd/api"
@@ -151,36 +150,27 @@ func buildHeartbeats(params params.Params) []heartbeat.Heartbeat {
 		userAgent = heartbeat.UserAgent(params.API.Plugin)
 	}
 
-	if params.Heartbeat.EntityType != heartbeat.FileType || isFile(params.Heartbeat.Entity) {
-		heartbeats = append(heartbeats, heartbeat.New(
-			params.Heartbeat.Category,
-			params.Heartbeat.CursorPosition,
-			params.Heartbeat.Entity,
-			params.Heartbeat.EntityType,
-			params.Heartbeat.IsWrite,
-			params.Heartbeat.Language,
-			params.Heartbeat.LanguageAlternate,
-			params.Heartbeat.LineNumber,
-			params.Heartbeat.LocalFile,
-			params.Heartbeat.Project.Alternate,
-			params.Heartbeat.Project.Override,
-			params.Heartbeat.Sanitize.ProjectPathOverride,
-			params.Heartbeat.Time,
-			userAgent,
-		))
-	} else {
-		log.Warnf("file '%s' does not exist. ignoring this heartbeat", params.Heartbeat.Entity)
-	}
+	heartbeats = append(heartbeats, heartbeat.New(
+		params.Heartbeat.Category,
+		params.Heartbeat.CursorPosition,
+		params.Heartbeat.Entity,
+		params.Heartbeat.EntityType,
+		params.Heartbeat.IsWrite,
+		params.Heartbeat.Language,
+		params.Heartbeat.LanguageAlternate,
+		params.Heartbeat.LineNumber,
+		params.Heartbeat.LocalFile,
+		params.Heartbeat.Project.Alternate,
+		params.Heartbeat.Project.Override,
+		params.Heartbeat.Sanitize.ProjectPathOverride,
+		params.Heartbeat.Time,
+		userAgent,
+	))
 
 	if len(params.Heartbeat.ExtraHeartbeats) > 0 {
 		log.Debugf("include %d extra heartbeat(s) from stdin", len(params.Heartbeat.ExtraHeartbeats))
 
 		for _, h := range params.Heartbeat.ExtraHeartbeats {
-			if h.EntityType == heartbeat.FileType && !isFile(h.Entity) {
-				log.Warnf("file '%s' does not exist. ignoring this extra heartbeat", h.Entity)
-				return nil
-			}
-
 			heartbeats = append(heartbeats, heartbeat.New(
 				h.Category,
 				h.CursorPosition,
@@ -250,10 +240,4 @@ func setLogFields(params *params.Params) {
 	}
 
 	log.WithField("file", params.Heartbeat.Entity)
-}
-
-// isFile checks if the passed in filepath is a valid file.
-func isFile(filepath string) bool {
-	info, err := os.Stat(filepath)
-	return !(os.IsNotExist(err) || info.IsDir())
 }

--- a/cmd/heartbeat/heartbeat_test.go
+++ b/cmd/heartbeat/heartbeat_test.go
@@ -301,10 +301,57 @@ func TestSendHeartbeats_NonExistingEntity(t *testing.T) {
 	output, err := io.ReadAll(logFile)
 	require.NoError(t, err)
 
-	assert.Contains(t, string(output), "file 'nonexisting' does not exist. ignoring this heartbeat")
+	assert.Contains(t, string(output), "skipping because of non-existing file")
 }
 
 func TestSendHeartbeats_NonExistingExtraHeartbeatsEntity(t *testing.T) {
+	testServerURL, router, tearDown := setupTestServer()
+	defer tearDown()
+
+	var (
+		plugin   = "plugin/0.0.1"
+		numCalls int
+	)
+
+	router.HandleFunc("/users/current/heartbeats.bulk", func(w http.ResponseWriter, req *http.Request) {
+		// check request
+		expectedBody, err := os.ReadFile("testdata/api_heartbeats_request_extra_heartbeats_filtered_template.json")
+		require.NoError(t, err)
+
+		body, err := io.ReadAll(req.Body)
+		require.NoError(t, err)
+
+		var entities []struct {
+			Entity string `json:"entity"`
+		}
+
+		err = json.Unmarshal(body, &entities)
+		require.NoError(t, err)
+
+		assert.True(t, strings.HasSuffix(entities[0].Entity, "testdata/main.go"))
+		assert.True(t, strings.HasSuffix(entities[1].Entity, "testdata/main.py"))
+
+		expectedBodyStr := fmt.Sprintf(
+			string(expectedBody),
+			entities[0].Entity, heartbeat.UserAgent(plugin),
+			entities[1].Entity, heartbeat.UserAgent(plugin),
+		)
+
+		assert.JSONEq(t, expectedBodyStr, string(body))
+
+		// send response
+		w.WriteHeader(http.StatusCreated)
+
+		f, err := os.Open("testdata/api_heartbeats_response_extra_heartbeats_filtered.json")
+		require.NoError(t, err)
+		defer f.Close()
+
+		_, err = io.Copy(w, f)
+		require.NoError(t, err)
+
+		numCalls++
+	})
+
 	inr, inw, err := os.Pipe()
 	require.NoError(t, err)
 
@@ -336,11 +383,15 @@ func TestSendHeartbeats_NonExistingExtraHeartbeatsEntity(t *testing.T) {
 
 	v := viper.New()
 	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("api-url", "https://example.org")
+	v.Set("api-url", testServerURL)
 	v.Set("entity", "testdata/main.go")
 	v.Set("entity-type", "file")
+	v.Set("hide-branch-names", "true")
+	v.Set("project", "wakatime-cli")
 	v.Set("extra-heartbeats", true)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
+	v.Set("plugin", plugin)
+	v.Set("time", 1585598059.1)
 	v.Set("log-file", logFile.Name())
 	v.Set("verbose", true)
 
@@ -357,7 +408,7 @@ func TestSendHeartbeats_NonExistingExtraHeartbeatsEntity(t *testing.T) {
 	output, err := io.ReadAll(logFile)
 	require.NoError(t, err)
 
-	assert.Contains(t, string(output), "file 'nonexisting' does not exist. ignoring this extra heartbeat")
+	assert.Contains(t, string(output), "skipping because of non-existing file")
 }
 
 func setupTestServer() (string, *http.ServeMux, func()) {

--- a/cmd/heartbeat/testdata/api_heartbeats_request_extra_heartbeats_filtered_template.json
+++ b/cmd/heartbeat/testdata/api_heartbeats_request_extra_heartbeats_filtered_template.json
@@ -1,0 +1,32 @@
+[
+    {
+        "branch": null,
+        "category": "coding",
+        "cursorpos": null,
+        "dependencies": ["os"],
+        "entity": "%s",
+        "is_write": null,
+        "language": "Go",
+        "lineno": null,
+        "lines": 11,
+        "project": "wakatime-cli",
+        "type": "file",
+        "time": 1585598059.1,
+        "user_agent": "%s"
+    },
+    {
+        "branch": null,
+        "category": "debugging",
+        "cursorpos": null,
+        "dependencies": ["flask","simplejson"],
+        "entity": "%s",
+        "is_write": null,
+        "language": "Python",
+        "lineno": null,
+        "lines": 20,
+        "project": "wakatime-cli",
+        "type": "file",
+        "time": 1585598060,
+        "user_agent": "%s"
+    }
+]

--- a/cmd/heartbeat/testdata/api_heartbeats_response_extra_heartbeats_filtered.json
+++ b/cmd/heartbeat/testdata/api_heartbeats_response_extra_heartbeats_filtered.json
@@ -1,0 +1,54 @@
+{
+    "responses": [
+        [
+            {
+                "data": {
+                    "branch": "heartbeat",
+                    "category": "coding",
+                    "created_at": "2020-04-14T21:27:15Z",
+                    "cursorpos": 12,
+                    "dependencies": ["dep1", "dep2"],
+                    "entity": "/tmp/main.go",
+                    "id": "845a922e-9e65-4775-bd68-bb3196d2e06a",
+                    "is_write": true,
+                    "language": "Go",
+                    "lineno": 42,
+                    "lines": 100,
+                    "machine_name_id": null,
+                    "project": "wakatime-cli",
+                    "type": "file",
+                    "time": 1585598059.0,
+                    "user_agent_id": null,
+                    "user_agent": "wakatime/13.0.6",
+                    "user_id": "9c4a41c0-eb11-4cf5-84b8-d5b7f5e91bea"
+                }
+            },
+            201
+        ],
+        [
+            {
+                "data": {
+                    "branch": "heartbeat",
+                    "category": "coding",
+                    "created_at": "2020-04-14T21:27:15Z",
+                    "cursorpos": 12,
+                    "dependencies": ["dep1", "dep2"],
+                    "entity": "/tmp/main.go",
+                    "id": "845a922e-9e65-4775-bd68-bb3196d2e06a",
+                    "is_write": true,
+                    "language": "Go",
+                    "lineno": 42,
+                    "lines": 100,
+                    "machine_name_id": null,
+                    "project": "wakatime-cli",
+                    "type": "file",
+                    "time": 1585598059.0,
+                    "user_agent_id": null,
+                    "user_agent": "wakatime/13.0.6",
+                    "user_id": "9c4a41c0-eb11-4cf5-84b8-d5b7f5e91bea"
+                }
+            },
+            201
+        ]
+    ]
+}

--- a/cmd/offline/offline.go
+++ b/cmd/offline/offline.go
@@ -3,7 +3,6 @@ package offline
 import (
 	"errors"
 	"fmt"
-	"os"
 
 	"github.com/wakatime/wakatime-cli/cmd/params"
 	"github.com/wakatime/wakatime-cli/pkg/deps"
@@ -73,36 +72,27 @@ func buildHeartbeats(params params.Params) []heartbeat.Heartbeat {
 		userAgent = heartbeat.UserAgent(params.API.Plugin)
 	}
 
-	if params.Heartbeat.EntityType != heartbeat.FileType || isFile(params.Heartbeat.Entity) {
-		heartbeats = append(heartbeats, heartbeat.New(
-			params.Heartbeat.Category,
-			params.Heartbeat.CursorPosition,
-			params.Heartbeat.Entity,
-			params.Heartbeat.EntityType,
-			params.Heartbeat.IsWrite,
-			params.Heartbeat.Language,
-			params.Heartbeat.LanguageAlternate,
-			params.Heartbeat.LineNumber,
-			params.Heartbeat.LocalFile,
-			params.Heartbeat.Project.Alternate,
-			params.Heartbeat.Project.Override,
-			params.Heartbeat.Sanitize.ProjectPathOverride,
-			params.Heartbeat.Time,
-			userAgent,
-		))
-	} else {
-		log.Warnf("file '%s' does not exist. ignoring this heartbeat", params.Heartbeat.Entity)
-	}
+	heartbeats = append(heartbeats, heartbeat.New(
+		params.Heartbeat.Category,
+		params.Heartbeat.CursorPosition,
+		params.Heartbeat.Entity,
+		params.Heartbeat.EntityType,
+		params.Heartbeat.IsWrite,
+		params.Heartbeat.Language,
+		params.Heartbeat.LanguageAlternate,
+		params.Heartbeat.LineNumber,
+		params.Heartbeat.LocalFile,
+		params.Heartbeat.Project.Alternate,
+		params.Heartbeat.Project.Override,
+		params.Heartbeat.Sanitize.ProjectPathOverride,
+		params.Heartbeat.Time,
+		userAgent,
+	))
 
 	if len(params.Heartbeat.ExtraHeartbeats) > 0 {
 		log.Debugf("include %d extra heartbeat(s) from stdin", len(params.Heartbeat.ExtraHeartbeats))
 
 		for _, h := range params.Heartbeat.ExtraHeartbeats {
-			if h.EntityType == heartbeat.FileType && !isFile(h.Entity) {
-				log.Warnf("file '%s' does not exist. ignoring this extra heartbeat", h.Entity)
-				return nil
-			}
-
 			heartbeats = append(heartbeats, heartbeat.New(
 				h.Category,
 				h.CursorPosition,
@@ -172,10 +162,4 @@ func initHandleOptions(params params.Params) []heartbeat.HandleOption {
 			ProjectPatterns:   params.Heartbeat.Sanitize.HideProjectNames,
 		}),
 	}
-}
-
-// isFile checks if the passed in filepath is a valid file.
-func isFile(filepath string) bool {
-	info, err := os.Stat(filepath)
-	return !(os.IsNotExist(err) || info.IsDir())
 }

--- a/main_test.go
+++ b/main_test.go
@@ -133,6 +133,7 @@ func testSendHeartbeats(t *testing.T, entity, project string) {
 		"--lines-in-file", "100",
 		"--time", "1585598059",
 		"--hide-branch-names", ".*",
+		"--project", project,
 		"--write",
 		"--verbose",
 	)
@@ -219,6 +220,8 @@ func TestSendHeartbeats_Err(t *testing.T) {
 
 	var numCalls int
 
+	project := "wakatime-cli"
+
 	router.HandleFunc("/users/current/heartbeats.bulk", func(w http.ResponseWriter, req *http.Request) {
 		numCalls++
 
@@ -240,7 +243,7 @@ func TestSendHeartbeats_Err(t *testing.T) {
 		expectedBody := fmt.Sprintf(
 			string(expectedBodyTpl),
 			entityPath,
-			"wakatime-cli",
+			project,
 			heartbeat.UserAgentUnknownPlugin(),
 		)
 
@@ -276,6 +279,7 @@ func TestSendHeartbeats_Err(t *testing.T) {
 		"--lines-in-file", "100",
 		"--time", "1585598059",
 		"--hide-branch-names", ".*",
+		"--project", project,
 		"--write",
 		"--verbose",
 	)

--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -1,7 +1,6 @@
 package filter
 
 import (
-	"errors"
 	"fmt"
 	"os"
 
@@ -32,13 +31,9 @@ func WithFiltering(config Config) heartbeat.HandleOption {
 			for _, h := range hh {
 				err := Filter(h, config)
 				if err != nil {
-					var errv Err
-					if errors.As(err, &errv) {
-						log.Debugln(errv.Error())
-						continue
-					}
+					log.Errorf(err.Error())
 
-					return nil, fmt.Errorf("error filtering heartbeat: %w", err)
+					continue
 				}
 
 				filtered = append(filtered, h)


### PR DESCRIPTION
This PR removes duplicated validation for file exists. The `filter.WithFiltering()` already takes care of filtering in case of missing file.

By removing the code it also fixed a bug when if any of extra heartbeat doesn't exist it returns `null` bypassing all parsed heartbeats. 
```
if h.EntityType == heartbeat.FileType && !isFile(h.Entity) {
    log.Warnf("file '%s' does not exist. ignoring this extra heartbeat", h.Entity)
    return nil
}
```
This PR is also a preparation for the next one.