### PR TITLE
Replace golint by revive

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,7 +13,7 @@ linters:
     - godot
     - gofmt
     - goimports
-    - golint
+    - revive
     - gosec
     - lll
     - misspell

--- a/pkg/api/option.go
+++ b/pkg/api/option.go
@@ -48,7 +48,7 @@ func WithHostname(hostname string) Option {
 // WithDisableSSLVerify disables verification of insecure certificates.
 func WithDisableSSLVerify() Option {
 	return func(c *Client) {
-		var transport *http.Transport = LazyCreateNewTransport(c)
+		var transport = LazyCreateNewTransport(c)
 
 		tlsConfig := transport.TLSClientConfig
 		tlsConfig.InsecureSkipVerify = true
@@ -121,7 +121,7 @@ func WithProxy(proxyURL string) (Option, error) {
 	}
 
 	return func(c *Client) {
-		var transport *http.Transport = LazyCreateNewTransport(c)
+		var transport = LazyCreateNewTransport(c)
 		transport.Proxy = http.ProxyURL(u)
 		c.client.Transport = transport
 	}, nil
@@ -143,7 +143,7 @@ func WithSSLCertFile(filepath string) (Option, error) {
 // WithSSLCertPool overrides the default CA cert pool to trust specified cert pool.
 func WithSSLCertPool(caCertPool *x509.CertPool) (Option, error) {
 	return func(c *Client) {
-		var transport *http.Transport = LazyCreateNewTransport(c)
+		var transport = LazyCreateNewTransport(c)
 		tlsConfig := transport.TLSClientConfig
 		tlsConfig.RootCAs = caCertPool
 		transport.TLSClientConfig = tlsConfig

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -119,7 +119,7 @@ func WithDetection(config Config) heartbeat.HandleOption {
 
 // Detect finds the current project and branch from config plugins.
 func Detect(entity string, patterns []MapPattern) Result {
-	var configPlugins []Detecter = []Detecter{
+	var configPlugins = []Detecter{
 		File{
 			Filepath: entity,
 		},
@@ -144,7 +144,7 @@ func Detect(entity string, patterns []MapPattern) Result {
 
 // DetectWithRevControl finds the current project and branch from rev control.
 func DetectWithRevControl(entity string, submodulePatterns []regex.Regex) Result {
-	var revControlPlugins []Detecter = []Detecter{
+	var revControlPlugins = []Detecter{
 		Git{
 			Filepath:          entity,
 			SubmodulePatterns: submodulePatterns,


### PR DESCRIPTION
This PR replaces deprecated `golint` by `revive` as well fixes lint warnings.

Must be reviewd after #669 