### PR TITLE
Fix api key being hidden incorrectly

### DIFF
--- a/cmd/params/params.go
+++ b/cmd/params/params.go
@@ -749,7 +749,7 @@ func (p API) String() string {
 	apiKey := p.Key
 	if len(apiKey) > 4 {
 		// only show last 4 chars of api key in logs
-		apiKey = "..." + apiKey[:len(apiKey)-4]
+		apiKey = fmt.Sprintf("<hidden>%s", apiKey[len(apiKey)-4:])
 	}
 
 	return fmt.Sprintf(


### PR DESCRIPTION
This PR fixes api key being hidden incorrectly and instead of last 4 chars it's considering the whole string but the first 4. I also replaced "..." with "<hidden>", what do you think?

```
<hidden>bb3c
```