### PR TITLE
Improve changelog for release and slack

### DIFF
--- a/.github/workflows/on_pull_request_linter.yml
+++ b/.github/workflows/on_pull_request_linter.yml
@@ -1,4 +1,4 @@
-name: "Tests"
+name: Tests
 
 on: pull_request
 
@@ -6,7 +6,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: lekterable/branchlint-action@1.2.0
+      - 
+        name: Lint allowed branch names
+        uses: lekterable/branchlint-action@1.2.0
         with:
           allowed: |
             /^(.+:)?bugfix/.+/i
@@ -16,3 +18,11 @@ jobs:
             /^(.+:)?major/.+/i
             /^(.+:)?misc/.+/i
             /^(.+:)?develop$/i
+      - 
+        # Run only for release branch
+        if: ${{ github.base_ref == 'release' }}
+        name: Check for changelog pattern
+        uses: JJ/github-pr-contains-action@v1
+        with:
+          github-token: ${{ github.token }}
+          bodyContains: 'Changelog:'

--- a/bin/prepare_changelog.sh
+++ b/bin/prepare_changelog.sh
@@ -24,6 +24,12 @@ replace_for_release() {
     changelog="${changelog//$'\r'/'%0D'}"
 }
 
+replace_for_slack() {
+    slack="${slack//'%'/'%25'}"
+    slack="${slack//$'\n'/'%0A'}"
+    slack="${slack//$'\r'/'%0D'}"
+}
+
 slack_output_for_develop() {
     local IFS=$'\n' # make newlines the only separator
     local temp=
@@ -67,6 +73,7 @@ case $branch in
         clean_up
         slack_output_for_release
         replace_for_release
+        replace_for_slack
         ;;
     *) exit 1 ;;
 esac


### PR DESCRIPTION
This PR adds the following:

* It prevents merging `develop` into `release` branch without having changelog well formatted.
* It fixes line breaking for slack messages when the changelog for release is multi-line.

It can't fix bakctick being interpreted as an unknown command since it's the legacy bash command evaluator and is hard (_almost impossible_) to replace it.

Closes #517 