### PR TITLE
Remove err type since it's unused

### DIFF
--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -55,19 +55,19 @@ func WithFiltering(config Config) heartbeat.HandleOption {
 func Filter(h heartbeat.Heartbeat, config Config) error {
 	// unknown project
 	if config.ExcludeUnknownProject && (h.Project == nil || *h.Project == "") {
-		return Err("skipping because of unknown project")
+		return fmt.Errorf("skipping because of unknown project")
 	}
 
 	// filter by pattern
 	if err := filterByPattern(h.Entity, config.Include, config.Exclude); err != nil {
-		return Err(fmt.Sprintf("filter by pattern: %s", err))
+		return fmt.Errorf(fmt.Sprintf("filter by pattern: %s", err))
 	}
 
 	// filter file
 	if h.EntityType == heartbeat.FileType {
 		err := filterFileEntity(h.Entity, config.IncludeOnlyWithProjectFile)
 		if err != nil {
-			return Err(fmt.Sprintf("filter file: %s", err))
+			return fmt.Errorf(fmt.Sprintf("filter file: %s", err))
 		}
 	}
 
@@ -92,7 +92,7 @@ func filterByPattern(entity string, include, exclude []regex.Regex) error {
 	// filter by  exclude pattern
 	for _, pattern := range exclude {
 		if pattern.MatchString(entity) {
-			return Err(fmt.Sprintf("skipping because matches exclude pattern %q", pattern.String()))
+			return fmt.Errorf(fmt.Sprintf("skipping because matches exclude pattern %q", pattern.String()))
 		}
 	}
 
@@ -106,14 +106,14 @@ func filterByPattern(entity string, include, exclude []regex.Regex) error {
 func filterFileEntity(filepath string, includeOnlyWithProjectFile bool) error {
 	// skip files that don't exist on disk
 	if _, err := os.Stat(filepath); os.IsNotExist(err) {
-		return Err(fmt.Sprintf("skipping because of non-existing file %q", filepath))
+		return fmt.Errorf(fmt.Sprintf("skipping because of non-existing file %q", filepath))
 	}
 
 	// when including only with project file, skip files when the project does not contain a .wakatime-project file
 	if includeOnlyWithProjectFile {
 		_, ok := project.FindFileOrDirectory(filepath, project.WakaTimeProjectFile)
 		if !ok {
-			return Err("skipping because missing .wakatime-project file in parent path")
+			return fmt.Errorf("skipping because missing .wakatime-project file in parent path")
 		}
 	}
 

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -145,11 +145,7 @@ func TestFilter_ErrMatchesExcludePattern(t *testing.T) {
 		},
 	})
 
-	var errv filter.Err
-
-	assert.True(t, errors.As(err, &errv))
-	assert.Equal(t,
-		filter.Err("filter by pattern: skipping because matches exclude pattern \"^.*exclude-this-file.*$\""), errv)
+	assert.EqualError(t, err, "filter by pattern: skipping because matches exclude pattern \"^.*exclude-this-file.*$\"")
 }
 
 func TestFilter_ErrUnknownProject(t *testing.T) {
@@ -175,10 +171,8 @@ func TestFilter_ErrUnknownProject(t *testing.T) {
 			err = filter.Filter(h, filter.Config{
 				ExcludeUnknownProject: true,
 			})
-			var errv filter.Err
-			assert.True(t, errors.As(err, &errv))
 
-			assert.Equal(t, filter.Err("skipping because of unknown project"), errv)
+			assert.EqualError(t, err, "skipping because of unknown project")
 		})
 	}
 }
@@ -188,10 +182,7 @@ func TestFilter_ErrNonExistingFile(t *testing.T) {
 
 	err := filter.Filter(h, filter.Config{})
 
-	var errv filter.Err
-
-	assert.True(t, errors.As(err, &errv))
-	assert.Equal(t, filter.Err("filter file: skipping because of non-existing file \"/tmp/main.go\""), errv)
+	assert.EqualError(t, err, "filter file: skipping because of non-existing file \"/tmp/main.go\"")
 }
 
 func TestFilter_ExistingProjectFile(t *testing.T) {
@@ -231,10 +222,7 @@ func TestFilter_ErrNonExistingProjectFile(t *testing.T) {
 		IncludeOnlyWithProjectFile: true,
 	})
 
-	var errv filter.Err
-
-	assert.True(t, errors.As(err, &errv))
-	assert.Equal(t, filter.Err("filter file: skipping because missing .wakatime-project file in parent path"), errv)
+	assert.EqualError(t, err, "filter file: skipping because missing .wakatime-project file in parent path")
 }
 
 func testHeartbeat() heartbeat.Heartbeat {


### PR DESCRIPTION
This PR simply removes unused `filter.Err` type.