### PR TITLE
Prevent PANIC when api key is empty string

### DIFF
--- a/cmd/params/params.go
+++ b/cmd/params/params.go
@@ -761,11 +761,17 @@ func (p API) String() string {
 		backoffAt = p.BackoffAt.Format(ini.DateFormat)
 	}
 
+	apiKey := p.Key
+	if len(apiKey) > 4 {
+		// only show last 4 chars of api key in logs
+		apiKey = "..." + apiKey[:len(apiKey)-4]
+	}
+
 	return fmt.Sprintf(
 		"api key: '%s', api url: '%s', backoff at: '%s', backoff retries: %d,"+
 			" hostname: '%s', plugin: '%s', timeout: %s, disable ssl verify: %t,"+
 			" proxy url: '%s', ssl cert filepath: '%s'",
-		p.Key[:4]+"...",
+		apiKey,
 		p.URL,
 		backoffAt,
 		p.BackoffRetries,


### PR DESCRIPTION
When api key is empty string or less than 4 chars in length, a `PANIC` occurs when logging:

`(%!s(PANIC=String method: runtime error: slice bounds out of range [:4] with length 0))`