### PR TITLE
Replace changelog lint

### DIFF
--- a/.github/workflows/on_pull_request_linter.yml
+++ b/.github/workflows/on_pull_request_linter.yml
@@ -27,9 +27,9 @@ jobs:
         # Run only for release branch
         if: ${{ github.base_ref == 'release' }}
         name: Check for changelog pattern
-        uses: Talentia-Software-OSS/check-pr-comments-action@v0.0.3
+        uses: gandarez/check-pr-body-action@v1.0.1
         with:
-          comments-must-contain: 'Changelog:'
-          comments-must-not-contain: '`'
+          contains: 'Changelog:'
+          not-contains: '`'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -543,7 +543,7 @@ jobs:
         name: Prepare changelog
         id: changelog
         run: |
-          changelog="${{ steps.changelog-develop.outputs.changelog || fromJson(steps.changelog-release.outputs.pr).body }}"
+          changelog="${{ steps.changelog-develop.outputs.changelog || steps.changelog-release.outputs.pr_body }}"
           ./bin/prepare_changelog.sh $(echo ${GITHUB_REF#refs/heads/}) "$changelog"
       -
         name: Download artifacts


### PR DESCRIPTION
This PR replaces the current changelog linter action by `gandarez/check-pr-body-action` which is hosted [here](https://github.com/marketplace/actions/check-pr-body).
