### PR TITLE
Use t.TempDir() on tests

### DIFF
--- a/cmd/configwrite/configwrite_test.go
+++ b/cmd/configwrite/configwrite_test.go
@@ -67,10 +67,10 @@ func TestLoadParamsErr(t *testing.T) {
 }
 
 func TestWrite(t *testing.T) {
-	tmpFile, err := os.CreateTemp(os.TempDir(), "wakatime")
+	tmpFile, err := os.CreateTemp(t.TempDir(), "wakatime")
 	require.NoError(t, err)
 
-	defer os.Remove(tmpFile.Name())
+	defer tmpFile.Close()
 
 	v := viper.New()
 	ini, err := ini.NewIniWriter(v, func(vp *viper.Viper) (string, error) {

--- a/cmd/logfile/logfile_test.go
+++ b/cmd/logfile/logfile_test.go
@@ -13,17 +13,17 @@ import (
 )
 
 func TestLoadParams(t *testing.T) {
-	tmpFile, err := os.CreateTemp(os.TempDir(), "wakatime.log")
+	tmpFile, err := os.CreateTemp(t.TempDir(), "wakatime.log")
 	require.NoError(t, err)
 
-	defer os.Remove(tmpFile.Name())
+	defer tmpFile.Close()
 
 	dir, _ := filepath.Split(tmpFile.Name())
 
-	_, err = os.Create(filepath.Join(dir, ".wakatime.log"))
+	logFile, err := os.Create(filepath.Join(dir, ".wakatime.log"))
 	require.NoError(t, err)
 
-	defer os.Remove(filepath.Join(dir, ".wakatime.log"))
+	defer logFile.Close()
 
 	home, err := os.UserHomeDir()
 	require.NoError(t, err)

--- a/cmd/offlinecount/offlinecount_test.go
+++ b/cmd/offlinecount/offlinecount_test.go
@@ -18,10 +18,10 @@ import (
 
 func TestOfflineCount_Empty(t *testing.T) {
 	// setup offline queue
-	f, err := os.CreateTemp(os.TempDir(), "")
+	f, err := os.CreateTemp(t.TempDir(), "")
 	require.NoError(t, err)
 
-	defer os.Remove(f.Name())
+	defer f.Close()
 
 	db, err := bolt.Open(f.Name(), 0600, nil)
 	require.NoError(t, err)
@@ -64,10 +64,10 @@ func TestOfflineCount_Empty(t *testing.T) {
 
 func TestOfflineCount(t *testing.T) {
 	// setup offline queue
-	f, err := os.CreateTemp(os.TempDir(), "")
+	f, err := os.CreateTemp(t.TempDir(), "")
 	require.NoError(t, err)
 
-	defer os.Remove(f.Name())
+	defer f.Close()
 
 	db, err := bolt.Open(f.Name(), 0600, nil)
 	require.NoError(t, err)

--- a/cmd/offlinesync/offlinesync_test.go
+++ b/cmd/offlinesync/offlinesync_test.go
@@ -61,10 +61,8 @@ func TestSyncOfflineActivity(t *testing.T) {
 	})
 
 	// setup offline queue
-	f, err := os.CreateTemp(os.TempDir(), "")
+	f, err := os.CreateTemp(t.TempDir(), "")
 	require.NoError(t, err)
-
-	defer os.Remove(f.Name())
 
 	db, err := bolt.Open(f.Name(), 0600, nil)
 	require.NoError(t, err)

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -28,15 +28,13 @@ func TestRunCmd_SendDiagnostics_Error(t *testing.T) {
 		version.Arch = "some architecture"
 		version.Version = "some version"
 
-		offlineQueueFile, err := os.CreateTemp(os.TempDir(), "")
+		tmpDir := t.TempDir()
+
+		offlineQueueFile, err := os.CreateTemp(tmpDir, "")
 		require.NoError(t, err)
 
-		defer os.Remove(offlineQueueFile.Name())
-
-		logFile, err := os.CreateTemp(os.TempDir(), "")
+		logFile, err := os.CreateTemp(tmpDir, "")
 		require.NoError(t, err)
-
-		defer os.Remove(logFile.Name())
 
 		v := viper.New()
 		v.Set("api-url", os.Getenv("TEST_SERVER_URL"))
@@ -113,15 +111,13 @@ func TestRunCmd_SendDiagnostics_Panic(t *testing.T) {
 		version.Arch = "some architecture"
 		version.Version = "some version"
 
-		offlineQueueFile, err := os.CreateTemp(os.TempDir(), "")
+		tmpDir := t.TempDir()
+
+		offlineQueueFile, err := os.CreateTemp(tmpDir, "")
 		require.NoError(t, err)
 
-		defer os.Remove(offlineQueueFile.Name())
-
-		logFile, err := os.CreateTemp(os.TempDir(), "")
+		logFile, err := os.CreateTemp(tmpDir, "")
 		require.NoError(t, err)
-
-		defer os.Remove(logFile.Name())
 
 		v := viper.New()
 		v.Set("api-url", os.Getenv("TEST_SERVER_URL"))
@@ -197,10 +193,10 @@ func TestRunCmdWithOfflineSync(t *testing.T) {
 		version.Arch = "some architecture"
 		version.Version = "some version"
 
-		logFile, err := os.CreateTemp(os.TempDir(), "")
+		logFile, err := os.CreateTemp(t.TempDir(), "")
 		require.NoError(t, err)
 
-		defer os.Remove(logFile.Name())
+		defer logFile.Close()
 
 		v := viper.New()
 		v.Set("api-url", os.Getenv("TEST_SERVER_URL"))
@@ -220,10 +216,10 @@ func TestRunCmdWithOfflineSync(t *testing.T) {
 	}
 
 	// setup test queue
-	offlineQueueFile, err := os.CreateTemp(os.TempDir(), "")
+	offlineQueueFile, err := os.CreateTemp(t.TempDir(), "")
 	require.NoError(t, err)
 
-	defer os.RemoveAll(offlineQueueFile.Name())
+	defer offlineQueueFile.Close()
 
 	db, err := bolt.Open(offlineQueueFile.Name(), 0600, nil)
 	require.NoError(t, err)

--- a/main_test.go
+++ b/main_test.go
@@ -60,6 +60,7 @@ func TestSendHeartbeats(t *testing.T) {
 
 func TestSendHeartbeats_EntityFileInTempDir(t *testing.T) {
 	tmpDir := t.TempDir()
+
 	runCmd(exec.Command("cp", "./testdata/main.go", tmpDir), &bytes.Buffer{})
 
 	testSendHeartbeats(t, filepath.Join(tmpDir, "main.go"), "")
@@ -110,15 +111,17 @@ func testSendHeartbeats(t *testing.T, entity, project string) {
 		require.NoError(t, err)
 	})
 
-	offlineQueueFile, err := os.CreateTemp(os.TempDir(), "")
+	tmpDir := t.TempDir()
+
+	offlineQueueFile, err := os.CreateTemp(tmpDir, "")
 	require.NoError(t, err)
 
-	defer os.Remove(offlineQueueFile.Name())
+	defer offlineQueueFile.Close()
 
-	tmpFile, err := os.CreateTemp(os.TempDir(), "wakatime.cfg")
+	tmpFile, err := os.CreateTemp(tmpDir, "wakatime.cfg")
 	require.NoError(t, err)
 
-	defer os.Remove(tmpFile.Name())
+	defer tmpFile.Close()
 
 	runWakatimeCli(
 		t,
@@ -166,15 +169,17 @@ func TestSendHeartbeats_ExtraHeartbeats(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	offlineQueueFile, err := os.CreateTemp(os.TempDir(), "")
+	tmpDir := t.TempDir()
+
+	offlineQueueFile, err := os.CreateTemp(tmpDir, "")
 	require.NoError(t, err)
 
-	defer os.Remove(offlineQueueFile.Name())
+	defer offlineQueueFile.Close()
 
-	tmpFile, err := os.CreateTemp(os.TempDir(), "wakatime.cfg")
+	tmpFile, err := os.CreateTemp(tmpDir, "wakatime.cfg")
 	require.NoError(t, err)
 
-	defer os.Remove(tmpFile.Name())
+	defer tmpFile.Close()
 
 	data, err := os.ReadFile("testdata/extra_heartbeats.json")
 	require.NoError(t, err)
@@ -256,15 +261,17 @@ func TestSendHeartbeats_Err(t *testing.T) {
 		w.WriteHeader(http.StatusBadGateway)
 	})
 
-	offlineQueueFile, err := os.CreateTemp(os.TempDir(), "")
+	tmpDir := t.TempDir()
+
+	offlineQueueFile, err := os.CreateTemp(tmpDir, "")
 	require.NoError(t, err)
 
-	defer os.Remove(offlineQueueFile.Name())
+	defer offlineQueueFile.Close()
 
-	tmpFile, err := os.CreateTemp(os.TempDir(), "wakatime.cfg")
+	tmpFile, err := os.CreateTemp(tmpDir, "wakatime.cfg")
 	require.NoError(t, err)
 
-	defer os.Remove(tmpFile.Name())
+	defer tmpFile.Close()
 
 	out := runWakatimeCliExpectErr(
 		t,
@@ -290,15 +297,17 @@ func TestSendHeartbeats_Err(t *testing.T) {
 }
 
 func TestSendHeartbeats_MalformedConfig(t *testing.T) {
-	tmpFile, err := os.CreateTemp(os.TempDir(), "wakatime-internal.cfg")
+	tmpDir := t.TempDir()
+
+	tmpFile, err := os.CreateTemp(tmpDir, "wakatime-internal.cfg")
 	require.NoError(t, err)
 
-	defer os.Remove(tmpFile.Name())
+	defer tmpFile.Close()
 
-	offlineQueueFile, err := os.CreateTemp(os.TempDir(), "")
+	offlineQueueFile, err := os.CreateTemp(tmpDir, "")
 	require.NoError(t, err)
 
-	defer os.Remove(offlineQueueFile.Name())
+	defer offlineQueueFile.Close()
 
 	out := runWakatimeCliExpectErr(
 		t,
@@ -319,10 +328,10 @@ func TestSendHeartbeats_MalformedConfig(t *testing.T) {
 }
 
 func TestSendHeartbeats_MalformedInternalConfig(t *testing.T) {
-	offlineQueueFile, err := os.CreateTemp(os.TempDir(), "")
+	offlineQueueFile, err := os.CreateTemp(t.TempDir(), "")
 	require.NoError(t, err)
 
-	defer os.Remove(offlineQueueFile.Name())
+	defer offlineQueueFile.Close()
 
 	out := runWakatimeCliExpectErr(
 		t,
@@ -347,10 +356,10 @@ func TestTodayGoal(t *testing.T) {
 
 	var numCalls int
 
-	tmpFile, err := os.CreateTemp(os.TempDir(), "wakatime.cfg")
+	tmpFile, err := os.CreateTemp(t.TempDir(), "wakatime.cfg")
 	require.NoError(t, err)
 
-	defer os.Remove(tmpFile.Name())
+	defer tmpFile.Close()
 
 	router.HandleFunc("/users/current/goals/11111111-1111-4111-8111-111111111111",
 		func(w http.ResponseWriter, req *http.Request) {
@@ -392,10 +401,10 @@ func TestTodaySummary(t *testing.T) {
 
 	var numCalls int
 
-	tmpFile, err := os.CreateTemp(os.TempDir(), "wakatime.cfg")
+	tmpFile, err := os.CreateTemp(t.TempDir(), "wakatime.cfg")
 	require.NoError(t, err)
 
-	defer os.Remove(tmpFile.Name())
+	defer tmpFile.Close()
 
 	router.HandleFunc("/users/current/statusbar/today", func(w http.ResponseWriter, req *http.Request) {
 		numCalls++
@@ -431,10 +440,10 @@ func TestTodaySummary(t *testing.T) {
 }
 
 func TestOfflineCountEmpty(t *testing.T) {
-	offlineQueueFile, err := os.CreateTemp(os.TempDir(), "")
+	offlineQueueFile, err := os.CreateTemp(t.TempDir(), "")
 	require.NoError(t, err)
 
-	defer os.Remove(offlineQueueFile.Name())
+	defer offlineQueueFile.Close()
 
 	out := runWakatimeCli(
 		t,
@@ -458,15 +467,17 @@ func TestOfflineCountWithOneHeartbeat(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	offlineQueueFile, err := os.CreateTemp(os.TempDir(), "")
+	tmpDir := t.TempDir()
+
+	offlineQueueFile, err := os.CreateTemp(tmpDir, "")
 	require.NoError(t, err)
 
-	defer os.Remove(offlineQueueFile.Name())
+	defer offlineQueueFile.Close()
 
-	tmpFile, err := os.CreateTemp(os.TempDir(), "wakatime.cfg")
+	tmpFile, err := os.CreateTemp(tmpDir, "wakatime.cfg")
 	require.NoError(t, err)
 
-	defer os.Remove(tmpFile.Name())
+	defer tmpFile.Close()
 
 	out := runWakatimeCliExpectErr(
 		t,
@@ -530,10 +541,10 @@ func TestVersionVerbose(t *testing.T) {
 func TestMultipleRunners_NotCorruptConfigFile(t *testing.T) {
 	var wg sync.WaitGroup
 
-	tmpFile, err := os.CreateTemp(os.TempDir(), "wakatime.cfg")
+	tmpFile, err := os.CreateTemp(t.TempDir(), "wakatime.cfg")
 	require.NoError(t, err)
 
-	defer os.Remove(tmpFile.Name())
+	defer tmpFile.Close()
 
 	for i := 0; i < 20; i++ {
 		wg.Add(1)
@@ -556,7 +567,7 @@ func TestMultipleRunners_NotCorruptConfigFile(t *testing.T) {
 }
 
 func runWakatimeCli(t *testing.T, buffer *bytes.Buffer, args ...string) string {
-	f, err := os.CreateTemp(os.TempDir(), "")
+	f, err := os.CreateTemp(t.TempDir(), "")
 	require.NoError(t, err)
 
 	defer func() {
@@ -575,7 +586,7 @@ func runWakatimeCli(t *testing.T, buffer *bytes.Buffer, args ...string) string {
 }
 
 func runWakatimeCliExpectErr(t *testing.T, exitcode int, args ...string) string {
-	f, err := os.CreateTemp(os.TempDir(), "")
+	f, err := os.CreateTemp(t.TempDir(), "")
 	require.NoError(t, err)
 
 	defer func() {

--- a/pkg/backoff/backoff_internal_test.go
+++ b/pkg/backoff/backoff_internal_test.go
@@ -37,10 +37,10 @@ func TestShouldBackoff_NegateBackoff(t *testing.T) {
 func TestUpdateBackoffSettings(t *testing.T) {
 	v := viper.New()
 
-	tmpFile, err := os.CreateTemp(os.TempDir(), "wakatime")
+	tmpFile, err := os.CreateTemp(t.TempDir(), "wakatime")
 	require.NoError(t, err)
 
-	defer os.Remove(tmpFile.Name())
+	defer tmpFile.Close()
 
 	v.Set("config", tmpFile.Name())
 	v.Set("internal-config", tmpFile.Name())
@@ -65,10 +65,10 @@ func TestUpdateBackoffSettings(t *testing.T) {
 func TestUpdateBackoffSettings_NotInBackoff(t *testing.T) {
 	v := viper.New()
 
-	tmpFile, err := os.CreateTemp(os.TempDir(), "wakatime")
+	tmpFile, err := os.CreateTemp(t.TempDir(), "wakatime")
 	require.NoError(t, err)
 
-	defer os.Remove(tmpFile.Name())
+	defer tmpFile.Close()
 
 	v.Set("config", tmpFile.Name())
 	v.Set("internal-config", tmpFile.Name())

--- a/pkg/backoff/backoff_test.go
+++ b/pkg/backoff/backoff_test.go
@@ -17,10 +17,10 @@ import (
 func TestWithRetry(t *testing.T) {
 	v := viper.New()
 
-	tmpFile, err := os.CreateTemp(os.TempDir(), "wakatime")
+	tmpFile, err := os.CreateTemp(t.TempDir(), "wakatime")
 	require.NoError(t, err)
 
-	defer os.Remove(tmpFile.Name())
+	defer tmpFile.Close()
 
 	v.Set("config", tmpFile.Name())
 
@@ -65,10 +65,10 @@ func TestWithRetry_BeforeNextBackoff(t *testing.T) {
 func TestWithRetry_ApiError(t *testing.T) {
 	v := viper.New()
 
-	tmpFile, err := os.CreateTemp(os.TempDir(), "wakatime")
+	tmpFile, err := os.CreateTemp(t.TempDir(), "wakatime")
 	require.NoError(t, err)
 
-	defer os.Remove(tmpFile.Name())
+	defer tmpFile.Close()
 
 	v.Set("config", tmpFile.Name())
 

--- a/pkg/filestats/filestats_test.go
+++ b/pkg/filestats/filestats_test.go
@@ -121,10 +121,10 @@ func TestWithDetection_RemoteFile(t *testing.T) {
 }
 
 func TestWithDetection_MaxFileSizeExceeded(t *testing.T) {
-	f, err := os.CreateTemp(os.TempDir(), "")
+	f, err := os.CreateTemp(t.TempDir(), "")
 	require.NoError(t, err)
 
-	defer os.Remove(f.Name())
+	defer f.Close()
 
 	b := bytes.NewBuffer(make([]byte, 2*1024*1024+1))
 	_, err = f.Write(b.Bytes())

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -16,16 +16,14 @@ import (
 )
 
 func TestWithFiltering(t *testing.T) {
-	tmpDir, err := os.MkdirTemp(os.TempDir(), "wakatime")
+	tmpFile, err := os.CreateTemp(t.TempDir(), "")
 	require.NoError(t, err)
 
-	defer os.RemoveAll(tmpDir)
-
-	tmpFile, err := os.CreateTemp(tmpDir, "")
-	require.NoError(t, err)
+	defer tmpFile.Close()
 
 	first := testHeartbeat()
 	first.Entity = tmpFile.Name()
+
 	second := testHeartbeat()
 	second.Time++
 
@@ -79,13 +77,10 @@ func TestWithFiltering_AbortAllFiltered(t *testing.T) {
 }
 
 func TestFilter(t *testing.T) {
-	tmpDir, err := os.MkdirTemp(os.TempDir(), "wakatime")
+	tmpFile, err := os.CreateTemp(t.TempDir(), "")
 	require.NoError(t, err)
 
-	defer os.RemoveAll(tmpDir)
-
-	tmpFile, err := os.CreateTemp(tmpDir, "")
-	require.NoError(t, err)
+	defer tmpFile.Close()
 
 	h := testHeartbeat()
 	h.Entity = tmpFile.Name()
@@ -104,13 +99,10 @@ func TestFilter_NonFileTypeEmptyEntity(t *testing.T) {
 }
 
 func TestFilter_IncludeMatchOverwritesExcludeMatch(t *testing.T) {
-	tmpDir, err := os.MkdirTemp(os.TempDir(), "wakatime")
+	tmpFile, err := os.CreateTemp(t.TempDir(), "")
 	require.NoError(t, err)
 
-	defer os.RemoveAll(tmpDir)
-
-	tmpFile, err := os.CreateTemp(tmpDir, "")
-	require.NoError(t, err)
+	defer tmpFile.Close()
 
 	h := testHeartbeat()
 	h.Entity = tmpFile.Name()
@@ -127,13 +119,10 @@ func TestFilter_IncludeMatchOverwritesExcludeMatch(t *testing.T) {
 }
 
 func TestFilter_ErrMatchesExcludePattern(t *testing.T) {
-	tmpDir, err := os.MkdirTemp(os.TempDir(), "wakatime")
+	tmpFile, err := os.CreateTemp(t.TempDir(), "exclude-this-file")
 	require.NoError(t, err)
 
-	defer os.RemoveAll(tmpDir)
-
-	tmpFile, err := os.CreateTemp(tmpDir, "exclude-this-file")
-	require.NoError(t, err)
+	defer tmpFile.Close()
 
 	h := testHeartbeat()
 	h.Entity = tmpFile.Name()
@@ -156,16 +145,17 @@ func TestFilter_ErrNonExistingFile(t *testing.T) {
 }
 
 func TestFilter_ExistingProjectFile(t *testing.T) {
-	tmpDir, err := os.MkdirTemp(os.TempDir(), "wakatime")
-	require.NoError(t, err)
-
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	tmpFile, err := os.CreateTemp(tmpDir, "")
 	require.NoError(t, err)
 
-	_, err = os.Create(filepath.Join(tmpDir, ".wakatime-project"))
+	defer tmpFile.Close()
+
+	tmpFile2, err := os.Create(filepath.Join(tmpDir, ".wakatime-project"))
 	require.NoError(t, err)
+
+	defer tmpFile2.Close()
 
 	h := testHeartbeat()
 	h.Entity = tmpFile.Name()
@@ -187,13 +177,10 @@ func TestFilter_RemoteFile(t *testing.T) {
 }
 
 func TestFilter_ErrNonExistingProjectFile(t *testing.T) {
-	tmpDir, err := os.MkdirTemp(os.TempDir(), "wakatime")
+	tmpFile, err := os.CreateTemp(t.TempDir(), "")
 	require.NoError(t, err)
 
-	defer os.RemoveAll(tmpDir)
-
-	tmpFile, err := os.CreateTemp(tmpDir, "")
-	require.NoError(t, err)
+	defer tmpFile.Close()
 
 	h := testHeartbeat()
 	h.Entity = tmpFile.Name()

--- a/pkg/heartbeat/entity_modifier_internal_test.go
+++ b/pkg/heartbeat/entity_modifier_internal_test.go
@@ -34,8 +34,6 @@ func TestIsXCodePlayground(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			defer os.RemoveAll(test.Dir)
-
 			ret := isXCodePlayground(test.Dir)
 
 			assert.Equal(t, test.Expected, ret)
@@ -44,10 +42,9 @@ func TestIsXCodePlayground(t *testing.T) {
 }
 
 func setupTestXCodePlayground(t *testing.T, dir string) string {
-	tmpDir, err := os.MkdirTemp(os.TempDir(), "wakatime")
-	require.NoError(t, err)
+	tmpDir := t.TempDir()
 
-	err = os.Mkdir(filepath.Join(tmpDir, dir), os.FileMode(int(0700)))
+	err := os.Mkdir(filepath.Join(tmpDir, dir), os.FileMode(int(0700)))
 	require.NoError(t, err)
 
 	return filepath.Join(tmpDir, dir)

--- a/pkg/heartbeat/entity_modify_test.go
+++ b/pkg/heartbeat/entity_modify_test.go
@@ -12,12 +12,9 @@ import (
 )
 
 func TestWithEntityModifier_XCodePlayground(t *testing.T) {
-	tmpDir, err := os.MkdirTemp(os.TempDir(), "wakatime")
-	require.NoError(t, err)
+	tmpDir := t.TempDir()
 
-	defer os.RemoveAll(tmpDir)
-
-	err = os.Mkdir(filepath.Join(tmpDir, "wakatime.playground"), os.FileMode(int(0700)))
+	err := os.Mkdir(filepath.Join(tmpDir, "wakatime.playground"), os.FileMode(int(0700)))
 	require.NoError(t, err)
 
 	opt := heartbeat.WithEntityModifer()

--- a/pkg/ini/ini_test.go
+++ b/pkg/ini/ini_test.go
@@ -200,10 +200,10 @@ func TestNewIniWriterErr(t *testing.T) {
 }
 
 func TestWrite(t *testing.T) {
-	tmpFile, err := os.CreateTemp(os.TempDir(), "wakatime")
+	tmpFile, err := os.CreateTemp(t.TempDir(), "wakatime")
 	require.NoError(t, err)
 
-	defer os.Remove(tmpFile.Name())
+	defer tmpFile.Close()
 
 	tests := map[string]struct {
 		Value   map[string]string
@@ -242,10 +242,10 @@ func TestWrite_NoMultilineSideEffects(t *testing.T) {
 	multilineOption := viper.IniLoadOptions(iniv1.LoadOptions{AllowPythonMultilineValues: true})
 	v := viper.NewWithOptions(multilineOption)
 
-	tmpFile, err := os.CreateTemp(os.TempDir(), "wakatime")
+	tmpFile, err := os.CreateTemp(t.TempDir(), "wakatime")
 	require.NoError(t, err)
 
-	defer os.Remove(tmpFile.Name())
+	defer tmpFile.Close()
 
 	v.Set("config", tmpFile.Name())
 
@@ -275,10 +275,10 @@ func TestWrite_NullsRemoved(t *testing.T) {
 	multilineOption := viper.IniLoadOptions(iniv1.LoadOptions{AllowPythonMultilineValues: true})
 	v := viper.NewWithOptions(multilineOption)
 
-	tmpFile, err := os.CreateTemp(os.TempDir(), "wakatime")
+	tmpFile, err := os.CreateTemp(t.TempDir(), "wakatime")
 	require.NoError(t, err)
 
-	defer os.Remove(tmpFile.Name())
+	defer tmpFile.Close()
 
 	v.Set("config", tmpFile.Name())
 

--- a/pkg/offline/offline_test.go
+++ b/pkg/offline/offline_test.go
@@ -56,10 +56,10 @@ func TestQueueFilepath(t *testing.T) {
 
 func TestWithQueue(t *testing.T) {
 	// setup
-	f, err := os.CreateTemp(os.TempDir(), "")
+	f, err := os.CreateTemp(t.TempDir(), "")
 	require.NoError(t, err)
 
-	defer os.Remove(f.Name())
+	defer f.Close()
 
 	db, err := bolt.Open(f.Name(), 0600, nil)
 	require.NoError(t, err)
@@ -144,10 +144,10 @@ func TestWithQueue(t *testing.T) {
 
 func TestWithQueue_ApiError(t *testing.T) {
 	// setup
-	f, err := os.CreateTemp(os.TempDir(), "")
+	f, err := os.CreateTemp(t.TempDir(), "")
 	require.NoError(t, err)
 
-	defer os.Remove(f.Name())
+	defer f.Close()
 
 	opt, err := offline.WithQueue(f.Name())
 	require.NoError(t, err)
@@ -207,10 +207,10 @@ func TestWithQueue_ApiError(t *testing.T) {
 
 func TestWithQueue_InvalidResults(t *testing.T) {
 	// setup
-	f, err := os.CreateTemp(os.TempDir(), "")
+	f, err := os.CreateTemp(t.TempDir(), "")
 	require.NoError(t, err)
 
-	defer os.Remove(f.Name())
+	defer f.Close()
 
 	opt, err := offline.WithQueue(f.Name())
 	require.NoError(t, err)
@@ -293,10 +293,10 @@ func TestWithQueue_InvalidResults(t *testing.T) {
 
 func TestWithQueue_HandleLeftovers(t *testing.T) {
 	// setup
-	f, err := os.CreateTemp(os.TempDir(), "")
+	f, err := os.CreateTemp(t.TempDir(), "")
 	require.NoError(t, err)
 
-	defer os.Remove(f.Name())
+	defer f.Close()
 
 	opt, err := offline.WithQueue(f.Name())
 	require.NoError(t, err)
@@ -362,10 +362,10 @@ func TestWithQueue_HandleLeftovers(t *testing.T) {
 
 func TestSync(t *testing.T) {
 	// setup
-	f, err := os.CreateTemp(os.TempDir(), "")
+	f, err := os.CreateTemp(t.TempDir(), "")
 	require.NoError(t, err)
 
-	defer os.RemoveAll(f.Name())
+	defer f.Close()
 
 	db, err := bolt.Open(f.Name(), 0600, nil)
 	require.NoError(t, err)
@@ -443,10 +443,10 @@ func TestSync(t *testing.T) {
 
 func TestSync_MultipleRequests(t *testing.T) {
 	// setup
-	f, err := os.CreateTemp(os.TempDir(), "")
+	f, err := os.CreateTemp(t.TempDir(), "")
 	require.NoError(t, err)
 
-	defer os.RemoveAll(f.Name())
+	defer f.Close()
 
 	db, err := bolt.Open(f.Name(), 0600, nil)
 	require.NoError(t, err)
@@ -533,10 +533,10 @@ func TestSync_MultipleRequests(t *testing.T) {
 
 func TestSync_APIError(t *testing.T) {
 	// setup
-	f, err := os.CreateTemp(os.TempDir(), "")
+	f, err := os.CreateTemp(t.TempDir(), "")
 	require.NoError(t, err)
 
-	defer os.RemoveAll(f.Name())
+	defer f.Close()
 
 	db, err := bolt.Open(f.Name(), 0600, nil)
 	require.NoError(t, err)
@@ -612,10 +612,10 @@ func TestSync_APIError(t *testing.T) {
 
 func TestSync_InvalidResults(t *testing.T) {
 	// setup
-	f, err := os.CreateTemp(os.TempDir(), "")
+	f, err := os.CreateTemp(t.TempDir(), "")
 	require.NoError(t, err)
 
-	defer os.RemoveAll(f.Name())
+	defer f.Close()
 
 	db, err := bolt.Open(f.Name(), 0600, nil)
 	require.NoError(t, err)
@@ -726,10 +726,10 @@ func TestSync_InvalidResults(t *testing.T) {
 
 func TestSync_SyncLimit(t *testing.T) {
 	// setup
-	f, err := os.CreateTemp(os.TempDir(), "")
+	f, err := os.CreateTemp(t.TempDir(), "")
 	require.NoError(t, err)
 
-	defer os.RemoveAll(f.Name())
+	defer f.Close()
 
 	db, err := bolt.Open(f.Name(), 0600, nil)
 	require.NoError(t, err)
@@ -804,13 +804,15 @@ func TestSync_SyncLimit(t *testing.T) {
 
 func TestQueue_PopMany(t *testing.T) {
 	// setup
-	f, err := os.CreateTemp(os.TempDir(), "")
+	f, err := os.CreateTemp(t.TempDir(), "")
 	require.NoError(t, err)
 
-	defer os.Remove(f.Name())
+	defer f.Close()
 
 	db, err := bolt.Open(f.Name(), 0600, nil)
 	require.NoError(t, err)
+
+	defer db.Close()
 
 	dataGo, err := os.ReadFile("testdata/heartbeat_go.json")
 	require.NoError(t, err)
@@ -1006,7 +1008,7 @@ func TestQueue_Count(t *testing.T) {
 
 func initDB(t *testing.T) (*bolt.DB, func()) {
 	// create tmp file
-	f, err := os.CreateTemp(os.TempDir(), "")
+	f, err := os.CreateTemp(t.TempDir(), "")
 	require.NoError(t, err)
 
 	// init db
@@ -1014,7 +1016,7 @@ func initDB(t *testing.T) (*bolt.DB, func()) {
 	require.NoError(t, err)
 
 	return db, func() {
-		defer os.Remove(f.Name())
+		defer f.Close()
 		defer db.Close()
 	}
 }

--- a/pkg/project/file.go
+++ b/pkg/project/file.go
@@ -26,6 +26,8 @@ func (f File) Detect() (Result, bool, error) {
 		return Result{}, false, nil
 	}
 
+	log.Debugf("wakatime project file found at: %s", fp)
+
 	lines, err := readFile(fp, 2)
 	if err != nil {
 		return Result{}, false, Err(fmt.Sprintf("error reading file: %s", err))

--- a/pkg/project/file_test.go
+++ b/pkg/project/file_test.go
@@ -34,12 +34,7 @@ func TestFile_Detect_FileExists(t *testing.T) {
 }
 
 func TestFile_Detect_ParentFolderExists(t *testing.T) {
-	tmpDir, err := os.MkdirTemp(os.TempDir(), "wakatime")
-	require.NoError(t, err)
-
-	defer os.RemoveAll(tmpDir)
-
-	tmpDir, err = realpath.Realpath(tmpDir)
+	tmpDir, err := realpath.Realpath(t.TempDir())
 	require.NoError(t, err)
 
 	dir := filepath.Join(tmpDir, "src", "otherfolder")
@@ -70,14 +65,16 @@ func TestFile_Detect_ParentFolderExists(t *testing.T) {
 	assert.Equal(t, expected, result)
 }
 
-func TestFile_Detect_AnyFileFound(t *testing.T) {
-	tmpFile, err := os.CreateTemp(os.TempDir(), "wakatime-project")
+func TestFile_Detect_NoFileFound(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	tmpFile, err := os.CreateTemp(tmpDir, "wakatime-project")
 	require.NoError(t, err)
 
-	defer os.Remove(tmpFile.Name())
+	defer tmpFile.Close()
 
 	f := project.File{
-		Filepath: os.TempDir(),
+		Filepath: tmpDir,
 	}
 
 	result, detected, err := f.Detect()
@@ -90,10 +87,10 @@ func TestFile_Detect_AnyFileFound(t *testing.T) {
 }
 
 func TestFile_Detect_InvalidPath(t *testing.T) {
-	tmpFile, err := os.CreateTemp(os.TempDir(), "non-valid-file")
+	tmpFile, err := os.CreateTemp(t.TempDir(), "non-valid-file")
 	require.NoError(t, err)
 
-	defer os.Remove(tmpFile.Name())
+	defer tmpFile.Close()
 
 	f := project.File{
 		Filepath: tmpFile.Name(),
@@ -106,14 +103,11 @@ func TestFile_Detect_InvalidPath(t *testing.T) {
 }
 
 func TestFindFileOrDirectory(t *testing.T) {
-	tmpDir, err := os.MkdirTemp(os.TempDir(), "wakatime")
-	require.NoError(t, err)
-
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	dir := filepath.Join(tmpDir, "src", "otherfolder")
 
-	err = os.MkdirAll(dir, os.FileMode(int(0700)))
+	err := os.MkdirAll(dir, os.FileMode(int(0700)))
 	require.NoError(t, err)
 
 	copyFile(

--- a/pkg/project/filter_test.go
+++ b/pkg/project/filter_test.go
@@ -12,13 +12,10 @@ import (
 )
 
 func TestWithFiltering(t *testing.T) {
-	tmpDir, err := os.MkdirTemp(os.TempDir(), "wakatime")
+	tmpFile, err := os.CreateTemp(t.TempDir(), "")
 	require.NoError(t, err)
 
-	defer os.RemoveAll(tmpDir)
-
-	tmpFile, err := os.CreateTemp(tmpDir, "")
-	require.NoError(t, err)
+	defer tmpFile.Close()
 
 	first := testHeartbeat()
 	first.Entity = tmpFile.Name()
@@ -73,13 +70,10 @@ func TestFilter_ErrUnknownProject(t *testing.T) {
 
 	for name, projectValue := range tests {
 		t.Run(name, func(t *testing.T) {
-			tmpDir, err := os.MkdirTemp(os.TempDir(), "wakatime")
+			tmpFile, err := os.CreateTemp(t.TempDir(), "")
 			require.NoError(t, err)
 
-			defer os.RemoveAll(tmpDir)
-
-			tmpFile, err := os.CreateTemp(tmpDir, "")
-			require.NoError(t, err)
+			defer tmpFile.Close()
 
 			h := heartbeat.Heartbeat{
 				Entity:  tmpFile.Name(),

--- a/pkg/project/git_test.go
+++ b/pkg/project/git_test.go
@@ -18,8 +18,7 @@ import (
 )
 
 func TestGit_Detect(t *testing.T) {
-	fp, tearDown := setupTestGitBasic(t)
-	defer tearDown()
+	fp := setupTestGitBasic(t)
 
 	g := project.Git{
 		Filepath: filepath.Join(fp, "wakatime-cli/src/pkg/file.go"),
@@ -38,8 +37,7 @@ func TestGit_Detect(t *testing.T) {
 }
 
 func TestGit_Detect_BranchWithSlash(t *testing.T) {
-	fp, tearDown := setupTestGitBasicBranchWithSlash(t)
-	defer tearDown()
+	fp := setupTestGitBasicBranchWithSlash(t)
 
 	g := project.Git{
 		Filepath: filepath.Join(fp, "wakatime-cli/src/pkg/file.go"),
@@ -58,8 +56,7 @@ func TestGit_Detect_BranchWithSlash(t *testing.T) {
 }
 
 func TestGit_Detect_DetachedHead(t *testing.T) {
-	fp, tearDown := setupTestGitBasicDetachedHead(t)
-	defer tearDown()
+	fp := setupTestGitBasicDetachedHead(t)
 
 	g := project.Git{
 		Filepath: filepath.Join(fp, "wakatime-cli/src/pkg/file.go"),
@@ -78,8 +75,7 @@ func TestGit_Detect_DetachedHead(t *testing.T) {
 }
 
 func TestGit_Detect_GitConfigFile_File(t *testing.T) {
-	fp, tearDown := setupTestGitFile(t)
-	defer tearDown()
+	fp := setupTestGitFile(t)
 
 	tests := map[string]struct {
 		Filepath string
@@ -120,8 +116,7 @@ func TestGit_Detect_GitConfigFile_File(t *testing.T) {
 }
 
 func TestGit_Detect_Worktree(t *testing.T) {
-	fp, tearDown := setupTestGitWorktree(t)
-	defer tearDown()
+	fp := setupTestGitWorktree(t)
 
 	g := project.Git{
 		Filepath: filepath.Join(fp, "api/src/pkg/file.go"),
@@ -140,8 +135,7 @@ func TestGit_Detect_Worktree(t *testing.T) {
 }
 
 func TestGit_Detect_Submodule(t *testing.T) {
-	fp, tearDown := setupTestGitSubmodule(t)
-	defer tearDown()
+	fp := setupTestGitSubmodule(t)
 
 	g := project.Git{
 		Filepath:          filepath.Join(fp, "wakatime-cli/lib/billing/src/lib/lib.cpp"),
@@ -161,8 +155,7 @@ func TestGit_Detect_Submodule(t *testing.T) {
 }
 
 func TestGit_Detect_SubmoduleDisabled(t *testing.T) {
-	fp, tearDown := setupTestGitSubmodule(t)
-	defer tearDown()
+	fp := setupTestGitSubmodule(t)
 
 	g := project.Git{
 		Filepath:          filepath.Join(fp, "wakatime-cli/lib/billing/src/lib/lib.cpp"),
@@ -181,11 +174,10 @@ func TestGit_Detect_SubmoduleDisabled(t *testing.T) {
 	}, result)
 }
 
-func setupTestGitBasic(t *testing.T) (fp string, tearDown func()) {
-	tmpDir, err := os.MkdirTemp(os.TempDir(), "wakatime-git")
-	require.NoError(t, err)
+func setupTestGitBasic(t *testing.T) (fp string) {
+	tmpDir := t.TempDir()
 
-	tmpDir, err = realpath.Realpath(tmpDir)
+	tmpDir, err := realpath.Realpath(tmpDir)
 	require.NoError(t, err)
 
 	if runtime.GOOS == "windows" {
@@ -207,14 +199,13 @@ func setupTestGitBasic(t *testing.T) (fp string, tearDown func()) {
 	copyFile(t, "testdata/git_basic/config", filepath.Join(tmpDir, "wakatime-cli/.git/config"))
 	copyFile(t, "testdata/git_basic/HEAD", filepath.Join(tmpDir, "wakatime-cli/.git/HEAD"))
 
-	return tmpDir, func() { os.RemoveAll(tmpDir) }
+	return tmpDir
 }
 
-func setupTestGitBasicBranchWithSlash(t *testing.T) (fp string, tearDown func()) {
-	tmpDir, err := os.MkdirTemp(os.TempDir(), "wakatime-git")
-	require.NoError(t, err)
+func setupTestGitBasicBranchWithSlash(t *testing.T) (fp string) {
+	tmpDir := t.TempDir()
 
-	tmpDir, err = realpath.Realpath(tmpDir)
+	tmpDir, err := realpath.Realpath(tmpDir)
 	require.NoError(t, err)
 
 	if runtime.GOOS == "windows" {
@@ -236,14 +227,13 @@ func setupTestGitBasicBranchWithSlash(t *testing.T) (fp string, tearDown func())
 	copyFile(t, "testdata/git_basic/config", filepath.Join(tmpDir, "wakatime-cli/.git/config"))
 	copyFile(t, "testdata/git_basic/HEAD_WITH_SLASH", filepath.Join(tmpDir, "wakatime-cli/.git/HEAD"))
 
-	return tmpDir, func() { os.RemoveAll(tmpDir) }
+	return tmpDir
 }
 
-func setupTestGitBasicDetachedHead(t *testing.T) (fp string, tearDown func()) {
-	tmpDir, err := os.MkdirTemp(os.TempDir(), "wakatime-git")
-	require.NoError(t, err)
+func setupTestGitBasicDetachedHead(t *testing.T) (fp string) {
+	tmpDir := t.TempDir()
 
-	tmpDir, err = realpath.Realpath(tmpDir)
+	tmpDir, err := realpath.Realpath(tmpDir)
 	require.NoError(t, err)
 
 	if runtime.GOOS == "windows" {
@@ -265,14 +255,13 @@ func setupTestGitBasicDetachedHead(t *testing.T) (fp string, tearDown func()) {
 	copyFile(t, "testdata/git_basic/config", filepath.Join(tmpDir, "wakatime-cli/.git/config"))
 	copyFile(t, "testdata/git_basic/HEAD_DETACHED", filepath.Join(tmpDir, "wakatime-cli/.git/HEAD"))
 
-	return tmpDir, func() { os.RemoveAll(tmpDir) }
+	return tmpDir
 }
 
-func setupTestGitFile(t *testing.T) (fp string, tearDown func()) {
-	tmpDir, err := os.MkdirTemp(os.TempDir(), "wakatime-git")
-	require.NoError(t, err)
+func setupTestGitFile(t *testing.T) (fp string) {
+	tmpDir := t.TempDir()
 
-	tmpDir, err = realpath.Realpath(tmpDir)
+	tmpDir, err := realpath.Realpath(tmpDir)
 	require.NoError(t, err)
 
 	if runtime.GOOS == "windows" {
@@ -327,14 +316,13 @@ func setupTestGitFile(t *testing.T) (fp string, tearDown func()) {
 	_, err = tmpFile.WriteString(fmt.Sprintf("gitdir: %s", gitdir))
 	require.NoError(t, err)
 
-	return tmpDir, func() { os.RemoveAll(tmpDir) }
+	return tmpDir
 }
 
-func setupTestGitWorktree(t *testing.T) (fp string, tearDown func()) {
-	tmpDir, err := os.MkdirTemp(os.TempDir(), "wakatime-git")
-	require.NoError(t, err)
+func setupTestGitWorktree(t *testing.T) (fp string) {
+	tmpDir := t.TempDir()
 
-	tmpDir, err = realpath.Realpath(tmpDir)
+	tmpDir, err := realpath.Realpath(tmpDir)
 	require.NoError(t, err)
 
 	if runtime.GOOS == "windows" {
@@ -379,14 +367,13 @@ func setupTestGitWorktree(t *testing.T) (fp string, tearDown func()) {
 	_, err = tmpFile.WriteString(fmt.Sprintf("gitdir: %s/wakatime-cli/.git/worktrees/api", tmpDir))
 	require.NoError(t, err)
 
-	return tmpDir, func() { os.RemoveAll(tmpDir) }
+	return tmpDir
 }
 
-func setupTestGitSubmodule(t *testing.T) (fp string, tearDown func()) {
-	tmpDir, err := os.MkdirTemp(os.TempDir(), "wakatime-git")
-	require.NoError(t, err)
+func setupTestGitSubmodule(t *testing.T) (fp string) {
+	tmpDir := t.TempDir()
 
-	tmpDir, err = realpath.Realpath(tmpDir)
+	tmpDir, err := realpath.Realpath(tmpDir)
 	require.NoError(t, err)
 
 	if runtime.GOOS == "windows" {
@@ -437,5 +424,5 @@ func setupTestGitSubmodule(t *testing.T) (fp string, tearDown func()) {
 	copyFile(t, "testdata/git_submodule/HEAD2", filepath.Join(tmpDir, "billing/.git/HEAD"))
 	copyFile(t, "testdata/git_submodule/git", filepath.Join(tmpDir, "wakatime-cli/lib/billing/.git"))
 
-	return tmpDir, func() { os.RemoveAll(tmpDir) }
+	return tmpDir
 }

--- a/pkg/project/mercurial_test.go
+++ b/pkg/project/mercurial_test.go
@@ -12,8 +12,7 @@ import (
 )
 
 func TestMercurial_Detect(t *testing.T) {
-	fp, tearDown := setupTestMercurial(t)
-	defer tearDown()
+	fp := setupTestMercurial(t)
 
 	m := project.Mercurial{
 		Filepath: filepath.Join(fp, "wakatime-cli/src/pkg/file.go"),
@@ -32,8 +31,7 @@ func TestMercurial_Detect(t *testing.T) {
 }
 
 func TestMercurial_Detect_BranchWithSlash(t *testing.T) {
-	fp, tearDown := setupTestMercurialBranchWithSlash(t)
-	defer tearDown()
+	fp := setupTestMercurialBranchWithSlash(t)
 
 	m := project.Mercurial{
 		Filepath: filepath.Join(fp, "wakatime-cli/src/pkg/file.go"),
@@ -52,8 +50,7 @@ func TestMercurial_Detect_BranchWithSlash(t *testing.T) {
 }
 
 func TestMercurial_Detect_NoBranch(t *testing.T) {
-	fp, tearDown := setupTestMercurialNoBranch(t)
-	defer tearDown()
+	fp := setupTestMercurialNoBranch(t)
 
 	m := project.Mercurial{
 		Filepath: filepath.Join(fp, "wakatime-cli/src/pkg/file.go"),
@@ -71,11 +68,10 @@ func TestMercurial_Detect_NoBranch(t *testing.T) {
 	}, result)
 }
 
-func setupTestMercurial(t *testing.T) (fp string, tearDown func()) {
-	tmpDir, err := os.MkdirTemp(os.TempDir(), "wakatime-hg")
-	require.NoError(t, err)
+func setupTestMercurial(t *testing.T) (fp string) {
+	tmpDir := t.TempDir()
 
-	err = os.MkdirAll(filepath.Join(tmpDir, "wakatime-cli/src/pkg"), os.FileMode(int(0700)))
+	err := os.MkdirAll(filepath.Join(tmpDir, "wakatime-cli/src/pkg"), os.FileMode(int(0700)))
 	require.NoError(t, err)
 
 	tmpFile, err := os.Create(filepath.Join(tmpDir, "wakatime-cli/src/pkg/file.go"))
@@ -88,14 +84,13 @@ func setupTestMercurial(t *testing.T) (fp string, tearDown func()) {
 
 	copyFile(t, "testdata/hg/branch", filepath.Join(tmpDir, "wakatime-cli/.hg/branch"))
 
-	return tmpDir, func() { os.RemoveAll(tmpDir) }
+	return tmpDir
 }
 
-func setupTestMercurialBranchWithSlash(t *testing.T) (fp string, tearDown func()) {
-	tmpDir, err := os.MkdirTemp(os.TempDir(), "wakatime-hg")
-	require.NoError(t, err)
+func setupTestMercurialBranchWithSlash(t *testing.T) (fp string) {
+	tmpDir := t.TempDir()
 
-	err = os.MkdirAll(filepath.Join(tmpDir, "wakatime-cli/src/pkg"), os.FileMode(int(0700)))
+	err := os.MkdirAll(filepath.Join(tmpDir, "wakatime-cli/src/pkg"), os.FileMode(int(0700)))
 	require.NoError(t, err)
 
 	tmpFile, err := os.Create(filepath.Join(tmpDir, "wakatime-cli/src/pkg/file.go"))
@@ -108,14 +103,13 @@ func setupTestMercurialBranchWithSlash(t *testing.T) (fp string, tearDown func()
 
 	copyFile(t, "testdata/hg/branch_with_slash", filepath.Join(tmpDir, "wakatime-cli/.hg/branch"))
 
-	return tmpDir, func() { os.RemoveAll(tmpDir) }
+	return tmpDir
 }
 
-func setupTestMercurialNoBranch(t *testing.T) (fp string, tearDown func()) {
-	tmpDir, err := os.MkdirTemp(os.TempDir(), "wakatime-hg")
-	require.NoError(t, err)
+func setupTestMercurialNoBranch(t *testing.T) (fp string) {
+	tmpDir := t.TempDir()
 
-	err = os.MkdirAll(filepath.Join(tmpDir, "wakatime-cli/src/pkg"), os.FileMode(int(0700)))
+	err := os.MkdirAll(filepath.Join(tmpDir, "wakatime-cli/src/pkg"), os.FileMode(int(0700)))
 	require.NoError(t, err)
 
 	tmpFile, err := os.Create(filepath.Join(tmpDir, "wakatime-cli/src/pkg/file.go"))
@@ -126,5 +120,5 @@ func setupTestMercurialNoBranch(t *testing.T) (fp string, tearDown func()) {
 	err = os.Mkdir(filepath.Join(tmpDir, "wakatime-cli/.hg"), os.FileMode(int(0700)))
 	require.NoError(t, err)
 
-	return tmpDir, func() { os.RemoveAll(tmpDir) }
+	return tmpDir
 }

--- a/pkg/project/project_test.go
+++ b/pkg/project/project_test.go
@@ -83,8 +83,7 @@ func TestWithDetection_EntityNotFile(t *testing.T) {
 }
 
 func TestWithDetection_OverrideTakesPrecedence(t *testing.T) {
-	fp, tearDown := setupTestGitBasic(t)
-	defer tearDown()
+	fp := setupTestGitBasic(t)
 
 	entity := filepath.Join(fp, "wakatime-cli/src/pkg/file.go")
 	projectPath := filepath.Join(fp, "wakatime-cli")
@@ -127,8 +126,7 @@ func TestWithDetection_OverrideTakesPrecedence(t *testing.T) {
 }
 
 func TestWithDetection_ObfuscateProject(t *testing.T) {
-	fp, tearDown := setupTestGitBasic(t)
-	defer tearDown()
+	fp := setupTestGitBasic(t)
 
 	entity := filepath.Join(fp, "wakatime-cli/src/pkg/file.go")
 	projectPath := filepath.Join(fp, "wakatime-cli")
@@ -174,8 +172,7 @@ func TestWithDetection_ObfuscateProject(t *testing.T) {
 }
 
 func TestWithDetection_WakatimeProjectTakesPrecedence(t *testing.T) {
-	fp, tearDown := setupTestGitBasic(t)
-	defer tearDown()
+	fp := setupTestGitBasic(t)
 
 	entity := filepath.Join(fp, "wakatime-cli/src/pkg/file.go")
 	projectPath := filepath.Join(fp, "wakatime-cli")
@@ -233,13 +230,12 @@ func TestDetect_FileDetected(t *testing.T) {
 }
 
 func TestDetect_MapDetected(t *testing.T) {
-	tmpDir, err := os.MkdirTemp(os.TempDir(), "wakatime")
-	require.NoError(t, err)
-
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	tmpFile, err := os.CreateTemp(tmpDir, "waka-billing")
 	require.NoError(t, err)
+
+	defer tmpFile.Close()
 
 	patterns := []project.MapPattern{
 		{
@@ -260,8 +256,7 @@ func TestDetect_MapDetected(t *testing.T) {
 }
 
 func TestDetectWithRevControl_GitDetected(t *testing.T) {
-	fp, tearDown := setupTestGitBasic(t)
-	defer tearDown()
+	fp := setupTestGitBasic(t)
 
 	result := project.DetectWithRevControl(
 		filepath.Join(fp, "wakatime-cli/src/pkg/file.go"),
@@ -277,10 +272,10 @@ func TestDetectWithRevControl_GitDetected(t *testing.T) {
 }
 
 func TestDetect_NoProjectDetected(t *testing.T) {
-	tmpFile, err := os.CreateTemp(os.TempDir(), "wakatime")
+	tmpFile, err := os.CreateTemp(t.TempDir(), "wakatime")
 	require.NoError(t, err)
 
-	defer os.Remove(tmpFile.Name())
+	defer tmpFile.Close()
 
 	result := project.Detect(tmpFile.Name(), []project.MapPattern{})
 
@@ -290,12 +285,9 @@ func TestDetect_NoProjectDetected(t *testing.T) {
 }
 
 func TestWrite(t *testing.T) {
-	tmpDir, err := os.MkdirTemp(os.TempDir(), "wakatime-git")
-	require.NoError(t, err)
+	tmpDir := t.TempDir()
 
-	defer os.RemoveAll(tmpDir)
-
-	err = project.Write(tmpDir, "billing")
+	err := project.Write(tmpDir, "billing")
 	require.NoError(t, err)
 
 	actual, err := os.ReadFile(filepath.Join(tmpDir, ".wakatime-project"))

--- a/pkg/project/subversion_test.go
+++ b/pkg/project/subversion_test.go
@@ -15,8 +15,7 @@ import (
 func TestSubversion_Detect(t *testing.T) {
 	skipIfBinaryNotFound(t)
 
-	fp, tearDown := setupTestSvn(t)
-	defer tearDown()
+	fp := setupTestSvn(t)
 
 	s := project.Subversion{
 		Filepath: filepath.Join(fp, "wakatime-cli", "src", "pkg", "file.go"),
@@ -36,8 +35,7 @@ func TestSubversion_Detect(t *testing.T) {
 func TestSubversion_Detect_Branch(t *testing.T) {
 	skipIfBinaryNotFound(t)
 
-	fp, tearDown := setupTestSvnBranch(t)
-	defer tearDown()
+	fp := setupTestSvnBranch(t)
 
 	s := project.Subversion{
 		Filepath: filepath.Join(fp, "wakatime-cli/src/pkg/file.go"),
@@ -54,11 +52,10 @@ func TestSubversion_Detect_Branch(t *testing.T) {
 	}, result)
 }
 
-func setupTestSvn(t *testing.T) (fp string, tearDown func()) {
-	tmpDir, err := os.MkdirTemp(os.TempDir(), "wakatime-svn")
-	require.NoError(t, err)
+func setupTestSvn(t *testing.T) (fp string) {
+	tmpDir := t.TempDir()
 
-	err = os.MkdirAll(filepath.Join(tmpDir, "wakatime-cli/src/pkg"), os.FileMode(int(0700)))
+	err := os.MkdirAll(filepath.Join(tmpDir, "wakatime-cli/src/pkg"), os.FileMode(int(0700)))
 	require.NoError(t, err)
 
 	tmpFile, err := os.Create(filepath.Join(tmpDir, "wakatime-cli/src/pkg/file.go"))
@@ -68,14 +65,13 @@ func setupTestSvn(t *testing.T) (fp string, tearDown func()) {
 
 	copyDir(t, "testdata/svn", filepath.Join(tmpDir, "wakatime-cli/.svn"))
 
-	return tmpDir, func() { os.RemoveAll(tmpDir) }
+	return tmpDir
 }
 
-func setupTestSvnBranch(t *testing.T) (fp string, tearDown func()) {
-	tmpDir, err := os.MkdirTemp(os.TempDir(), "wakatime-svn")
-	require.NoError(t, err)
+func setupTestSvnBranch(t *testing.T) (fp string) {
+	tmpDir := t.TempDir()
 
-	err = os.MkdirAll(filepath.Join(tmpDir, "wakatime-cli/src/pkg"), os.FileMode(int(0700)))
+	err := os.MkdirAll(filepath.Join(tmpDir, "wakatime-cli/src/pkg"), os.FileMode(int(0700)))
 	require.NoError(t, err)
 
 	tmpFile, err := os.Create(filepath.Join(tmpDir, "wakatime-cli/src/pkg/file.go"))
@@ -85,7 +81,7 @@ func setupTestSvnBranch(t *testing.T) (fp string, tearDown func()) {
 
 	copyDir(t, "testdata/svn_branch", filepath.Join(tmpDir, "wakatime-cli/.svn"))
 
-	return tmpDir, func() { os.RemoveAll(tmpDir) }
+	return tmpDir
 }
 
 func copyDir(t *testing.T, src string, dst string) {

--- a/pkg/project/tfvc_test.go
+++ b/pkg/project/tfvc_test.go
@@ -18,8 +18,7 @@ func TestTfvc_Detect(t *testing.T) {
 		t.Skip("Skipping because OS is windows.")
 	}
 
-	fp, tearDown := setupTestTfvc(t, ".tf")
-	defer tearDown()
+	fp := setupTestTfvc(t, ".tf")
 
 	s := project.Tfvc{
 		Filepath: filepath.Join(fp, "wakatime-cli", "src", "pkg", "file.go"),
@@ -41,8 +40,7 @@ func TestTfvc_Detect_Windows(t *testing.T) {
 		t.Skip("Skipping because OS is not windows.")
 	}
 
-	fp, tearDown := setupTestTfvc(t, "$tf")
-	defer tearDown()
+	fp := setupTestTfvc(t, "$tf")
 
 	s := project.Tfvc{
 		Filepath: filepath.Join(fp, "wakatime-cli", "src", "pkg", "file.go"),
@@ -59,11 +57,10 @@ func TestTfvc_Detect_Windows(t *testing.T) {
 	}, result)
 }
 
-func setupTestTfvc(t *testing.T, tfFolderName string) (fp string, tearDown func()) {
-	tmpDir, err := os.MkdirTemp(os.TempDir(), "wakatime-tfvc")
-	require.NoError(t, err)
+func setupTestTfvc(t *testing.T, tfFolderName string) (fp string) {
+	tmpDir := t.TempDir()
 
-	err = os.MkdirAll(filepath.Join(tmpDir, "wakatime-cli/src/pkg"), os.FileMode(int(0700)))
+	err := os.MkdirAll(filepath.Join(tmpDir, "wakatime-cli/src/pkg"), os.FileMode(int(0700)))
 	require.NoError(t, err)
 
 	err = os.Mkdir(filepath.Join(tmpDir, fmt.Sprintf("wakatime-cli/%s", tfFolderName)), os.FileMode(int(0700)))
@@ -79,5 +76,5 @@ func setupTestTfvc(t *testing.T, tfFolderName string) (fp string, tearDown func(
 
 	defer tmpPropertiesFile.Close()
 
-	return tmpDir, func() { os.RemoveAll(tmpDir) }
+	return tmpDir
 }

--- a/pkg/windows/windows_internal_test.go
+++ b/pkg/windows/windows_internal_test.go
@@ -68,10 +68,10 @@ func TestFormatLocalFilePath(t *testing.T) {
 }
 
 func TestFormatLocalFilePath_LocalFileExists(t *testing.T) {
-	tmpFile, err := os.CreateTemp(os.TempDir(), "")
+	tmpFile, err := os.CreateTemp(t.TempDir(), "")
 	require.NoError(t, err)
 
-	defer os.Remove(tmpFile.Name())
+	defer tmpFile.Close()
 
 	cmd = testCommander{}
 	formatted, err := FormatLocalFilePath(tmpFile.Name(), `S:\entity`)
@@ -81,10 +81,10 @@ func TestFormatLocalFilePath_LocalFileExists(t *testing.T) {
 }
 
 func TestFormatLocalFilePath_EntityExists(t *testing.T) {
-	tmpFile, err := os.CreateTemp(os.TempDir(), "")
+	tmpFile, err := os.CreateTemp(t.TempDir(), "")
 	require.NoError(t, err)
 
-	defer os.Remove(tmpFile.Name())
+	defer tmpFile.Close()
 
 	cmd = testCommander{}
 	formatted, err := FormatLocalFilePath(`X:\localfile`, tmpFile.Name())


### PR DESCRIPTION
This PR changes to `t.TempDir()` which is automatically cleaned up after test runs. Don't need to create or use `os.TempDir()` and defer a function to remove them. It simplifies and uses test suite to manage temporary folder.