### PR TITLE
Update github-script to v5

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -202,11 +202,11 @@ jobs:
           prerelease_id: alpha
           main_branch_name: release
       - name: Create tag
-        uses: actions/github-script@v4
+        uses: actions/github-script@v5
         with:
           github-token: ${{ github.token }}
           script: |
-            github.git.createRef({
+            github.rest.git.createRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
               ref: "refs/tags/${{ steps.semver-tag.outputs.semver_tag }}",
@@ -242,11 +242,11 @@ jobs:
       -
         name: Remove tag if failure
         if: ${{ failure() }}
-        uses: actions/github-script@v4
+        uses: actions/github-script@v5
         with:
           github-token: ${{ github.token }}
           script: |
-            github.git.deleteRef({
+            github.rest.git.deleteRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
               ref: "tags/${{ needs.version.outputs.semver_tag }}"
@@ -281,11 +281,11 @@ jobs:
       -
         name: Remove tag if failure
         if: ${{ failure() }}
-        uses: actions/github-script@v4
+        uses: actions/github-script@v5
         with:
           github-token: ${{ github.token }}
           script: |
-            github.git.deleteRef({
+            github.rest.git.deleteRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
               ref: "tags/${{ needs.version.outputs.semver_tag }}"
@@ -320,11 +320,11 @@ jobs:
       -
         name: Remove tag if failure
         if: ${{ failure() }}
-        uses: actions/github-script@v4
+        uses: actions/github-script@v5
         with:
           github-token: ${{ github.token }}
           script: |
-            github.git.deleteRef({
+            github.rest.git.deleteRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
               ref: "tags/${{ needs.version.outputs.semver_tag }}"
@@ -359,11 +359,11 @@ jobs:
       -
         name: Remove tag if failure
         if: ${{ failure() }}
-        uses: actions/github-script@v4
+        uses: actions/github-script@v5
         with:
           github-token: ${{ github.token }}
           script: |
-            github.git.deleteRef({
+            github.rest.git.deleteRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
               ref: "tags/${{ needs.version.outputs.semver_tag }}"
@@ -398,11 +398,11 @@ jobs:
       -
         name: Remove tag if failure
         if: ${{ failure() }}
-        uses: actions/github-script@v4
+        uses: actions/github-script@v5
         with:
           github-token: ${{ github.token }}
           script: |
-            github.git.deleteRef({
+            github.rest.git.deleteRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
               ref: "tags/${{ needs.version.outputs.semver_tag }}"
@@ -437,11 +437,11 @@ jobs:
       -
         name: Remove tag if failure
         if: ${{ failure() }}
-        uses: actions/github-script@v4
+        uses: actions/github-script@v5
         with:
           github-token: ${{ github.token }}
           script: |
-            github.git.deleteRef({
+            github.rest.git.deleteRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
               ref: "tags/${{ needs.version.outputs.semver_tag }}"
@@ -492,11 +492,11 @@ jobs:
       -
         name: Remove tag if failure
         if: ${{ failure() }}
-        uses: actions/github-script@v4
+        uses: actions/github-script@v5
         with:
           github-token: ${{ github.token }}
           script: |
-            github.git.deleteRef({
+            github.rest.git.deleteRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
               ref: "tags/${{ needs.version.outputs.semver_tag }}"
@@ -570,11 +570,11 @@ jobs:
       -
         name: Remove tag if failure
         if: ${{ failure() }}
-        uses: actions/github-script@v4
+        uses: actions/github-script@v5
         with:
           github-token: ${{ github.token }}
           script: |
-            github.git.deleteRef({
+            github.rest.git.deleteRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
               ref: "tags/${{ needs.version.outputs.semver_tag }}"


### PR DESCRIPTION
This PR updates github-script action to v5. It will also get rid of this warning:

```
(node:2310) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
```