### PR TITLE
Remove workaround for gon installation

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -512,13 +512,6 @@ jobs:
       -
         name: Install gon via Homebrew for code signing and app notarization
         run: |
-          # workaround for https://github.com/mitchellh/gon/issues/56
-          pushd .
-          cd /usr/local/Homebrew
-          git fetch origin tag 3.3.9 --no-tags
-          git checkout 3.3.9
-          popd
-          # /workaround
           brew tap mitchellh/gon
           brew install mitchellh/gon/gon
       -


### PR DESCRIPTION
This PR removes the workaround needed to install gon via Homebrew since it got fixed. More details in this [thread](https://github.com/mitchellh/gon/issues/56#issuecomment-1082599471).