### PR TITLE
Fix gaps where heartbeats not saved to offline db

### DIFF
--- a/cmd/heartbeat/heartbeat_test.go
+++ b/cmd/heartbeat/heartbeat_test.go
@@ -74,6 +74,11 @@ func TestSendHeartbeats(t *testing.T) {
 		numCalls++
 	})
 
+	offlineFile, err := os.CreateTemp(t.TempDir(), "")
+	require.NoError(t, err)
+
+	defer offlineFile.Close()
+
 	v := viper.New()
 	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("api-url", testServerURL)
@@ -92,11 +97,9 @@ func TestSendHeartbeats(t *testing.T) {
 	v.Set("time", 1585598059.1)
 	v.Set("timeout", 5)
 	v.Set("write", true)
+	v.Set("offline-queue-file", offlineFile.Name())
 
-	f, err := os.CreateTemp(t.TempDir(), "")
-	require.NoError(t, err)
-
-	err = cmdheartbeat.SendHeartbeats(v, f.Name())
+	err = cmdheartbeat.SendHeartbeats(v)
 	require.NoError(t, err)
 
 	assert.Eventually(t, func() bool { return numCalls == 1 }, time.Second, 50*time.Millisecond)
@@ -114,6 +117,11 @@ func TestSendHeartbeats_WithFiltering_Exclude(t *testing.T) {
 		numCalls++
 	})
 
+	offlineFile, err := os.CreateTemp(t.TempDir(), "")
+	require.NoError(t, err)
+
+	defer offlineFile.Close()
+
 	v := viper.New()
 	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("api-url", testServerURL)
@@ -126,11 +134,9 @@ func TestSendHeartbeats_WithFiltering_Exclude(t *testing.T) {
 	v.Set("time", 1585598059.1)
 	v.Set("timeout", 5)
 	v.Set("write", true)
+	v.Set("offline-queue-file", offlineFile.Name())
 
-	f, err := os.CreateTemp(t.TempDir(), "")
-	require.NoError(t, err)
-
-	err = cmdheartbeat.SendHeartbeats(v, f.Name())
+	err = cmdheartbeat.SendHeartbeats(v)
 	require.NoError(t, err)
 
 	assert.Equal(t, 0, numCalls)
@@ -236,6 +242,11 @@ func TestSendHeartbeats_ExtraHeartbeats(t *testing.T) {
 		w.Close()
 	}()
 
+	offlineFile, err := os.CreateTemp(t.TempDir(), "")
+	require.NoError(t, err)
+
+	defer offlineFile.Close()
+
 	v := viper.New()
 	v.SetDefault("sync-offline-activity", 0)
 	v.Set("api-url", testServerURL)
@@ -254,16 +265,12 @@ func TestSendHeartbeats_ExtraHeartbeats(t *testing.T) {
 	v.Set("time", 1585598059.1)
 	v.Set("timeout", 5)
 	v.Set("write", true)
+	v.Set("offline-queue-file", offlineFile.Name())
 
-	offlineQueueFile, err := os.CreateTemp(t.TempDir(), "")
+	err = cmdheartbeat.SendHeartbeats(v)
 	require.NoError(t, err)
 
-	defer offlineQueueFile.Close()
-
-	err = cmdheartbeat.SendHeartbeats(v, offlineQueueFile.Name())
-	require.NoError(t, err)
-
-	offlineCount, err := offline.CountHeartbeats(offlineQueueFile.Name())
+	offlineCount, err := offline.CountHeartbeats(offlineFile.Name())
 	require.NoError(t, err)
 
 	assert.Equal(t, 1, offlineCount)
@@ -279,6 +286,11 @@ func TestSendHeartbeats_NonExistingEntity(t *testing.T) {
 
 	defer logFile.Close()
 
+	offlineFile, err := os.CreateTemp(tmpDir, "")
+	require.NoError(t, err)
+
+	defer offlineFile.Close()
+
 	v := viper.New()
 	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("api-url", "https://example.org")
@@ -286,6 +298,7 @@ func TestSendHeartbeats_NonExistingEntity(t *testing.T) {
 	v.Set("entity-type", "file")
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("log-file", logFile.Name())
+	v.Set("offline-queue-file", offlineFile.Name())
 
 	cmd.SetupLogging(v)
 
@@ -298,12 +311,7 @@ func TestSendHeartbeats_NonExistingEntity(t *testing.T) {
 		}
 	}()
 
-	f, err := os.CreateTemp(tmpDir, "")
-	require.NoError(t, err)
-
-	defer f.Close()
-
-	err = cmdheartbeat.SendHeartbeats(v, f.Name())
+	err = cmdheartbeat.SendHeartbeats(v)
 	require.NoError(t, err)
 
 	output, err := io.ReadAll(logFile)
@@ -389,6 +397,9 @@ func TestSendHeartbeats_NonExistingExtraHeartbeatsEntity(t *testing.T) {
 	logFile, err := os.CreateTemp(tmpDir, "")
 	require.NoError(t, err)
 
+	offlineFile, err := os.CreateTemp(t.TempDir(), "")
+	require.NoError(t, err)
+
 	v := viper.New()
 	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("api-url", testServerURL)
@@ -401,15 +412,13 @@ func TestSendHeartbeats_NonExistingExtraHeartbeatsEntity(t *testing.T) {
 	v.Set("plugin", plugin)
 	v.Set("time", 1585598059.1)
 	v.Set("log-file", logFile.Name())
+	v.Set("offline-queue-file", offlineFile.Name())
 	v.Set("verbose", true)
 
 	cmd.SetupLogging(v)
 
-	f, err := os.CreateTemp(tmpDir, "")
-	require.NoError(t, err)
-
 	defer func() {
-		f.Close()
+		offlineFile.Close()
 		logFile.Close()
 
 		if file, ok := log.Output().(*os.File); ok {
@@ -420,7 +429,7 @@ func TestSendHeartbeats_NonExistingExtraHeartbeatsEntity(t *testing.T) {
 		}
 	}()
 
-	err = cmdheartbeat.SendHeartbeats(v, f.Name())
+	err = cmdheartbeat.SendHeartbeats(v)
 	require.NoError(t, err)
 
 	output, err := io.ReadAll(logFile)

--- a/cmd/offlinecount/offlinecount.go
+++ b/cmd/offlinecount/offlinecount.go
@@ -12,7 +12,7 @@ import (
 
 // Run executes the offline-count command.
 func Run(v *viper.Viper) (int, error) {
-	queueFilepath, err := offline.QueueFilepath()
+	queueFilepath, err := offline.QueueFilepathWithErr()
 	if err != nil {
 		return exitcode.ErrGeneric, fmt.Errorf(
 			"failed to load offline queue filepath: %s",

--- a/cmd/offlinesync/offlinesync.go
+++ b/cmd/offlinesync/offlinesync.go
@@ -16,7 +16,7 @@ import (
 
 // Run executes the sync-offline-activity command.
 func Run(v *viper.Viper) (int, error) {
-	queueFilepath, err := offline.QueueFilepath()
+	queueFilepath, err := offline.QueueFilepathWithErr()
 	if err != nil {
 		return exitcode.ErrGeneric, fmt.Errorf(
 			"offline sync failed: failed to load offline queue filepath: %s",

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -25,7 +25,6 @@ import (
 	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 	"github.com/wakatime/wakatime-cli/pkg/ini"
 	"github.com/wakatime/wakatime-cli/pkg/log"
-	"github.com/wakatime/wakatime-cli/pkg/offline"
 	"github.com/wakatime/wakatime-cli/pkg/vipertools"
 
 	"github.com/spf13/cobra"
@@ -36,19 +35,10 @@ import (
 func Run(cmd *cobra.Command, v *viper.Viper) {
 	err := parseConfigFiles(v)
 	if err != nil {
-		if !v.IsSet("entity") {
-			os.Exit(exitcode.ErrConfigFileParse)
-		}
-
-		queueFilepath, err := offline.QueueFilepath()
-		if err != nil {
-			log.Errorf("failed to load offline queue filepath: %s", err)
-
-			os.Exit(exitcode.ErrConfigFileParse)
-		}
-
-		if err := offlinecmd.SaveHeartbeats(v, nil, queueFilepath); err != nil {
-			log.Errorf("failed to save extra heartbeats to offline queue: %s", err)
+		if v.IsSet("entity") {
+			if err := offlinecmd.SaveHeartbeats(v, nil); err != nil {
+				log.Errorf("failed to save heartbeats to offline queue: %s", err)
+			}
 		}
 
 		os.Exit(exitcode.ErrConfigFileParse)

--- a/pkg/offline/offline.go
+++ b/pkg/offline/offline.go
@@ -82,8 +82,21 @@ func WithQueue(filepath string) (heartbeat.HandleOption, error) {
 	}, nil
 }
 
-// QueueFilepath returns the path for offline queue db file.
-func QueueFilepath() (string, error) {
+// QueueFilepath returns the path for offline queue db file. If
+// the user's $HOME folder cannot be detected, it defaults to the
+// current directory.
+func QueueFilepath() string {
+	home, err := ini.WakaHomeDir()
+	if err != nil {
+		log.Errorf("failed getting user's home directory: %s", err)
+	}
+
+	return filepath.Join(home, dbFilename)
+}
+
+// QueueFilepathWithErr returns the path for offline queue db file
+// or an error if the user's $HOME folder could not be detected.
+func QueueFilepathWithErr() (string, error) {
 	home, err := ini.WakaHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("failed getting user's home directory: %s", err)

--- a/pkg/offline/offline_test.go
+++ b/pkg/offline/offline_test.go
@@ -48,7 +48,7 @@ func TestQueueFilepath(t *testing.T) {
 
 			defer os.Unsetenv("WAKATIME_HOME")
 
-			queueFilepath, err := offline.QueueFilepath()
+			queueFilepath, err := offline.QueueFilepathWithErr()
 			require.NoError(t, err)
 
 			assert.Equal(t, test.Expected, queueFilepath)


### PR DESCRIPTION
We had several places where `return` or `os.Exit` were called before executing `heartbeat.NewHandle(apiClient, handleOpts...)`. Any early return/exit before `heartbeat.NewHandle(apiClient, handleOpts...)` causes heartbeats to be lost.

Related to #579.