### PR TITLE
Remove extra if for project validation

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -92,12 +92,8 @@ func WithDetection(config Config) heartbeat.HandleOption {
 					if config.ShouldObfuscateProject && revControlResult.Project != "" && result.Project == "" {
 						result.Project = obfuscateProjectName(result.Folder)
 					} else {
-						result.Project = firstNonEmptyString(result.Project, revControlResult.Project)
+						result.Project = firstNonEmptyString(result.Project, revControlResult.Project, h.ProjectAlternate)
 					}
-				}
-
-				if result.Project == "" {
-					result.Project = h.ProjectAlternate
 				}
 
 				if runtime.GOOS == "windows" && result.Folder != "" {


### PR DESCRIPTION
This PR removes extra "if" in project validation. It's fair to get first non empty string and fall back to alternate project name.