### PR TITLE
Improve loading params

### DIFF
--- a/cmd/offlinecount/offlinecount.go
+++ b/cmd/offlinecount/offlinecount.go
@@ -12,7 +12,7 @@ import (
 
 // Run executes the offline-count command.
 func Run(v *viper.Viper) (int, error) {
-	queueFilepath, err := offline.QueueFilepathWithErr()
+	queueFilepath, err := offline.QueueFilepath()
 	if err != nil {
 		return exitcode.ErrGeneric, fmt.Errorf(
 			"failed to load offline queue filepath: %s",
@@ -20,13 +20,13 @@ func Run(v *viper.Viper) (int, error) {
 		)
 	}
 
-	p, err := params.Load(v, params.Config{})
+	p, err := params.LoadOfflineParams(v)
 	if err != nil {
-		return exitcode.ErrGeneric, fmt.Errorf("failed to load command parameters: %w", err)
+		return exitcode.ErrGeneric, fmt.Errorf("failed to load offline parameters: %w", err)
 	}
 
-	if p.Offline.QueueFile != "" {
-		queueFilepath = p.Offline.QueueFile
+	if p.QueueFile != "" {
+		queueFilepath = p.QueueFile
 	}
 
 	count, err := offline.CountHeartbeats(queueFilepath)

--- a/cmd/params/params_test.go
+++ b/cmd/params/params_test.go
@@ -25,27 +25,23 @@ import (
 
 func TestLoadParams_AlternateProject(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("alternate-project", "web")
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+	params, err := paramscmd.LoadHeartbeatParams(v)
 	require.NoError(t, err)
 
-	assert.Equal(t, "web", params.Heartbeat.Project.Alternate)
+	assert.Equal(t, "web", params.Project.Alternate)
 }
 
 func TestLoadParams_AlternateProject_Unset(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+	params, err := paramscmd.LoadHeartbeatParams(v)
 	require.NoError(t, err)
 
-	assert.Empty(t, params.Heartbeat.Project.Alternate)
+	assert.Empty(t, params.Project.Alternate)
 }
 
 func TestLoadParams_Category(t *testing.T) {
@@ -65,119 +61,102 @@ func TestLoadParams_Category(t *testing.T) {
 	for name, category := range tests {
 		t.Run(name, func(t *testing.T) {
 			v := viper.New()
-			v.SetDefault("sync-offline-activity", 1000)
-			v.Set("key", "00000000-0000-4000-8000-000000000000")
 			v.Set("entity", "/path/to/file")
 			v.Set("category", name)
 
-			params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+			params, err := paramscmd.LoadHeartbeatParams(v)
 			require.NoError(t, err)
 
-			assert.Equal(t, category, params.Heartbeat.Category)
+			assert.Equal(t, category, params.Category)
 		})
 	}
 }
 
 func TestLoadParams_Category_Default(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true})
+	params, err := paramscmd.LoadHeartbeatParams(v)
 	require.NoError(t, err)
 
-	assert.Equal(t, heartbeat.CodingCategory, params.Heartbeat.Category)
+	assert.Equal(t, heartbeat.CodingCategory, params.Category)
 }
 
 func TestLoadParams_Category_Invalid(t *testing.T) {
 	v := viper.New()
 	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
-	v.Set("entity", "/path/to/file")
 	v.Set("category", "invalid")
 
-	_, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+	_, err := paramscmd.LoadHeartbeatParams(v)
 	require.Error(t, err)
 
-	assert.Equal(t, "failed to load heartbeat params: failed to parse category: invalid category \"invalid\"", err.Error())
+	assert.Equal(t, "failed to parse category: invalid category \"invalid\"", err.Error())
 }
 
 func TestLoadParams_CursorPosition(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("entity", "/path/to/file")
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("cursorpos", 42)
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+	params, err := paramscmd.LoadHeartbeatParams(v)
 	require.NoError(t, err)
 
-	assert.Equal(t, 42, *params.Heartbeat.CursorPosition)
+	assert.Equal(t, 42, *params.CursorPosition)
 }
 
 func TestLoadParams_CursorPosition_Zero(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("entity", "/path/to/file")
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("cursorpos", 0)
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+	params, err := paramscmd.LoadHeartbeatParams(v)
 	require.NoError(t, err)
 
-	assert.Equal(t, 0, *params.Heartbeat.CursorPosition)
+	assert.Zero(t, *params.CursorPosition)
 }
 
 func TestLoadParams_CursorPosition_Unset(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("entity", "/path/to/file")
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+	params, err := paramscmd.LoadHeartbeatParams(v)
 	require.NoError(t, err)
 
-	assert.Nil(t, params.Heartbeat.CursorPosition)
+	assert.Nil(t, params.CursorPosition)
 }
 
 func TestLoadParams_Entity_EntityFlagTakesPrecedence(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("file", "ignored")
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+	params, err := paramscmd.LoadHeartbeatParams(v)
 	require.NoError(t, err)
 
-	assert.Equal(t, "/path/to/file", params.Heartbeat.Entity)
+	assert.Equal(t, "/path/to/file", params.Entity)
 }
 
 func TestLoadParams_Entity_FileFlag(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("file", "~/path/to/file")
 
 	home, err := os.UserHomeDir()
 	require.NoError(t, err)
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+	params, err := paramscmd.LoadHeartbeatParams(v)
 	require.NoError(t, err)
 
-	assert.Equal(t, filepath.Join(home, "/path/to/file"), params.Heartbeat.Entity)
+	assert.Equal(t, filepath.Join(home, "/path/to/file"), params.Entity)
 }
 
 func TestLoadParams_Entity_Unset(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
 
-	_, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+	_, err := paramscmd.LoadHeartbeatParams(v)
 	require.Error(t, err)
 
-	assert.Equal(t, "failed to load heartbeat params: failed to retrieve entity", err.Error())
+	assert.Equal(t, "failed to retrieve entity", err.Error())
 }
 
 func TestLoadParams_EntityType(t *testing.T) {
@@ -190,44 +169,38 @@ func TestLoadParams_EntityType(t *testing.T) {
 	for name, entityType := range tests {
 		t.Run(name, func(t *testing.T) {
 			v := viper.New()
-			v.SetDefault("sync-offline-activity", 1000)
-			v.Set("key", "00000000-0000-4000-8000-000000000000")
 			v.Set("entity", "/path/to/file")
 			v.Set("entity-type", name)
 
-			params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+			params, err := paramscmd.LoadHeartbeatParams(v)
 			require.NoError(t, err)
 
-			assert.Equal(t, entityType, params.Heartbeat.EntityType)
+			assert.Equal(t, entityType, params.EntityType)
 		})
 	}
 }
 
 func TestLoadParams_EntityType_Default(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+	params, err := paramscmd.LoadHeartbeatParams(v)
 	require.NoError(t, err)
 
-	assert.Equal(t, heartbeat.FileType, params.Heartbeat.EntityType)
+	assert.Equal(t, heartbeat.FileType, params.EntityType)
 }
 
 func TestLoadParams_EntityType_Invalid(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("entity-type", "invalid")
 
-	_, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+	_, err := paramscmd.LoadHeartbeatParams(v)
 	require.Error(t, err)
 
 	assert.Equal(
 		t,
-		"failed to load heartbeat params: failed to parse entity type: invalid entity type \"invalid\"",
+		"failed to parse entity type: invalid entity type \"invalid\"",
 		err.Error())
 }
 
@@ -257,20 +230,18 @@ func TestLoadParams_ExtraHeartbeats(t *testing.T) {
 	}()
 
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("extra-heartbeats", true)
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+	params, err := paramscmd.LoadHeartbeatParams(v)
 	require.NoError(t, err)
 
-	assert.Len(t, params.Heartbeat.ExtraHeartbeats, 2)
+	assert.Len(t, params.ExtraHeartbeats, 2)
 
-	assert.NotNil(t, params.Heartbeat.ExtraHeartbeats[0].Language)
-	assert.Equal(t, heartbeat.LanguageGo.String(), *params.Heartbeat.ExtraHeartbeats[0].Language)
-	assert.NotNil(t, params.Heartbeat.ExtraHeartbeats[1].Language)
-	assert.Equal(t, heartbeat.LanguagePython.String(), *params.Heartbeat.ExtraHeartbeats[1].Language)
+	assert.NotNil(t, params.ExtraHeartbeats[0].Language)
+	assert.Equal(t, heartbeat.LanguageGo.String(), *params.ExtraHeartbeats[0].Language)
+	assert.NotNil(t, params.ExtraHeartbeats[1].Language)
+	assert.Equal(t, heartbeat.LanguagePython.String(), *params.ExtraHeartbeats[1].Language)
 
 	assert.Equal(t, []heartbeat.Heartbeat{
 		{
@@ -286,7 +257,7 @@ func TestLoadParams_ExtraHeartbeats(t *testing.T) {
 			ProjectOverride:   "wakatime-cli",
 			Time:              1585598059,
 			// tested above
-			Language: params.Heartbeat.ExtraHeartbeats[0].Language,
+			Language: params.ExtraHeartbeats[0].Language,
 		},
 		{
 			Category:          heartbeat.DebuggingCategory,
@@ -299,9 +270,9 @@ func TestLoadParams_ExtraHeartbeats(t *testing.T) {
 			ProjectOverride:   "wakatime-cli",
 			Time:              1585598060,
 			// tested above
-			Language: params.Heartbeat.ExtraHeartbeats[1].Language,
+			Language: params.ExtraHeartbeats[1].Language,
 		},
-	}, params.Heartbeat.ExtraHeartbeats)
+	}, params.ExtraHeartbeats)
 }
 
 func TestLoadParams_ExtraHeartbeats_WithStringValues(t *testing.T) {
@@ -330,20 +301,18 @@ func TestLoadParams_ExtraHeartbeats_WithStringValues(t *testing.T) {
 	}()
 
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("extra-heartbeats", true)
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+	params, err := paramscmd.LoadHeartbeatParams(v)
 	require.NoError(t, err)
 
-	assert.Len(t, params.Heartbeat.ExtraHeartbeats, 2)
+	assert.Len(t, params.ExtraHeartbeats, 2)
 
-	assert.NotNil(t, params.Heartbeat.ExtraHeartbeats[0].Language)
-	assert.Equal(t, heartbeat.LanguageGo.String(), *params.Heartbeat.ExtraHeartbeats[0].Language)
-	assert.NotNil(t, params.Heartbeat.ExtraHeartbeats[1].Language)
-	assert.Equal(t, heartbeat.LanguagePython.String(), *params.Heartbeat.ExtraHeartbeats[1].Language)
+	assert.NotNil(t, params.ExtraHeartbeats[0].Language)
+	assert.Equal(t, heartbeat.LanguageGo.String(), *params.ExtraHeartbeats[0].Language)
+	assert.NotNil(t, params.ExtraHeartbeats[1].Language)
+	assert.Equal(t, heartbeat.LanguagePython.String(), *params.ExtraHeartbeats[1].Language)
 
 	assert.Equal(t, []heartbeat.Heartbeat{
 		{
@@ -352,7 +321,7 @@ func TestLoadParams_ExtraHeartbeats_WithStringValues(t *testing.T) {
 			Entity:         "testdata/main.go",
 			EntityType:     heartbeat.FileType,
 			IsWrite:        heartbeat.Bool(true),
-			Language:       params.Heartbeat.ExtraHeartbeats[0].Language,
+			Language:       params.ExtraHeartbeats[0].Language,
 			Lines:          heartbeat.Int(45),
 			LineNumber:     heartbeat.Int(42),
 			Time:           1585598059,
@@ -363,12 +332,12 @@ func TestLoadParams_ExtraHeartbeats_WithStringValues(t *testing.T) {
 			Entity:         "testdata/main.go",
 			EntityType:     heartbeat.FileType,
 			IsWrite:        heartbeat.Bool(true),
-			Language:       params.Heartbeat.ExtraHeartbeats[1].Language,
+			Language:       params.ExtraHeartbeats[1].Language,
 			LineNumber:     heartbeat.Int(43),
 			Lines:          heartbeat.Int(46),
 			Time:           1585598060,
 		},
-	}, params.Heartbeat.ExtraHeartbeats)
+	}, params.ExtraHeartbeats)
 }
 
 func TestLoadParams_IsWrite(t *testing.T) {
@@ -380,158 +349,112 @@ func TestLoadParams_IsWrite(t *testing.T) {
 	for name, isWrite := range tests {
 		t.Run(name, func(t *testing.T) {
 			v := viper.New()
-			v.SetDefault("sync-offline-activity", 1000)
-			v.Set("key", "00000000-0000-4000-8000-000000000000")
 			v.Set("entity", "/path/to/file")
 			v.Set("write", isWrite)
 
-			params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+			params, err := paramscmd.LoadHeartbeatParams(v)
 			require.NoError(t, err)
 
-			assert.Equal(t, isWrite, *params.Heartbeat.IsWrite)
+			assert.Equal(t, isWrite, *params.IsWrite)
 		})
 	}
 }
 
 func TestLoadParams_IsWrite_Unset(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+	params, err := paramscmd.LoadHeartbeatParams(v)
 	require.NoError(t, err)
 
-	assert.Nil(t, params.Heartbeat.IsWrite)
+	assert.Nil(t, params.IsWrite)
 }
 
 func TestLoadParams_Language(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("entity", "/path/to/file")
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("language", "Go")
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+	params, err := paramscmd.LoadHeartbeatParams(v)
 	require.NoError(t, err)
 
-	assert.NotNil(t, params.Heartbeat.Language)
-	assert.Equal(t, heartbeat.LanguageGo.String(), *params.Heartbeat.Language)
+	assert.Equal(t, heartbeat.LanguageGo.String(), *params.Language)
 }
 
 func TestLoadParams_LanguageAlternate(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("entity", "/path/to/file")
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("alternate-language", "Go")
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+	params, err := paramscmd.LoadHeartbeatParams(v)
 	require.NoError(t, err)
 
-	assert.Equal(t, heartbeat.LanguageGo.String(), params.Heartbeat.LanguageAlternate)
-	assert.Nil(t, params.Heartbeat.Language)
+	assert.Equal(t, heartbeat.LanguageGo.String(), params.LanguageAlternate)
+	assert.Nil(t, params.Language)
 }
 
 func TestLoadParams_LineNumber(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("entity", "/path/to/file")
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("lineno", 42)
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+	params, err := paramscmd.LoadHeartbeatParams(v)
 	require.NoError(t, err)
 
-	assert.Equal(t, 42, *params.Heartbeat.LineNumber)
+	assert.Equal(t, 42, *params.LineNumber)
 }
 
 func TestLoadParams_LineNumber_Zero(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("entity", "/path/to/file")
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("lineno", 0)
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+	params, err := paramscmd.LoadHeartbeatParams(v)
 	require.NoError(t, err)
 
-	assert.Equal(t, 0, *params.Heartbeat.LineNumber)
+	assert.Zero(t, *params.LineNumber)
 }
 
 func TestLoadParams_LineNumber_Unset(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("entity", "/path/to/file")
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+	params, err := paramscmd.LoadHeartbeatParams(v)
 	require.NoError(t, err)
 
-	assert.Nil(t, params.Heartbeat.LineNumber)
+	assert.Nil(t, params.LineNumber)
 }
 
 func TestLoadParams_LocalFile(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("entity", "/path/to/file")
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("local-file", "/path/to/file")
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+	params, err := paramscmd.LoadHeartbeatParams(v)
 	require.NoError(t, err)
 
-	assert.Equal(t, "/path/to/file", params.Heartbeat.LocalFile)
-}
-
-func TestLoadParams_Plugin(t *testing.T) {
-	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
-	v.Set("entity", "/path/to/file")
-	v.Set("plugin", "plugin/10.0.0")
-
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
-	require.NoError(t, err)
-
-	assert.Equal(t, "plugin/10.0.0", params.API.Plugin)
-}
-
-func TestLoadParams_Plugin_Unset(t *testing.T) {
-	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
-	v.Set("entity", "/path/to/file")
-
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
-	require.NoError(t, err)
-
-	assert.Empty(t, params.API.Plugin)
+	assert.Equal(t, "/path/to/file", params.LocalFile)
 }
 
 func TestLoadParams_Project(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("project", "billing")
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+	params, err := paramscmd.LoadHeartbeatParams(v)
 	require.NoError(t, err)
 
-	assert.Equal(t, "billing", params.Heartbeat.Project.Override)
+	assert.Equal(t, "billing", params.Project.Override)
 }
 
 func TestLoadParams_Project_Unset(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+	params, err := paramscmd.LoadHeartbeatParams(v)
 	require.NoError(t, err)
 
-	assert.Empty(t, params.Heartbeat.Project.Override)
+	assert.Empty(t, params.Project.Override)
 }
 
 func TestLoadParams_ProjectMap(t *testing.T) {
@@ -568,121 +491,82 @@ func TestLoadParams_ProjectMap(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			v := viper.New()
-			v.SetDefault("sync-offline-activity", 1000)
-			v.Set("key", "00000000-0000-4000-8000-000000000000")
 			v.Set("entity", test.Entity)
 			v.Set(fmt.Sprintf("projectmap.%s", test.Regex.String()), test.Project)
 
-			params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+			params, err := paramscmd.LoadHeartbeatParams(v)
 			require.NoError(t, err)
 
-			assert.Equal(t, test.Expected, params.Heartbeat.Project.MapPatterns)
+			assert.Equal(t, test.Expected, params.Project.MapPatterns)
 		})
 	}
 }
 
-func TestLoadParams_Timeout_FlagTakesPreceedence(t *testing.T) {
-	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
-	v.Set("entity", "/path/to/file")
-	v.Set("timeout", 5)
-	v.Set("settings.timeout", 10)
-
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
-	require.NoError(t, err)
-
-	assert.Equal(t, 5*time.Second, params.API.Timeout)
-}
-
-func TestLoadParams_Timeout_FromConfig(t *testing.T) {
-	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("entity", "/path/to/file")
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
-	v.Set("settings.timeout", 10)
-
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
-	require.NoError(t, err)
-
-	assert.Equal(t, 10*time.Second, params.API.Timeout)
-}
-
 func TestLoadParams_Time(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("time", 1590609206.1)
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+	params, err := paramscmd.LoadHeartbeatParams(v)
 	require.NoError(t, err)
 
-	assert.Equal(t, 1590609206.1, params.Heartbeat.Time)
+	assert.Equal(t, 1590609206.1, params.Time)
 }
 
 func TestLoadParams_Time_Default(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+	params, err := paramscmd.LoadHeartbeatParams(v)
 	require.NoError(t, err)
 
 	now := float64(time.Now().UnixNano()) / 1000000000
-	assert.GreaterOrEqual(t, now, params.Heartbeat.Time)
-	assert.GreaterOrEqual(t, params.Heartbeat.Time, now-60)
+	assert.GreaterOrEqual(t, now, params.Time)
+	assert.GreaterOrEqual(t, params.Time, now-60)
 }
 
 func TestLoadParams_Filter_Exclude(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("exclude", []string{".*", "wakatime.*"})
 	v.Set("settings.exclude", []string{".+", "wakatime.+"})
 	v.Set("settings.ignore", []string{".?", "wakatime.?"})
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+	params, err := paramscmd.LoadHeartbeatParams(v)
 	require.NoError(t, err)
 
-	require.Len(t, params.Heartbeat.Filter.Exclude, 6)
-	assert.Equal(t, ".*", params.Heartbeat.Filter.Exclude[0].String())
-	assert.Equal(t, "wakatime.*", params.Heartbeat.Filter.Exclude[1].String())
-	assert.Equal(t, ".+", params.Heartbeat.Filter.Exclude[2].String())
-	assert.Equal(t, "wakatime.+", params.Heartbeat.Filter.Exclude[3].String())
-	assert.Equal(t, ".?", params.Heartbeat.Filter.Exclude[4].String())
-	assert.Equal(t, "wakatime.?", params.Heartbeat.Filter.Exclude[5].String())
+	require.Len(t, params.Filter.Exclude, 6)
+	assert.Equal(t, ".*", params.Filter.Exclude[0].String())
+	assert.Equal(t, "wakatime.*", params.Filter.Exclude[1].String())
+	assert.Equal(t, ".+", params.Filter.Exclude[2].String())
+	assert.Equal(t, "wakatime.+", params.Filter.Exclude[3].String())
+	assert.Equal(t, ".?", params.Filter.Exclude[4].String())
+	assert.Equal(t, "wakatime.?", params.Filter.Exclude[5].String())
 }
 
 func TestLoadParams_Filter_Exclude_Multiline(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("settings.ignore", "\t.?\n\twakatime.? \t\n")
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+	params, err := paramscmd.LoadHeartbeatParams(v)
 	require.NoError(t, err)
 
-	require.Len(t, params.Heartbeat.Filter.Exclude, 2)
-	assert.Equal(t, ".?", params.Heartbeat.Filter.Exclude[0].String())
-	assert.Equal(t, "wakatime.?", params.Heartbeat.Filter.Exclude[1].String())
+	require.Len(t, params.Filter.Exclude, 2)
+	assert.Equal(t, ".?", params.Filter.Exclude[0].String())
+	assert.Equal(t, "wakatime.?", params.Filter.Exclude[1].String())
 }
 
 func TestLoadParams_Filter_Exclude_IgnoresInvalidRegex(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("exclude", []string{".*", "["})
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+	params, err := paramscmd.LoadHeartbeatParams(v)
 	require.NoError(t, err)
 
-	require.Len(t, params.Heartbeat.Filter.Exclude, 1)
-	assert.Equal(t, ".*", params.Heartbeat.Filter.Exclude[0].String())
+	require.Len(t, params.Filter.Exclude, 1)
+	assert.Equal(t, ".*", params.Filter.Exclude[0].String())
 }
 
 func TestLoadParams_Filter_Exclude_PerlRegexPatterns(t *testing.T) {
@@ -694,77 +578,67 @@ func TestLoadParams_Filter_Exclude_PerlRegexPatterns(t *testing.T) {
 	for name, pattern := range tests {
 		t.Run(name, func(t *testing.T) {
 			v := viper.New()
-			v.SetDefault("sync-offline-activity", 1000)
-			v.Set("key", "00000000-0000-4000-8000-000000000000")
 			v.Set("entity", "/path/to/file")
 			v.Set("exclude", []string{pattern})
 
-			params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+			params, err := paramscmd.LoadHeartbeatParams(v)
 			require.NoError(t, err)
 
-			require.Len(t, params.Heartbeat.Filter.Exclude, 1)
-			assert.Equal(t, pattern, params.Heartbeat.Filter.Exclude[0].String())
+			require.Len(t, params.Filter.Exclude, 1)
+			assert.Equal(t, pattern, params.Filter.Exclude[0].String())
 		})
 	}
 }
 
 func TestLoadParams_Filter_ExcludeUnknownProject(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("exclude-unknown-project", true)
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+	params, err := paramscmd.LoadHeartbeatParams(v)
 	require.NoError(t, err)
 
-	assert.Equal(t, true, params.Heartbeat.Filter.ExcludeUnknownProject)
+	assert.True(t, params.Filter.ExcludeUnknownProject)
 }
 
 func TestLoadParams_Filter_ExcludeUnknownProject_FromConfig(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("exclude-unknown-project", false)
 	v.Set("settings.exclude_unknown_project", true)
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+	params, err := paramscmd.LoadHeartbeatParams(v)
 	require.NoError(t, err)
 
-	assert.Equal(t, true, params.Heartbeat.Filter.ExcludeUnknownProject)
+	assert.True(t, params.Filter.ExcludeUnknownProject)
 }
 
 func TestLoadParams_Filter_Include(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("include", []string{".*", "wakatime.*"})
 	v.Set("settings.include", []string{".+", "wakatime.+"})
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+	params, err := paramscmd.LoadHeartbeatParams(v)
 	require.NoError(t, err)
 
-	require.Len(t, params.Heartbeat.Filter.Include, 4)
-	assert.Equal(t, ".*", params.Heartbeat.Filter.Include[0].String())
-	assert.Equal(t, "wakatime.*", params.Heartbeat.Filter.Include[1].String())
-	assert.Equal(t, ".+", params.Heartbeat.Filter.Include[2].String())
-	assert.Equal(t, "wakatime.+", params.Heartbeat.Filter.Include[3].String())
+	require.Len(t, params.Filter.Include, 4)
+	assert.Equal(t, ".*", params.Filter.Include[0].String())
+	assert.Equal(t, "wakatime.*", params.Filter.Include[1].String())
+	assert.Equal(t, ".+", params.Filter.Include[2].String())
+	assert.Equal(t, "wakatime.+", params.Filter.Include[3].String())
 }
 
 func TestLoadParams_Filter_Include_IgnoresInvalidRegex(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("include", []string{".*", "["})
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+	params, err := paramscmd.LoadHeartbeatParams(v)
 	require.NoError(t, err)
 
-	require.Len(t, params.Heartbeat.Filter.Include, 1)
-	assert.Equal(t, ".*", params.Heartbeat.Filter.Include[0].String())
+	require.Len(t, params.Filter.Include, 1)
+	assert.Equal(t, ".*", params.Filter.Include[0].String())
 }
 
 func TestLoadParams_Filter_Include_PerlRegexPatterns(t *testing.T) {
@@ -776,45 +650,39 @@ func TestLoadParams_Filter_Include_PerlRegexPatterns(t *testing.T) {
 	for name, pattern := range tests {
 		t.Run(name, func(t *testing.T) {
 			v := viper.New()
-			v.SetDefault("sync-offline-activity", 1000)
-			v.Set("key", "00000000-0000-4000-8000-000000000000")
 			v.Set("entity", "/path/to/file")
 			v.Set("include", []string{pattern})
 
-			params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+			params, err := paramscmd.LoadHeartbeatParams(v)
 			require.NoError(t, err)
 
-			require.Len(t, params.Heartbeat.Filter.Include, 1)
-			assert.Equal(t, pattern, params.Heartbeat.Filter.Include[0].String())
+			require.Len(t, params.Filter.Include, 1)
+			assert.Equal(t, pattern, params.Filter.Include[0].String())
 		})
 	}
 }
 
 func TestLoadParams_Filter_IncludeOnlyWithProjectFile(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("include-only-with-project-file", true)
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+	params, err := paramscmd.LoadHeartbeatParams(v)
 	require.NoError(t, err)
 
-	assert.Equal(t, true, params.Heartbeat.Filter.IncludeOnlyWithProjectFile)
+	assert.True(t, params.Filter.IncludeOnlyWithProjectFile)
 }
 
 func TestLoadParams_Filter_IncludeOnlyWithProjectFile_FromConfig(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("include-only-with-project-file", false)
 	v.Set("settings.include_only_with_project_file", true)
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+	params, err := paramscmd.LoadHeartbeatParams(v)
 	require.NoError(t, err)
 
-	assert.Equal(t, true, params.Heartbeat.Filter.IncludeOnlyWithProjectFile)
+	assert.True(t, params.Filter.IncludeOnlyWithProjectFile)
 }
 
 func TestLoadParams_SanitizeParams_HideBranchNames_True(t *testing.T) {
@@ -827,17 +695,15 @@ func TestLoadParams_SanitizeParams_HideBranchNames_True(t *testing.T) {
 	for name, viperValue := range tests {
 		t.Run(name, func(t *testing.T) {
 			v := viper.New()
-			v.SetDefault("sync-offline-activity", 1000)
-			v.Set("key", "00000000-0000-4000-8000-000000000000")
 			v.Set("entity", "/path/to/file")
 			v.Set("hide-branch-names", viperValue)
 
-			params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+			params, err := paramscmd.LoadHeartbeatParams(v)
 			require.NoError(t, err)
 
 			assert.Equal(t, paramscmd.SanitizeParams{
 				HideBranchNames: []regex.Regex{regex.MustCompile(".*")},
-			}, params.Heartbeat.Sanitize)
+			}, params.Sanitize)
 		})
 	}
 }
@@ -852,15 +718,13 @@ func TestLoadParams_SanitizeParams_HideBranchNames_False(t *testing.T) {
 	for name, viperValue := range tests {
 		t.Run(name, func(t *testing.T) {
 			v := viper.New()
-			v.SetDefault("sync-offline-activity", 1000)
-			v.Set("key", "00000000-0000-4000-8000-000000000000")
 			v.Set("entity", "/path/to/file")
 			v.Set("hide-branch-names", viperValue)
 
-			params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+			params, err := paramscmd.LoadHeartbeatParams(v)
 			require.NoError(t, err)
 
-			assert.Equal(t, paramscmd.SanitizeParams{}, params.Heartbeat.Sanitize)
+			assert.Equal(t, paramscmd.SanitizeParams{}, params.Sanitize)
 		})
 	}
 }
@@ -888,100 +752,88 @@ func TestLoadParams_SanitizeParams_HideBranchNames_List(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			v := viper.New()
-			v.SetDefault("sync-offline-activity", 1000)
-			v.Set("key", "00000000-0000-4000-8000-000000000000")
 			v.Set("entity", "/path/to/file")
 			v.Set("hide-branch-names", test.ViperValue)
 
-			params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+			params, err := paramscmd.LoadHeartbeatParams(v)
 			require.NoError(t, err)
 
 			assert.Equal(t, paramscmd.SanitizeParams{
 				HideBranchNames: test.Expected,
-			}, params.Heartbeat.Sanitize)
+			}, params.Sanitize)
 		})
 	}
 }
 
 func TestLoadParams_SanitizeParams_HideBranchNames_FlagTakesPrecedence(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("hide-branch-names", "true")
 	v.Set("settings.hide_branch_names", "ignored")
 	v.Set("settings.hide_branchnames", "ignored")
 	v.Set("settings.hidebranchnames", "ignored")
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+	params, err := paramscmd.LoadHeartbeatParams(v)
 	require.NoError(t, err)
 
 	assert.Equal(t, paramscmd.SanitizeParams{
 		HideBranchNames: []regex.Regex{regexp.MustCompile(".*")},
-	}, params.Heartbeat.Sanitize)
+	}, params.Sanitize)
 }
 
 func TestLoadParams_SanitizeParams_HideBranchNames_ConfigTakesPrecedence(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("settings.hide_branch_names", "true")
 	v.Set("settings.hide_branchnames", "ignored")
 	v.Set("settings.hidebranchnames", "ignored")
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+	params, err := paramscmd.LoadHeartbeatParams(v)
 	require.NoError(t, err)
 
 	assert.Equal(t, paramscmd.SanitizeParams{
 		HideBranchNames: []regex.Regex{regexp.MustCompile(".*")},
-	}, params.Heartbeat.Sanitize)
+	}, params.Sanitize)
 }
 
 func TestLoadParams_SanitizeParams_HideBranchNames_ConfigDeprecatedOneTakesPrecedence(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("settings.hide_branchnames", "true")
 	v.Set("settings.hidebranchnames", "ignored")
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+	params, err := paramscmd.LoadHeartbeatParams(v)
 	require.NoError(t, err)
 
 	assert.Equal(t, paramscmd.SanitizeParams{
 		HideBranchNames: []regex.Regex{regexp.MustCompile(".*")},
-	}, params.Heartbeat.Sanitize)
+	}, params.Sanitize)
 }
 
 func TestLoadParams_SanitizeParams_HideBranchNames_ConfigDeprecatedTwo(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("settings.hidebranchnames", "true")
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+	params, err := paramscmd.LoadHeartbeatParams(v)
 	require.NoError(t, err)
 
 	assert.Equal(t, paramscmd.SanitizeParams{
 		HideBranchNames: []regex.Regex{regexp.MustCompile(".*")},
-	}, params.Heartbeat.Sanitize)
+	}, params.Sanitize)
 }
 
 func TestLoadParams_SanitizeParams_HideBranchNames_InvalidRegex(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("hide-branch-names", ".*secret.*\n[0-9+")
 
-	_, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+	_, err := paramscmd.LoadHeartbeatParams(v)
 	require.Error(t, err)
 
 	assert.True(t, strings.HasPrefix(
 		err.Error(),
-		"failed to load heartbeat params: failed to load sanitize params:"+
+		"failed to load sanitize params:"+
 			" failed to parse regex hide branch names param \".*secret.*\\n[0-9+\":"+
 			" failed to compile regex \"[0-9+\":",
 	))
@@ -997,17 +849,15 @@ func TestLoadParams_SanitizeParams_HideProjectNames_True(t *testing.T) {
 	for name, viperValue := range tests {
 		t.Run(name, func(t *testing.T) {
 			v := viper.New()
-			v.SetDefault("sync-offline-activity", 1000)
-			v.Set("key", "00000000-0000-4000-8000-000000000000")
 			v.Set("entity", "/path/to/file")
 			v.Set("hide-project-names", viperValue)
 
-			params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+			params, err := paramscmd.LoadHeartbeatParams(v)
 			require.NoError(t, err)
 
 			assert.Equal(t, paramscmd.SanitizeParams{
 				HideProjectNames: []regex.Regex{regexp.MustCompile(".*")},
-			}, params.Heartbeat.Sanitize)
+			}, params.Sanitize)
 		})
 	}
 }
@@ -1022,15 +872,13 @@ func TestLoadParams_SanitizeParams_HideProjectNames_False(t *testing.T) {
 	for name, viperValue := range tests {
 		t.Run(name, func(t *testing.T) {
 			v := viper.New()
-			v.SetDefault("sync-offline-activity", 1000)
-			v.Set("key", "00000000-0000-4000-8000-000000000000")
 			v.Set("entity", "/path/to/file")
 			v.Set("hide-project-names", viperValue)
 
-			params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+			params, err := paramscmd.LoadHeartbeatParams(v)
 			require.NoError(t, err)
 
-			assert.Equal(t, paramscmd.SanitizeParams{}, params.Heartbeat.Sanitize)
+			assert.Equal(t, paramscmd.SanitizeParams{}, params.Sanitize)
 		})
 	}
 }
@@ -1058,100 +906,88 @@ func TestLoadParams_SanitizeParams_HideProjecthNames_List(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			v := viper.New()
-			v.SetDefault("sync-offline-activity", 1000)
-			v.Set("key", "00000000-0000-4000-8000-000000000000")
 			v.Set("entity", "/path/to/file")
 			v.Set("hide-project-names", test.ViperValue)
 
-			params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+			params, err := paramscmd.LoadHeartbeatParams(v)
 			require.NoError(t, err)
 
 			assert.Equal(t, paramscmd.SanitizeParams{
 				HideProjectNames: test.Expected,
-			}, params.Heartbeat.Sanitize)
+			}, params.Sanitize)
 		})
 	}
 }
 
 func TestLoadParams_SanitizeParams_HideProjectNames_FlagTakesPrecedence(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("hide-project-names", "true")
 	v.Set("settings.hide_project_names", "ignored")
 	v.Set("settings.hide_projectnames", "ignored")
 	v.Set("settings.hideprojectnames", "ignored")
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+	params, err := paramscmd.LoadHeartbeatParams(v)
 	require.NoError(t, err)
 
 	assert.Equal(t, paramscmd.SanitizeParams{
 		HideProjectNames: []regex.Regex{regexp.MustCompile(".*")},
-	}, params.Heartbeat.Sanitize)
+	}, params.Sanitize)
 }
 
 func TestLoadParams_SanitizeParams_HideProjectNames_ConfigTakesPrecedence(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("settings.hide_project_names", "true")
 	v.Set("settings.hide_projectnames", "ignored")
 	v.Set("settings.hideprojectnames", "ignored")
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+	params, err := paramscmd.LoadHeartbeatParams(v)
 	require.NoError(t, err)
 
 	assert.Equal(t, paramscmd.SanitizeParams{
 		HideProjectNames: []regex.Regex{regexp.MustCompile(".*")},
-	}, params.Heartbeat.Sanitize)
+	}, params.Sanitize)
 }
 
 func TestLoadParams_SanitizeParams_HideProjectNames_ConfigDeprecatedOneTakesPrecedence(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("settings.hide_projectnames", "true")
 	v.Set("settings.hideprojectnames", "ignored")
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+	params, err := paramscmd.LoadHeartbeatParams(v)
 	require.NoError(t, err)
 
 	assert.Equal(t, paramscmd.SanitizeParams{
 		HideProjectNames: []regex.Regex{regexp.MustCompile(".*")},
-	}, params.Heartbeat.Sanitize)
+	}, params.Sanitize)
 }
 
 func TestLoadParams_SanitizeParams_HideProjectNames_ConfigDeprecatedTwo(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("settings.hideprojectnames", "true")
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+	params, err := paramscmd.LoadHeartbeatParams(v)
 	require.NoError(t, err)
 
 	assert.Equal(t, paramscmd.SanitizeParams{
 		HideProjectNames: []regex.Regex{regexp.MustCompile(".*")},
-	}, params.Heartbeat.Sanitize)
+	}, params.Sanitize)
 }
 
 func TestLoadParams_SanitizeParams_HideProjectNames_InvalidRegex(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("hide-project-names", ".*secret.*\n[0-9+")
 
-	_, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+	_, err := paramscmd.LoadHeartbeatParams(v)
 	require.Error(t, err)
 
 	assert.True(t, strings.HasPrefix(
 		err.Error(),
-		"failed to load heartbeat params: failed to load sanitize params:"+
+		"failed to load sanitize params:"+
 			" failed to parse regex hide project names param \".*secret.*\\n[0-9+\":"+
 			" failed to compile regex \"[0-9+\":",
 	))
@@ -1167,17 +1003,15 @@ func TestLoadParams_SanitizeParams_HideFileNames_True(t *testing.T) {
 	for name, viperValue := range tests {
 		t.Run(name, func(t *testing.T) {
 			v := viper.New()
-			v.SetDefault("sync-offline-activity", 1000)
-			v.Set("key", "00000000-0000-4000-8000-000000000000")
 			v.Set("entity", "/path/to/file")
 			v.Set("hide-file-names", viperValue)
 
-			params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+			params, err := paramscmd.LoadHeartbeatParams(v)
 			require.NoError(t, err)
 
 			assert.Equal(t, paramscmd.SanitizeParams{
 				HideFileNames: []regex.Regex{regexp.MustCompile(".*")},
-			}, params.Heartbeat.Sanitize)
+			}, params.Sanitize)
 		})
 	}
 }
@@ -1192,15 +1026,13 @@ func TestLoadParams_SanitizeParams_HideFileNames_False(t *testing.T) {
 	for name, viperValue := range tests {
 		t.Run(name, func(t *testing.T) {
 			v := viper.New()
-			v.SetDefault("sync-offline-activity", 1000)
-			v.Set("key", "00000000-0000-4000-8000-000000000000")
 			v.Set("entity", "/path/to/file")
 			v.Set("hide-file-names", viperValue)
 
-			params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+			params, err := paramscmd.LoadHeartbeatParams(v)
 			require.NoError(t, err)
 
-			assert.Equal(t, paramscmd.SanitizeParams{}, params.Heartbeat.Sanitize)
+			assert.Equal(t, paramscmd.SanitizeParams{}, params.Sanitize)
 		})
 	}
 }
@@ -1228,25 +1060,21 @@ func TestLoadParams_SanitizeParams_HideFileNames_List(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			v := viper.New()
-			v.SetDefault("sync-offline-activity", 1000)
-			v.Set("key", "00000000-0000-4000-8000-000000000000")
 			v.Set("entity", "/path/to/file")
 			v.Set("hide-file-names", test.ViperValue)
 
-			params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+			params, err := paramscmd.LoadHeartbeatParams(v)
 			require.NoError(t, err)
 
 			assert.Equal(t, paramscmd.SanitizeParams{
 				HideFileNames: test.Expected,
-			}, params.Heartbeat.Sanitize)
+			}, params.Sanitize)
 		})
 	}
 }
 
 func TestLoadParams_SanitizeParams_HideFileNames_FlagTakesPrecedence(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("hide-file-names", "true")
 	v.Set("hide-filenames", "ignored")
@@ -1255,18 +1083,16 @@ func TestLoadParams_SanitizeParams_HideFileNames_FlagTakesPrecedence(t *testing.
 	v.Set("settings.hide_filenames", "ignored")
 	v.Set("settings.hidefilenames", "ignored")
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+	params, err := paramscmd.LoadHeartbeatParams(v)
 	require.NoError(t, err)
 
 	assert.Equal(t, paramscmd.SanitizeParams{
 		HideFileNames: []regex.Regex{regexp.MustCompile(".*")},
-	}, params.Heartbeat.Sanitize)
+	}, params.Sanitize)
 }
 
 func TestLoadParams_SanitizeParams_HideFileNames_FlagDeprecatedOneTakesPrecedence(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("hide-filenames", "true")
 	v.Set("hidefilenames", "ignored")
@@ -1274,93 +1100,83 @@ func TestLoadParams_SanitizeParams_HideFileNames_FlagDeprecatedOneTakesPrecedenc
 	v.Set("settings.hide_filenames", "ignored")
 	v.Set("settings.hidefilenames", "ignored")
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+	params, err := paramscmd.LoadHeartbeatParams(v)
 	require.NoError(t, err)
 
 	assert.Equal(t, paramscmd.SanitizeParams{
 		HideFileNames: []regex.Regex{regexp.MustCompile(".*")},
-	}, params.Heartbeat.Sanitize)
+	}, params.Sanitize)
 }
 
 func TestLoadParams_SanitizeParams_HideFileNames_FlagDeprecatedTwoTakesPrecedence(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("hidefilenames", "true")
 	v.Set("settings.hide_file_names", "ignored")
 	v.Set("settings.hide_filenames", "ignored")
 	v.Set("settings.hidefilenames", "ignored")
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+	params, err := paramscmd.LoadHeartbeatParams(v)
 	require.NoError(t, err)
 
 	assert.Equal(t, paramscmd.SanitizeParams{
 		HideFileNames: []regex.Regex{regexp.MustCompile(".*")},
-	}, params.Heartbeat.Sanitize)
+	}, params.Sanitize)
 }
 
 func TestLoadParams_SanitizeParams_HideFileNames_ConfigTakesPrecedence(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("settings.hide_file_names", "true")
 	v.Set("settings.hide_filenames", "ignored")
 	v.Set("settings.hidefilenames", "ignored")
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+	params, err := paramscmd.LoadHeartbeatParams(v)
 	require.NoError(t, err)
 
 	assert.Equal(t, paramscmd.SanitizeParams{
 		HideFileNames: []regex.Regex{regexp.MustCompile(".*")},
-	}, params.Heartbeat.Sanitize)
+	}, params.Sanitize)
 }
 
 func TestLoadParams_SanitizeParams_HideFileNames_ConfigDeprecatedOneTakesPrecedence(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("settings.hide_filenames", "true")
 	v.Set("settings.hidefilenames", "ignored")
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+	params, err := paramscmd.LoadHeartbeatParams(v)
 	require.NoError(t, err)
 
 	assert.Equal(t, paramscmd.SanitizeParams{
 		HideFileNames: []regex.Regex{regexp.MustCompile(".*")},
-	}, params.Heartbeat.Sanitize)
+	}, params.Sanitize)
 }
 
 func TestLoadParams_SanitizeParams_HideFileNames_ConfigDeprecatedTwo(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("settings.hidefilenames", "true")
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+	params, err := paramscmd.LoadHeartbeatParams(v)
 	require.NoError(t, err)
 
 	assert.Equal(t, paramscmd.SanitizeParams{
 		HideFileNames: []regex.Regex{regexp.MustCompile(".*")},
-	}, params.Heartbeat.Sanitize)
+	}, params.Sanitize)
 }
 
 func TestLoadParams_SanitizeParams_HideFileNames_InvalidRegex(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("hide-file-names", ".*secret.*\n[0-9+")
 
-	_, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+	_, err := paramscmd.LoadHeartbeatParams(v)
 	require.Error(t, err)
 
 	assert.True(t, strings.HasPrefix(
 		err.Error(),
-		"failed to load heartbeat params: failed to load sanitize params:"+
+		"failed to load sanitize params:"+
 			" failed to parse regex hide file names param \".*secret.*\\n[0-9+\":"+
 			" failed to compile regex \"[0-9+\":",
 	))
@@ -1368,47 +1184,41 @@ func TestLoadParams_SanitizeParams_HideFileNames_InvalidRegex(t *testing.T) {
 
 func TestLoadParams_SanitizeParams_HideProjectFolder(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("hide-project-folder", true)
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+	params, err := paramscmd.LoadHeartbeatParams(v)
 	require.NoError(t, err)
 
 	assert.Equal(t, paramscmd.SanitizeParams{
 		HideProjectFolder: true,
-	}, params.Heartbeat.Sanitize)
+	}, params.Sanitize)
 }
 
 func TestLoadParams_SanitizeParams_HideProjectFolder_ConfigTakesPrecedence(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("settings.hide_project_folder", true)
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+	params, err := paramscmd.LoadHeartbeatParams(v)
 	require.NoError(t, err)
 
 	assert.Equal(t, paramscmd.SanitizeParams{
 		HideProjectFolder: true,
-	}, params.Heartbeat.Sanitize)
+	}, params.Sanitize)
 }
 
 func TestLoadParams_SanitizeParams_OverrideProjectPath(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("entity", "/path/to/file")
 	v.Set("project-folder", "/custom-path")
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+	params, err := paramscmd.LoadHeartbeatParams(v)
 	require.NoError(t, err)
 
 	assert.Equal(t, paramscmd.SanitizeParams{
 		ProjectPathOverride: "/custom-path",
-	}, params.Heartbeat.Sanitize)
+	}, params.Sanitize)
 }
 
 func TestLoadParams_DisableSubmodule_True(t *testing.T) {
@@ -1421,15 +1231,13 @@ func TestLoadParams_DisableSubmodule_True(t *testing.T) {
 	for name, viperValue := range tests {
 		t.Run(name, func(t *testing.T) {
 			v := viper.New()
-			v.SetDefault("sync-offline-activity", 1000)
-			v.Set("key", "00000000-0000-4000-8000-000000000000")
 			v.Set("entity", "/path/to/file")
 			v.Set("git.submodules_disabled", viperValue)
 
-			params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+			params, err := paramscmd.LoadHeartbeatParams(v)
 			require.NoError(t, err)
 
-			assert.Equal(t, []regex.Regex{regexp.MustCompile(".*")}, params.Heartbeat.Project.DisableSubmodule)
+			assert.Equal(t, []regex.Regex{regexp.MustCompile(".*")}, params.Project.DisableSubmodule)
 		})
 	}
 }
@@ -1444,15 +1252,13 @@ func TestLoadParams_DisableSubmodule_False(t *testing.T) {
 	for name, viperValue := range tests {
 		t.Run(name, func(t *testing.T) {
 			v := viper.New()
-			v.SetDefault("sync-offline-activity", 1000)
-			v.Set("key", "00000000-0000-4000-8000-000000000000")
 			v.Set("entity", "/path/to/file")
 			v.Set("git.submodules_disabled", viperValue)
 
-			params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+			params, err := paramscmd.LoadHeartbeatParams(v)
 			require.NoError(t, err)
 
-			assert.Equal(t, []regex.Regex(nil), params.Heartbeat.Project.DisableSubmodule)
+			assert.Empty(t, params.Project.DisableSubmodule)
 		})
 	}
 }
@@ -1481,148 +1287,156 @@ func TestLoadParams_DisableSubmodule_List(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			multilineOption := viper.IniLoadOptions(ini.LoadOptions{AllowPythonMultilineValues: true})
 			v := viper.NewWithOptions(multilineOption)
-			v.SetDefault("sync-offline-activity", 1000)
-			v.Set("key", "00000000-0000-4000-8000-000000000000")
 			v.Set("entity", "/path/to/file")
 			v.Set("git.submodules_disabled", test.ViperValue)
 
-			params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true, HeartbeatRequired: true})
+			params, err := paramscmd.LoadHeartbeatParams(v)
 			require.NoError(t, err)
 
-			assert.Equal(t, test.Expected, params.Heartbeat.Project.DisableSubmodule)
+			assert.Equal(t, test.Expected, params.Project.DisableSubmodule)
 		})
 	}
 }
 
+func TestLoadParams_Plugin(t *testing.T) {
+	v := viper.New()
+	v.Set("key", "00000000-0000-4000-8000-000000000000")
+	v.Set("plugin", "plugin/10.0.0")
+
+	params, err := paramscmd.LoadAPIParams(v)
+	require.NoError(t, err)
+
+	assert.Equal(t, "plugin/10.0.0", params.Plugin)
+}
+
+func TestLoadParams_Plugin_Unset(t *testing.T) {
+	v := viper.New()
+	v.Set("key", "00000000-0000-4000-8000-000000000000")
+
+	params, err := paramscmd.LoadAPIParams(v)
+	require.NoError(t, err)
+
+	assert.Empty(t, params.Plugin)
+}
+
+func TestLoadParams_Timeout_FlagTakesPreceedence(t *testing.T) {
+	v := viper.New()
+	v.Set("key", "00000000-0000-4000-8000-000000000000")
+	v.Set("timeout", 5)
+	v.Set("settings.timeout", 10)
+
+	params, err := paramscmd.LoadAPIParams(v)
+	require.NoError(t, err)
+
+	assert.Equal(t, 5*time.Second, params.Timeout)
+}
+
+func TestLoadParams_Timeout_FromConfig(t *testing.T) {
+	v := viper.New()
+	v.Set("key", "00000000-0000-4000-8000-000000000000")
+	v.Set("settings.timeout", 10)
+
+	params, err := paramscmd.LoadAPIParams(v)
+	require.NoError(t, err)
+
+	assert.Equal(t, 10*time.Second, params.Timeout)
+}
+
 func TestLoad_OfflineDisabled_ConfigTakesPrecedence(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
-	v.Set("entity", "/path/to/file")
 	v.Set("disable-offline", false)
 	v.Set("disableoffline", false)
 	v.Set("settings.offline", false)
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true})
+	params, err := paramscmd.LoadOfflineParams(v)
 	require.NoError(t, err)
 
-	assert.True(t, params.Offline.Disabled)
+	assert.True(t, params.Disabled)
 }
 
 func TestLoad_OfflineDisabled_FlagDeprecatedTakesPrecedence(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
-	v.Set("entity", "/path/to/file")
 	v.Set("disable-offline", false)
 	v.Set("disableoffline", true)
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true})
+	params, err := paramscmd.LoadOfflineParams(v)
 	require.NoError(t, err)
 
-	assert.True(t, params.Offline.Disabled)
+	assert.True(t, params.Disabled)
 }
 
 func TestLoad_OfflineDisabled_FromFlag(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
-	v.Set("entity", "/path/to/file")
 	v.Set("disable-offline", true)
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true})
+	params, err := paramscmd.LoadOfflineParams(v)
 	require.NoError(t, err)
 
-	assert.True(t, params.Offline.Disabled)
+	assert.True(t, params.Disabled)
 }
 
 func TestLoad_OfflineQueueFile(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
-	v.Set("entity", "/path/to/file")
 	v.Set("offline-queue-file", "/path/to/file")
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true})
+	params, err := paramscmd.LoadOfflineParams(v)
 	require.NoError(t, err)
 
-	assert.Equal(t, "/path/to/file", params.Offline.QueueFile)
+	assert.Equal(t, "/path/to/file", params.QueueFile)
 }
 
 func TestLoad_OfflineSyncMax(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
-	v.Set("entity", "/path/to/file")
 	v.Set("sync-offline-activity", 42)
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true})
+	params, err := paramscmd.LoadOfflineParams(v)
 	require.NoError(t, err)
 
-	assert.Equal(t, 42, params.Offline.SyncMax)
-}
-
-func TestLoad_OfflineSyncMax_NoEntity(t *testing.T) {
-	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
-	v.Set("sync-offline-activity", 42)
-
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true})
-	require.NoError(t, err)
-
-	assert.Equal(t, 42, params.Offline.SyncMax)
+	assert.Equal(t, 42, params.SyncMax)
 }
 
 func TestLoad_OfflineSyncMax_None(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
-	v.Set("entity", "/path/to/file")
 	v.Set("sync-offline-activity", "none")
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true})
+	params, err := paramscmd.LoadOfflineParams(v)
 	require.NoError(t, err)
 
-	assert.Equal(t, 0, params.Offline.SyncMax)
+	assert.Zero(t, params.SyncMax)
 }
 
 func TestLoad_OfflineSyncMax_Default(t *testing.T) {
 	v := viper.New()
 	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
-	v.Set("entity", "/path/to/file")
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true})
+	params, err := paramscmd.LoadOfflineParams(v)
 	require.NoError(t, err)
 
-	assert.Equal(t, 1000, params.Offline.SyncMax)
+	assert.Equal(t, 1000, params.SyncMax)
 }
 
 func TestLoad_OfflineSyncMax_NegativeNumber(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
-	v.Set("entity", "/path/to/file")
 	v.Set("sync-offline-activity", -1)
 
-	_, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true})
+	_, err := paramscmd.LoadOfflineParams(v)
 	require.Error(t, err)
 
-	assert.Contains(t, err.Error(), "--sync-offline-activity")
+	assert.Equal(t, err.Error(), "argument --sync-offline-activity must be \"none\" or a positive integer number")
 }
 
 func TestLoad_OfflineSyncMax_NonIntegerValue(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
-	v.Set("entity", "/path/to/file")
 	v.Set("sync-offline-activity", "invalid")
 
-	_, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true})
+	_, err := paramscmd.LoadOfflineParams(v)
 	require.Error(t, err)
 
-	assert.Contains(t, err.Error(), "--sync-offline-activity")
+	assert.Equal(
+		t,
+		err.Error(),
+		"argument --sync-offline-activity must be \"none\" or a positive integer number:"+
+			" strconv.Atoi: parsing \"invalid\": invalid syntax")
 }
 
 func TestLoad_API_APIKey(t *testing.T) {
@@ -1630,42 +1444,33 @@ func TestLoad_API_APIKey(t *testing.T) {
 		ViperAPIKey          string
 		ViperAPIKeyConfig    string
 		ViperAPIKeyConfigOld string
-		Expected             paramscmd.Params
+		Expected             paramscmd.API
 	}{
 		"api key flag takes preceedence": {
 			ViperAPIKey:          "00000000-0000-4000-8000-000000000000",
 			ViperAPIKeyConfig:    "10000000-0000-4000-8000-000000000000",
 			ViperAPIKeyConfigOld: "20000000-0000-4000-8000-000000000000",
-			Expected: paramscmd.Params{
-				API: paramscmd.API{
-
-					Key:      "00000000-0000-4000-8000-000000000000",
-					URL:      "https://api.wakatime.com/api/v1",
-					Hostname: "my-computer",
-				},
+			Expected: paramscmd.API{
+				Key:      "00000000-0000-4000-8000-000000000000",
+				URL:      "https://api.wakatime.com/api/v1",
+				Hostname: "my-computer",
 			},
 		},
 		"api from config takes preceedence": {
 			ViperAPIKeyConfig:    "00000000-0000-4000-8000-000000000000",
 			ViperAPIKeyConfigOld: "10000000-0000-4000-8000-000000000000",
-			Expected: paramscmd.Params{
-				API: paramscmd.API{
-
-					Key:      "00000000-0000-4000-8000-000000000000",
-					URL:      "https://api.wakatime.com/api/v1",
-					Hostname: "my-computer",
-				},
+			Expected: paramscmd.API{
+				Key:      "00000000-0000-4000-8000-000000000000",
+				URL:      "https://api.wakatime.com/api/v1",
+				Hostname: "my-computer",
 			},
 		},
 		"api key from config deprecated": {
 			ViperAPIKeyConfigOld: "00000000-0000-4000-8000-000000000000",
-			Expected: paramscmd.Params{
-				API: paramscmd.API{
-
-					Key:      "00000000-0000-4000-8000-000000000000",
-					URL:      "https://api.wakatime.com/api/v1",
-					Hostname: "my-computer",
-				},
+			Expected: paramscmd.API{
+				Key:      "00000000-0000-4000-8000-000000000000",
+				URL:      "https://api.wakatime.com/api/v1",
+				Hostname: "my-computer",
 			},
 		},
 	}
@@ -1673,13 +1478,12 @@ func TestLoad_API_APIKey(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			v := viper.New()
-			v.Set("sync-offline-activity", "none")
+			v.Set("hostname", "my-computer")
 			v.Set("key", test.ViperAPIKey)
 			v.Set("settings.api_key", test.ViperAPIKeyConfig)
 			v.Set("settings.apikey", test.ViperAPIKeyConfigOld)
-			v.Set("hostname", "my-computer")
 
-			params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true})
+			params, err := paramscmd.LoadAPIParams(v)
 			require.NoError(t, err)
 
 			assert.Equal(t, test.Expected, params)
@@ -1698,10 +1502,9 @@ func TestLoad_API_APIKeyInvalid(t *testing.T) {
 	for name, value := range tests {
 		t.Run(name, func(t *testing.T) {
 			v := viper.New()
-			v.SetDefault("sync-offline-activity", 1000)
 			v.Set("key", value)
 
-			_, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true})
+			_, err := paramscmd.LoadAPIParams(v)
 			require.Error(t, err)
 
 			var errauth api.ErrAuth
@@ -1715,75 +1518,57 @@ func TestLoad_API_APIUrl(t *testing.T) {
 		ViperAPIUrl       string
 		ViperAPIUrlConfig string
 		ViperAPIUrlOld    string
-		Expected          paramscmd.Params
+		Expected          paramscmd.API
 	}{
 		"api url flag takes preceedence": {
 			ViperAPIUrl:       "http://localhost:8080",
 			ViperAPIUrlConfig: "http://localhost:8081",
 			ViperAPIUrlOld:    "http://localhost:8082",
-			Expected: paramscmd.Params{
-				API: paramscmd.API{
-
-					Key:      "00000000-0000-4000-8000-000000000000",
-					URL:      "http://localhost:8080",
-					Hostname: "my-computer",
-				},
+			Expected: paramscmd.API{
+				Key:      "00000000-0000-4000-8000-000000000000",
+				URL:      "http://localhost:8080",
+				Hostname: "my-computer",
 			},
 		},
 		"api url deprecated flag takes preceedence": {
 			ViperAPIUrlConfig: "http://localhost:8081",
 			ViperAPIUrlOld:    "http://localhost:8082",
-			Expected: paramscmd.Params{
-				API: paramscmd.API{
-
-					Key:      "00000000-0000-4000-8000-000000000000",
-					URL:      "http://localhost:8082",
-					Hostname: "my-computer",
-				},
+			Expected: paramscmd.API{
+				Key:      "00000000-0000-4000-8000-000000000000",
+				URL:      "http://localhost:8082",
+				Hostname: "my-computer",
 			},
 		},
 		"api url from config": {
 			ViperAPIUrlConfig: "http://localhost:8081",
-			Expected: paramscmd.Params{
-				API: paramscmd.API{
-
-					Key:      "00000000-0000-4000-8000-000000000000",
-					URL:      "http://localhost:8081",
-					Hostname: "my-computer",
-				},
+			Expected: paramscmd.API{
+				Key:      "00000000-0000-4000-8000-000000000000",
+				URL:      "http://localhost:8081",
+				Hostname: "my-computer",
 			},
 		},
 		"api url with legacy heartbeats endpoint": {
 			ViperAPIUrl: "http://localhost:8080/api/v1/heartbeats.bulk",
-			Expected: paramscmd.Params{
-				API: paramscmd.API{
-
-					Key:      "00000000-0000-4000-8000-000000000000",
-					URL:      "http://localhost:8080/api/v1",
-					Hostname: "my-computer",
-				},
+			Expected: paramscmd.API{
+				Key:      "00000000-0000-4000-8000-000000000000",
+				URL:      "http://localhost:8080/api/v1",
+				Hostname: "my-computer",
 			},
 		},
 		"api url with trailing slash": {
 			ViperAPIUrl: "http://localhost:8080/api/",
-			Expected: paramscmd.Params{
-				API: paramscmd.API{
-
-					Key:      "00000000-0000-4000-8000-000000000000",
-					URL:      "http://localhost:8080/api",
-					Hostname: "my-computer",
-				},
+			Expected: paramscmd.API{
+				Key:      "00000000-0000-4000-8000-000000000000",
+				URL:      "http://localhost:8080/api",
+				Hostname: "my-computer",
 			},
 		},
 		"api url with wakapi style endpoint": {
 			ViperAPIUrl: "http://localhost:8080/api/heartbeat",
-			Expected: paramscmd.Params{
-				API: paramscmd.API{
-
-					Key:      "00000000-0000-4000-8000-000000000000",
-					URL:      "http://localhost:8080/api",
-					Hostname: "my-computer",
-				},
+			Expected: paramscmd.API{
+				Key:      "00000000-0000-4000-8000-000000000000",
+				URL:      "http://localhost:8080/api",
+				Hostname: "my-computer",
 			},
 		},
 	}
@@ -1791,14 +1576,13 @@ func TestLoad_API_APIUrl(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			v := viper.New()
-			v.Set("sync-offline-activity", "none")
+			v.Set("hostname", "my-computer")
 			v.Set("key", "00000000-0000-4000-8000-000000000000")
 			v.Set("api-url", test.ViperAPIUrl)
 			v.Set("apiurl", test.ViperAPIUrlOld)
 			v.Set("settings.api_url", test.ViperAPIUrlConfig)
-			v.Set("hostname", "my-computer")
 
-			params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true})
+			params, err := paramscmd.LoadAPIParams(v)
 			require.NoError(t, err)
 
 			assert.Equal(t, test.Expected, params)
@@ -1808,25 +1592,22 @@ func TestLoad_API_APIUrl(t *testing.T) {
 
 func TestLoad_APIUrl_Default(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
-	v.Set("entity", "/path/to/file")
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true})
+	params, err := paramscmd.LoadAPIParams(v)
 	require.NoError(t, err)
 
-	assert.Equal(t, api.BaseURL, params.API.URL)
+	assert.Equal(t, api.BaseURL, params.URL)
 }
 
 func TestLoad_API_BackoffAt(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("hostname", "my-computer")
+	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("internal.backoff_at", "2021-08-30T18:50:42-03:00")
 	v.Set("internal.backoff_retries", "3")
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true})
+	params, err := paramscmd.LoadAPIParams(v)
 	require.NoError(t, err)
 
 	backoffAt, err := time.Parse(inipkg.DateFormat, "2021-08-30T18:50:42-03:00")
@@ -1838,18 +1619,17 @@ func TestLoad_API_BackoffAt(t *testing.T) {
 		Key:            "00000000-0000-4000-8000-000000000000",
 		URL:            "https://api.wakatime.com/api/v1",
 		Hostname:       "my-computer",
-	}, params.API)
+	}, params)
 }
 
 func TestLoad_API_BackoffAtErr(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("hostname", "my-computer")
+	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("internal.backoff_at", "2021-08-30")
 	v.Set("internal.backoff_retries", "2")
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true})
+	params, err := paramscmd.LoadAPIParams(v)
 	require.NoError(t, err)
 
 	assert.Equal(t, paramscmd.API{
@@ -1858,17 +1638,16 @@ func TestLoad_API_BackoffAtErr(t *testing.T) {
 		Key:            "00000000-0000-4000-8000-000000000000",
 		URL:            "https://api.wakatime.com/api/v1",
 		Hostname:       "my-computer",
-	}, params.API)
+	}, params)
 }
 
 func TestLoad_API_Plugin(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
+	v.Set("hostname", "my-computer")
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("plugin", "plugin/10.0.0")
-	v.Set("hostname", "my-computer")
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true})
+	params, err := paramscmd.LoadAPIParams(v)
 	require.NoError(t, err)
 
 	assert.Equal(t, paramscmd.API{
@@ -1876,71 +1655,63 @@ func TestLoad_API_Plugin(t *testing.T) {
 		URL:      "https://api.wakatime.com/api/v1",
 		Plugin:   "plugin/10.0.0",
 		Hostname: "my-computer",
-	}, params.API)
+	}, params)
 }
 
 func TestLoad_API_Timeout_FlagTakesPreceedence(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("timeout", 5)
 	v.Set("settings.timeout", 10)
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true})
+	params, err := paramscmd.LoadAPIParams(v)
 	require.NoError(t, err)
 
-	assert.Equal(t, 5*time.Second, params.API.Timeout)
+	assert.Equal(t, 5*time.Second, params.Timeout)
 }
 
 func TestLoad_API_Timeout_FromConfig(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("settings.timeout", 10)
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true})
+	params, err := paramscmd.LoadAPIParams(v)
 	require.NoError(t, err)
 
-	assert.Equal(t, 10*time.Second, params.API.Timeout)
+	assert.Equal(t, 10*time.Second, params.Timeout)
 }
 
 func TestLoad_API_DisableSSLVerify_FlagTakesPrecedence(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
-	v.Set("entity", "/path/to/file")
 	v.Set("no-ssl-verify", true)
 	v.Set("settings.no_ssl_verify", false)
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true})
+	params, err := paramscmd.LoadAPIParams(v)
 	require.NoError(t, err)
 
-	assert.True(t, params.API.DisableSSLVerify)
+	assert.True(t, params.DisableSSLVerify)
 }
 
 func TestLoad_API_DisableSSLVerify_FromConfig(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
-	v.Set("entity", "/path/to/file")
 	v.Set("settings.no_ssl_verify", true)
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true})
+	params, err := paramscmd.LoadAPIParams(v)
 	require.NoError(t, err)
 
-	assert.True(t, params.API.DisableSSLVerify)
+	assert.True(t, params.DisableSSLVerify)
 }
 
 func TestLoad_API_DisableSSLVerify_Default(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
-	v.Set("entity", "/path/to/file")
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true})
+	params, err := paramscmd.LoadAPIParams(v)
 	require.NoError(t, err)
 
-	assert.False(t, params.API.DisableSSLVerify)
+	assert.False(t, params.DisableSSLVerify)
 }
 
 func TestLoad_API_ProxyURL(t *testing.T) {
@@ -1954,123 +1725,112 @@ func TestLoad_API_ProxyURL(t *testing.T) {
 	for name, proxyURL := range tests {
 		t.Run(name, func(t *testing.T) {
 			v := viper.New()
-			v.SetDefault("sync-offline-activity", 1000)
 			v.Set("key", "00000000-0000-4000-8000-000000000000")
-			v.Set("entity", "/path/to/file")
 			v.Set("proxy", proxyURL)
 
-			params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true})
+			params, err := paramscmd.LoadAPIParams(v)
 			require.NoError(t, err)
 
-			assert.Equal(t, proxyURL, params.API.ProxyURL)
+			assert.Equal(t, proxyURL, params.ProxyURL)
 		})
 	}
 }
 
 func TestLoad_API_ProxyURL_FlagTakesPrecedence(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
-	v.Set("entity", "/path/to/file")
 	v.Set("proxy", "https://john:secret@example.org:8888")
 	v.Set("settings.proxy", "ignored")
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true})
+	params, err := paramscmd.LoadAPIParams(v)
 	require.NoError(t, err)
 
-	assert.Equal(t, "https://john:secret@example.org:8888", params.API.ProxyURL)
+	assert.Equal(t, "https://john:secret@example.org:8888", params.ProxyURL)
 }
 
 func TestLoad_API_ProxyURL_FromConfig(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
-	v.Set("entity", "/path/to/file")
 	v.Set("settings.proxy", "https://john:secret@example.org:8888")
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true})
+	params, err := paramscmd.LoadAPIParams(v)
 	require.NoError(t, err)
 
-	assert.Equal(t, "https://john:secret@example.org:8888", params.API.ProxyURL)
+	assert.Equal(t, "https://john:secret@example.org:8888", params.ProxyURL)
 }
 
 func TestLoad_API_ProxyURL_InvalidFormat(t *testing.T) {
-	proxyURL := "ftp://john:secret@example.org:8888"
-
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
-	v.Set("entity", "/path/to/file")
-	v.Set("proxy", proxyURL)
+	v.Set("proxy", "ftp://john:secret@example.org:8888")
 
-	_, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true})
+	_, err := paramscmd.LoadAPIParams(v)
 	require.Error(t, err)
+
+	assert.Equal(
+		t,
+		err.Error(),
+		"invalid url \"ftp://john:secret@example.org:8888\". Must be in format'https://user:pass@host:port' or"+
+			" 'socks5://user:pass@host:port' or 'domain\\\\user:pass.'")
 }
 
 func TestLoad_API_SSLCertFilepath_FlagTakesPrecedence(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
-	v.Set("entity", "/path/to/file")
 	v.Set("ssl-certs-file", "~/path/to/cert.pem")
 
 	home, err := os.UserHomeDir()
 	require.NoError(t, err)
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true})
+	params, err := paramscmd.LoadAPIParams(v)
 	require.NoError(t, err)
 
-	assert.Equal(t, filepath.Join(home, "/path/to/cert.pem"), params.API.SSLCertFilepath)
+	assert.Equal(t, filepath.Join(home, "/path/to/cert.pem"), params.SSLCertFilepath)
 }
 
 func TestLoad_API_SSLCertFilepath_FromConfig(t *testing.T) {
 	v := viper.New()
-	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
-	v.Set("entity", "/path/to/file")
 	v.Set("settings.ssl_certs_file", "/path/to/cert.pem")
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true})
+	params, err := paramscmd.LoadAPIParams(v)
 	require.NoError(t, err)
 
-	assert.Equal(t, "/path/to/cert.pem", params.API.SSLCertFilepath)
+	assert.Equal(t, "/path/to/cert.pem", params.SSLCertFilepath)
 }
 
 func TestLoadParams_Hostname_FlagTakesPrecedence(t *testing.T) {
 	v := viper.New()
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
-	v.Set("entity", "/path/to/file")
 	v.Set("hostname", "my-machine")
 	v.Set("settings.hostname", "ignored")
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true})
+	params, err := paramscmd.LoadAPIParams(v)
 	require.NoError(t, err)
 
-	assert.Equal(t, "my-machine", params.API.Hostname)
+	assert.Equal(t, "my-machine", params.Hostname)
 }
 
 func TestLoadParams_Hostname_FromConfig(t *testing.T) {
 	v := viper.New()
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
-	v.Set("entity", "/path/to/file")
 	v.Set("settings.hostname", "my-machine")
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true})
+	params, err := paramscmd.LoadAPIParams(v)
 	require.NoError(t, err)
 
-	assert.Equal(t, "my-machine", params.API.Hostname)
+	assert.Equal(t, "my-machine", params.Hostname)
 }
 
 func TestLoadParams_Hostname_DefaultFromSystem(t *testing.T) {
 	v := viper.New()
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
-	v.Set("entity", "/path/to/file")
 
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true})
+	params, err := paramscmd.LoadAPIParams(v)
 	require.NoError(t, err)
 
 	expected, err := os.Hostname()
 	require.NoError(t, err)
 
-	assert.Equal(t, expected, params.API.Hostname)
+	assert.Equal(t, expected, params.Hostname)
 }

--- a/cmd/today/today.go
+++ b/cmd/today/today.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"fmt"
 
-	apicmd "github.com/wakatime/wakatime-cli/cmd/api"
-	paramscmd "github.com/wakatime/wakatime-cli/cmd/params"
+	cmdapi "github.com/wakatime/wakatime-cli/cmd/api"
+	"github.com/wakatime/wakatime-cli/cmd/params"
 	"github.com/wakatime/wakatime-cli/pkg/api"
 	"github.com/wakatime/wakatime-cli/pkg/exitcode"
 	"github.com/wakatime/wakatime-cli/pkg/log"
@@ -56,12 +56,14 @@ func Run(v *viper.Viper) (int, error) {
 
 // Today returns a rendered summary of todays coding activity.
 func Today(v *viper.Viper) (string, error) {
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true})
+	paramAPI, err := params.LoadAPIParams(v)
 	if err != nil {
-		return "", fmt.Errorf("failed to load command parameters: %w", err)
+		return "", fmt.Errorf("failed to load API parameters: %w", err)
 	}
 
-	apiClient, err := apicmd.NewClient(params.API)
+	statusBarParam := params.LoadStausBarParams(v)
+
+	apiClient, err := cmdapi.NewClient(paramAPI)
 	if err != nil {
 		return "", fmt.Errorf("failed to initialize api client: %w", err)
 	}
@@ -71,7 +73,7 @@ func Today(v *viper.Viper) (string, error) {
 		return "", fmt.Errorf("failed fetching today from api: %w", err)
 	}
 
-	output, err := summary.RenderToday(s, params.StatusBar.HideCategories)
+	output, err := summary.RenderToday(s, statusBarParam.HideCategories)
 	if err != nil {
 		return "", fmt.Errorf("failed generating today output: %s", err)
 	}

--- a/cmd/today/today_test.go
+++ b/cmd/today/today_test.go
@@ -165,7 +165,7 @@ func TestToday_ErrAuth_UnsetAPIKey(t *testing.T) {
 	var errauth api.ErrAuth
 
 	assert.True(t, errors.As(err, &errauth))
-	assert.Equal(t, "failed to load command parameters: failed to load api params: failed to load api key", err.Error())
+	assert.Equal(t, "failed to load API parameters: failed to load api key", err.Error())
 }
 
 func setupTestServer() (string, *http.ServeMux, func()) {

--- a/cmd/todaygoal/todaygoal.go
+++ b/cmd/todaygoal/todaygoal.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"regexp"
 
-	apicmd "github.com/wakatime/wakatime-cli/cmd/api"
-	paramscmd "github.com/wakatime/wakatime-cli/cmd/params"
+	cmdapi "github.com/wakatime/wakatime-cli/cmd/api"
+	"github.com/wakatime/wakatime-cli/cmd/params"
 	"github.com/wakatime/wakatime-cli/pkg/api"
 	"github.com/wakatime/wakatime-cli/pkg/exitcode"
 	"github.com/wakatime/wakatime-cli/pkg/log"
@@ -20,7 +20,7 @@ var uuid4Regex = regexp.MustCompile("^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab
 // Params contains today-goal command parameters.
 type Params struct {
 	GoalID string
-	API    paramscmd.API
+	API    params.API
 }
 
 // Run executes the today-goal command.
@@ -70,7 +70,7 @@ func Goal(v *viper.Viper) (string, error) {
 		return "", fmt.Errorf("failed to load command parameters: %w", err)
 	}
 
-	apiClient, err := apicmd.NewClient(params.API)
+	apiClient, err := cmdapi.NewClient(params.API)
 	if err != nil {
 		return "", fmt.Errorf("failed to initialize api client: %w", err)
 	}
@@ -86,9 +86,9 @@ func Goal(v *viper.Viper) (string, error) {
 // LoadParams loads todaygoal config params from viper.Viper instance. Returns ErrAuth
 // if failed to retrieve api key.
 func LoadParams(v *viper.Viper) (Params, error) {
-	params, err := paramscmd.Load(v, paramscmd.Config{APIKeyRequired: true})
+	paramAPI, err := params.LoadAPIParams(v)
 	if err != nil {
-		return Params{}, fmt.Errorf("failed to load params: %w", err)
+		return Params{}, fmt.Errorf("failed to load API parameters: %w", err)
 	}
 
 	if !v.IsSet("today-goal") {
@@ -102,6 +102,6 @@ func LoadParams(v *viper.Viper) (Params, error) {
 
 	return Params{
 		GoalID: goalID,
-		API:    params.API,
+		API:    paramAPI,
 	}, nil
 }

--- a/cmd/todaygoal/todaygoal_test.go
+++ b/cmd/todaygoal/todaygoal_test.go
@@ -176,7 +176,7 @@ func TestGoal_ErrAuth_UnsetAPIKey(t *testing.T) {
 	assert.True(t, errors.As(err, &errauth))
 	assert.Equal(
 		t,
-		"failed to load command parameters: failed to load params: failed to load api params: failed to load api key",
+		"failed to load command parameters: failed to load API parameters: failed to load api key",
 		err.Error(),
 	)
 }

--- a/pkg/ini/ini.go
+++ b/pkg/ini/ini.go
@@ -160,26 +160,32 @@ func WakaHomeDir() (string, error) {
 	home, exists := os.LookupEnv("WAKATIME_HOME")
 	if exists && home != "" {
 		home, err := homedir.Expand(home)
-		if err == nil {
+		if err != nil {
+			log.Warnf("failed to expand WAKATIME_HOME filepath: %s", err)
+		} else {
 			return home, nil
 		}
 	}
 
 	home, err := os.UserHomeDir()
-	if err == nil && home != "" {
+	if err != nil {
+		log.Warnf("failed to get user home dir: %s", err)
+	}
+
+	if home != "" {
 		return home, nil
 	}
 
-	var allerrs error = err
-
 	u, err := user.LookupId(strconv.Itoa(os.Getuid()))
-	if err == nil && u.HomeDir != "" {
+	if err != nil {
+		log.Warnf("failed to user info by userid: %s", err)
+	}
+
+	if u.HomeDir != "" {
 		return u.HomeDir, nil
 	}
 
-	allerrs = fmt.Errorf("%s: %s", allerrs, err)
-
-	return "", allerrs
+	return "", fmt.Errorf("could not determine wakatime home dir")
 }
 
 // mutexClock is used to implement mutex.Clock interface.

--- a/pkg/offline/offline.go
+++ b/pkg/offline/offline.go
@@ -85,21 +85,10 @@ func WithQueue(filepath string) (heartbeat.HandleOption, error) {
 // QueueFilepath returns the path for offline queue db file. If
 // the user's $HOME folder cannot be detected, it defaults to the
 // current directory.
-func QueueFilepath() string {
+func QueueFilepath() (string, error) {
 	home, err := ini.WakaHomeDir()
 	if err != nil {
-		log.Errorf("failed getting user's home directory: %s", err)
-	}
-
-	return filepath.Join(home, dbFilename)
-}
-
-// QueueFilepathWithErr returns the path for offline queue db file
-// or an error if the user's $HOME folder could not be detected.
-func QueueFilepathWithErr() (string, error) {
-	home, err := ini.WakaHomeDir()
-	if err != nil {
-		return "", fmt.Errorf("failed getting user's home directory: %s", err)
+		return dbFilename, fmt.Errorf("failed getting user's home directory, defaulting to current directory: %s", err)
 	}
 
 	return filepath.Join(home, dbFilename), nil

--- a/pkg/offline/offline_test.go
+++ b/pkg/offline/offline_test.go
@@ -48,7 +48,7 @@ func TestQueueFilepath(t *testing.T) {
 
 			defer os.Unsetenv("WAKATIME_HOME")
 
-			queueFilepath, err := offline.QueueFilepathWithErr()
+			queueFilepath, err := offline.QueueFilepath()
 			require.NoError(t, err)
 
 			assert.Equal(t, test.Expected, queueFilepath)


### PR DESCRIPTION
This PR originally was intended to remove `QueueFilepathWithErr()` but other improvements were necessary and all are described and explained below. In a nutshell them are small ones but many lines were needed to changes specially at tests

* Both `QueueFilepath()` and `QueueFilepathWithErr()` have the same logic but one is not returning error. To avoid duplicated code `QueueFilepathWithErr()` has been removed in order to have only `QueueFilepath() (string, error)`.
* The default folder returned when `ini.WakaHomeDir()` fails was always a join of "empty" folder with ".wakatime.bdb" so it has been fixed to simply return `.wakatime.bdb`.
* The params config struct was removed in order to simplify `params.Load()` function. Taking that approach few functions were made public to be called individually and make the error handling better. Functions are `LoadHeartbeatParams`, `LoadAPIParams`, `LoadOfflineParams` and `LoadStausBarParams`. Also all unit tests of `params_test.go` were calling the `Load()` function and were replaced accordingly.
* The flags `--today`, `--today-goal`, `--sync-offline-activity` and `--offline-count` have also been changed to better handle error when parsing config file.
* The `cmd.offline.go` dropped the usage of `params.Load()` in order to call them individually and again to get better error handling. Also a bug was fixed in a rare condition where `heartbeats` could be not nil and any heartbeat param was loaded where them are required at `initHandleOptions()`. 
* The `cmd.heartbeat.go` still calls `params.Load()` since it needs all of them loaded correctly as it's designed.
* At the `cmd.run.go` I introduced a call to `SetupLogging()` when `parseConfigFiles()` fails. It basically sets the log to output to file instead of the std out which at this time isn't the wakatime log file .
* Changed `sendDiagnostics()` to return an error and properly handle it at the caller as a warning.
* The `ini` package has been fixed to always return an empty string when any error occurs. It also logs as warning and goes to the next step. So it always try to get the home directory unless all steps fail.