### PR TITLE
Fix sanitization for offline heartbeats

### DIFF
--- a/cmd/heartbeat/heartbeat_test.go
+++ b/cmd/heartbeat/heartbeat_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -16,10 +17,13 @@ import (
 	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 	"github.com/wakatime/wakatime-cli/pkg/log"
 	"github.com/wakatime/wakatime-cli/pkg/offline"
+	"github.com/wakatime/wakatime-cli/pkg/version"
 
+	"github.com/matishsiao/goInfo"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	bolt "go.etcd.io/bbolt"
 )
 
 func TestSendHeartbeats(t *testing.T) {
@@ -245,7 +249,7 @@ func TestSendHeartbeats_ExtraHeartbeats(t *testing.T) {
 	v.Set("entity-type", "file")
 	v.Set("extra-heartbeats", true)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
-	v.Set("hide-branch-names", "true")
+	v.Set("hide-branch-names", true)
 	v.Set("project", "wakatime-cli")
 	v.Set("language", "Go")
 	v.Set("alternate-language", "Golang")
@@ -267,6 +271,136 @@ func TestSendHeartbeats_ExtraHeartbeats(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, 1, offlineCount)
+
+	assert.Eventually(t, func() bool { return numCalls == 1 }, time.Second, 50*time.Millisecond)
+}
+
+func TestSendHeartbeats_ExtraHeartbeats_Sanitize(t *testing.T) {
+	testServerURL, router, tearDown := setupTestServer()
+	defer tearDown()
+
+	var (
+		plugin   = "plugin/0.0.1"
+		numCalls int
+	)
+
+	router.HandleFunc("/users/current/heartbeats.bulk", func(w http.ResponseWriter, req *http.Request) {
+		// send response
+		w.WriteHeader(http.StatusCreated)
+
+		f, err := os.Open("testdata/api_heartbeats_response_extra_heartbeats.json")
+		require.NoError(t, err)
+		defer f.Close()
+
+		_, err = io.Copy(w, f)
+		require.NoError(t, err)
+
+		numCalls++
+	})
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+
+	defer func() {
+		r.Close()
+		w.Close()
+	}()
+
+	origStdin := os.Stdin
+
+	defer func() { os.Stdin = origStdin }()
+
+	os.Stdin = r
+
+	data, err := os.ReadFile("testdata/extra_heartbeats.json")
+	require.NoError(t, err)
+
+	go func() {
+		_, err := w.Write(data)
+		require.NoError(t, err)
+
+		w.Close()
+	}()
+
+	v := viper.New()
+	v.SetDefault("sync-offline-activity", 0)
+	v.Set("api-url", testServerURL)
+	v.Set("category", "debugging")
+	v.Set("cursorpos", 42)
+	v.Set("entity", "testdata/main.go")
+	v.Set("entity-type", "file")
+	v.Set("extra-heartbeats", true)
+	v.Set("key", "00000000-0000-4000-8000-000000000000")
+	v.Set("hide-branch-names", true)
+	v.Set("hide-file-names", true)
+	v.Set("project", "wakatime-cli")
+	v.Set("language", "Go")
+	v.Set("alternate-language", "Golang")
+	v.Set("lineno", 13)
+	v.Set("plugin", plugin)
+	v.Set("time", 1585598059.1)
+	v.Set("timeout", 5)
+	v.Set("write", true)
+
+	offlineQueueFile, err := os.CreateTemp(t.TempDir(), "")
+	require.NoError(t, err)
+
+	defer offlineQueueFile.Close()
+
+	err = cmdheartbeat.SendHeartbeats(v, offlineQueueFile.Name())
+	require.NoError(t, err)
+
+	offlineCount, err := offline.CountHeartbeats(offlineQueueFile.Name())
+	require.NoError(t, err)
+
+	db, err := bolt.Open(offlineQueueFile.Name(), 0600, nil)
+	require.NoError(t, err)
+
+	defer db.Close()
+
+	tx, err := db.Begin(true)
+	require.NoError(t, err)
+
+	q := offline.NewQueue(tx)
+
+	hh, err := q.PopMany(1)
+	require.NoError(t, err)
+
+	err = tx.Commit()
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, offlineCount)
+	assert.Len(t, hh, 1)
+
+	info, err := goInfo.GetInfo()
+	require.NoError(t, err)
+
+	userAgent := fmt.Sprintf(
+		"wakatime/%s (%s-%s-%s) %s %s",
+		version.Version,
+		runtime.GOOS,
+		info.Core,
+		info.Platform,
+		runtime.Version(),
+		plugin,
+	)
+
+	assert.Equal(t, []heartbeat.Heartbeat{
+		{
+			Branch:         nil,
+			Category:       heartbeat.CodingCategory,
+			CursorPosition: nil,
+			Dependencies:   nil,
+			Entity:         "HIDDEN.go",
+			EntityType:     heartbeat.FileType,
+			IsWrite:        heartbeat.PointerTo(true),
+			Language:       heartbeat.PointerTo("Go"),
+			LineNumber:     nil,
+			Lines:          nil,
+			Project:        heartbeat.PointerTo("wakatime-cli"),
+			Time:           1585598059,
+			UserAgent:      userAgent,
+		}}, hh)
 
 	assert.Eventually(t, func() bool { return numCalls == 1 }, time.Second, 50*time.Millisecond)
 }

--- a/pkg/offline/offline.go
+++ b/pkg/offline/offline.go
@@ -46,7 +46,7 @@ func (*Sender) SendHeartbeats(_ []heartbeat.Heartbeat) ([]heartbeat.Result, erro
 // failing connection to API, failed sending or errors returned by API, the
 // heartbeats will be temporarily stored in a DB and sending will be retried
 // at next usages of the wakatime cli.
-func WithQueue(filepath string) (heartbeat.HandleOption, error) {
+func WithQueue(filepath string) heartbeat.HandleOption {
 	return func(next heartbeat.Handle) heartbeat.Handle {
 		return func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
 			log.Debugf("execute offline queue with file %s", filepath)
@@ -79,7 +79,7 @@ func WithQueue(filepath string) (heartbeat.HandleOption, error) {
 
 			return results, nil
 		}
-	}, nil
+	}
 }
 
 // QueueFilepath returns the path for offline queue db file. If

--- a/pkg/offline/offline_test.go
+++ b/pkg/offline/offline_test.go
@@ -78,8 +78,7 @@ func TestWithQueue(t *testing.T) {
 
 	db.Close()
 
-	opt, err := offline.WithQueue(f.Name())
-	require.NoError(t, err)
+	opt := offline.WithQueue(f.Name())
 
 	handle := opt(func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
 		assert.Len(t, hh, 2)
@@ -151,8 +150,7 @@ func TestWithQueue_ApiError(t *testing.T) {
 
 	defer f.Close()
 
-	opt, err := offline.WithQueue(f.Name())
-	require.NoError(t, err)
+	opt := offline.WithQueue(f.Name())
 
 	handle := opt(func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
 		assert.Equal(t, hh, []heartbeat.Heartbeat{
@@ -214,8 +212,7 @@ func TestWithQueue_InvalidResults(t *testing.T) {
 
 	defer f.Close()
 
-	opt, err := offline.WithQueue(f.Name())
-	require.NoError(t, err)
+	opt := offline.WithQueue(f.Name())
 
 	handle := opt(func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
 		assert.Equal(t, hh, testHeartbeats())
@@ -300,8 +297,7 @@ func TestWithQueue_HandleLeftovers(t *testing.T) {
 
 	defer f.Close()
 
-	opt, err := offline.WithQueue(f.Name())
-	require.NoError(t, err)
+	opt := offline.WithQueue(f.Name())
 
 	handle := opt(func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
 		assert.Equal(t, hh, testHeartbeats())


### PR DESCRIPTION
This PR fixes heartbeats not sanitizeds in an specific situation causing sanitize params not being loaded. It also fixed:

1. Don't  need to return error for `offline.WithQueue()`.
2. Don't try to save heartbeats to offline db after `params.Load(v)` has failed since it needs params to be loaded and might fail.

To cover this scenario the following test was added:

* TestSendHeartbeats_ExtraHeartbeats_Sanitize

Fixes https://github.com/wakatime/wakatime-cli/issues/676