### PR TITLE
Ensure env var is unset on test files

### DIFF
--- a/cmd/logfile/logfile_test.go
+++ b/cmd/logfile/logfile_test.go
@@ -106,6 +106,8 @@ func TestLoadParams(t *testing.T) {
 			err := os.Setenv("WAKATIME_HOME", test.EnvVar)
 			require.NoError(t, err)
 
+			defer os.Unsetenv("WAKATIME_HOME")
+
 			params, err := logfile.LoadParams(v)
 			require.NoError(t, err)
 

--- a/pkg/ini/ini_test.go
+++ b/pkg/ini/ini_test.go
@@ -131,6 +131,8 @@ func TestFilePath(t *testing.T) {
 			err := os.Setenv("WAKATIME_HOME", test.EnvVar)
 			require.NoError(t, err)
 
+			defer os.Unsetenv("WAKATIME_HOME")
+
 			configFilepath, err := ini.FilePath(v)
 			require.NoError(t, err)
 
@@ -165,8 +167,11 @@ func TestInternalFilePath(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			v := viper.New()
 			v.Set("internal-config", test.ViperValue)
+
 			err := os.Setenv("WAKATIME_HOME", test.EnvVar)
 			require.NoError(t, err)
+
+			defer os.Unsetenv("WAKATIME_HOME")
 
 			configFilepath, err := ini.InternalFilePath(v)
 			require.NoError(t, err)

--- a/pkg/offline/offline_test.go
+++ b/pkg/offline/offline_test.go
@@ -46,6 +46,8 @@ func TestQueueFilepath(t *testing.T) {
 			err := os.Setenv("WAKATIME_HOME", test.EnvVar)
 			require.NoError(t, err)
 
+			defer os.Unsetenv("WAKATIME_HOME")
+
 			queueFilepath, err := offline.QueueFilepath()
 			require.NoError(t, err)
 


### PR DESCRIPTION
This PR adds `defer os.Unsetenv("<var>")` to ensure all environment variables are unset upon tests finish.