### PR TITLE
Downgrade checkout action

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -191,7 +191,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
         with:
           fetch-depth: 0
       -


### PR DESCRIPTION
`actions/checkout@v3` clones the repo using the GitHub API, but semver-action needs it cloned with `git clone`.