### PR TITLE
Log api key pattern match results in debug mode

### DIFF
--- a/pkg/apikey/apikey.go
+++ b/pkg/apikey/apikey.go
@@ -48,7 +48,10 @@ func WithReplacing(config Config) heartbeat.HandleOption {
 func MatchPattern(fp string, patterns []MapPattern) (string, bool) {
 	for _, pattern := range patterns {
 		if pattern.Regex.MatchString(fp) {
+			log.Debugf("api key replacing pattern matched: %s\n", pattern.Regex.String())
 			return pattern.ApiKey, true
+		} else {
+			log.Debugf("api key replacing pattern not matched: %s\n", pattern.Regex.String())
 		}
 	}
 


### PR DESCRIPTION
To help with debugging why a `[project_api_key]` pattern is or isn't matching an entity path.