### PR TITLE
Run remote handler before filtering

### DIFF
--- a/cmd/heartbeat/heartbeat.go
+++ b/cmd/heartbeat/heartbeat.go
@@ -202,18 +202,17 @@ func initHandleOptions(params paramscmd.Params) []heartbeat.HandleOption {
 		heartbeat.WithFormatting(heartbeat.FormatConfig{
 			RemoteAddressPattern: remote.RemoteAddressRegex,
 		}),
+		heartbeat.WithEntityModifer(),
+		remote.WithDetection(),
 		filter.WithFiltering(filter.Config{
 			Exclude:                    params.Heartbeat.Filter.Exclude,
 			Include:                    params.Heartbeat.Filter.Include,
 			IncludeOnlyWithProjectFile: params.Heartbeat.Filter.IncludeOnlyWithProjectFile,
-			RemoteAddressPattern:       remote.RemoteAddressRegex,
 		}),
-		heartbeat.WithEntityModifer(),
 		apikey.WithReplacing(apikey.Config{
 			DefaultApiKey: params.API.Key,
 			MapPatterns:   params.API.KeyPatterns,
 		}),
-		remote.WithDetection(),
 		filestats.WithDetection(),
 		language.WithDetection(),
 		deps.WithDetection(deps.Config{

--- a/cmd/offline/offline.go
+++ b/cmd/offline/offline.go
@@ -143,14 +143,13 @@ func initHandleOptions(params paramscmd.Params) []heartbeat.HandleOption {
 		heartbeat.WithFormatting(heartbeat.FormatConfig{
 			RemoteAddressPattern: remote.RemoteAddressRegex,
 		}),
+		heartbeat.WithEntityModifer(),
+		remote.WithDetection(),
 		filter.WithFiltering(filter.Config{
 			Exclude:                    params.Heartbeat.Filter.Exclude,
 			Include:                    params.Heartbeat.Filter.Include,
 			IncludeOnlyWithProjectFile: params.Heartbeat.Filter.IncludeOnlyWithProjectFile,
-			RemoteAddressPattern:       remote.RemoteAddressRegex,
 		}),
-		heartbeat.WithEntityModifer(),
-		remote.WithDetection(),
 		filestats.WithDetection(),
 		language.WithDetection(),
 		deps.WithDetection(deps.Config{

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
-	"regexp"
 	"testing"
 
 	"github.com/wakatime/wakatime-cli/pkg/filter"
@@ -178,12 +177,11 @@ func TestFilter_ExistingProjectFile(t *testing.T) {
 
 func TestFilter_RemoteFile(t *testing.T) {
 	h := testHeartbeat()
+	h.LocalFile = h.Entity
 	h.Entity = "ssh://wakatime:1234@192.168.1.1/path/to/remote/main.go"
 
-	err := filter.Filter(h, filter.Config{
-		RemoteAddressPattern: regexp.MustCompile(`(?i)^((ssh|sftp)://)+(?P<credentials>[^:@]+(:([^:@])+)?@)?[^:]+(:\d+)?`),
-	})
-	require.NoError(t, err)
+	err := filter.Filter(h, filter.Config{})
+	assert.EqualError(t, err, "filter file: skipping because of non-existing file \"/tmp/main.go\"")
 }
 
 func TestFilter_ErrNonExistingProjectFile(t *testing.T) {

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -54,24 +54,20 @@ func WithDetection() heartbeat.HandleOption {
 			log.Debugln("execute remote file detection")
 
 			var (
-				tmpDir   string
-				err      error
-				filtered []heartbeat.Heartbeat
+				tmpDir string
+				err    error
 			)
 
-			for _, h := range hh {
+			for i, h := range hh {
 				if h.EntityType != heartbeat.FileType {
-					filtered = append(filtered, h)
 					continue
 				}
 
 				if h.IsUnsavedEntity {
-					filtered = append(filtered, h)
 					continue
 				}
 
 				if !RemoteAddressRegex.MatchString(h.Entity) {
-					filtered = append(filtered, h)
 					continue
 				}
 
@@ -105,18 +101,12 @@ func WithDetection() heartbeat.HandleOption {
 					continue
 				}
 
-				h.LocalFile = tmpFile.Name()
+				hh[i].LocalFile = tmpFile.Name()
 				// we save untouched entity for offline handling
-				h.EntityRaw = h.Entity
-
-				filtered = append(filtered, h)
+				hh[i].EntityRaw = h.Entity
 			}
 
-			if len(filtered) == 0 {
-				log.Errorln("FILTERED IS EMPTY")
-			}
-
-			return next(filtered)
+			return next(hh)
 		}
 	}
 }

--- a/pkg/remote/remote_test.go
+++ b/pkg/remote/remote_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kevinburke/ssh_config"
 	"github.com/mitchellh/go-homedir"
 	"github.com/pkg/sftp"
+	"github.com/wakatime/wakatime-cli/pkg/filter"
 	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 	"github.com/wakatime/wakatime-cli/pkg/log"
 	"github.com/wakatime/wakatime-cli/pkg/remote"
@@ -220,6 +221,11 @@ func TestWithDetection_sshConfig_UserKnownHostsFile_mismatch(t *testing.T) {
 
 	opts := []heartbeat.HandleOption{
 		remote.WithDetection(),
+		filter.WithFiltering(filter.Config{
+			Exclude:                    nil,
+			Include:                    nil,
+			IncludeOnlyWithProjectFile: false,
+		}),
 	}
 
 	handle := heartbeat.NewHandle(&sender, opts...)
@@ -303,6 +309,11 @@ func TestWithDetection_sshConfig_UserKnownHostsFile_match(t *testing.T) {
 
 	opts := []heartbeat.HandleOption{
 		remote.WithDetection(),
+		filter.WithFiltering(filter.Config{
+			Exclude:                    nil,
+			Include:                    nil,
+			IncludeOnlyWithProjectFile: true,
+		}),
 	}
 
 	handle := heartbeat.NewHandle(&sender, opts...)


### PR DESCRIPTION
Runs `remote.WithDetection()` before `filter.WithFiltering()` so `filter.WithFiltering()` can use `heartbeat.LocalFile` instead of pattern matching entity for remote file specs.