### PR TITLE
All project api key regex are case insensitive

### DIFF
--- a/cmd/params/params.go
+++ b/cmd/params/params.go
@@ -192,6 +192,11 @@ func LoadAPIParams(v *viper.Viper) (API, error) {
 	apiKeyMap := vipertools.GetStringMapString(v, "project_api_key")
 
 	for k, s := range apiKeyMap {
+		// make all regex case insensitive
+		if !strings.HasPrefix(k, "(?i)") {
+			k = "(?i)" + k
+		}
+
 		compiled, err := regexp.Compile(k)
 		if err != nil {
 			log.Warnf("failed to compile project_api_key regex pattern %q", k)

--- a/cmd/params/params_test.go
+++ b/cmd/params/params_test.go
@@ -531,7 +531,7 @@ func TestLoadParams_ProjectApiKey(t *testing.T) {
 			Expected: []apikey.MapPattern{
 				{
 					ApiKey: "00000000-0000-4000-8000-000000000001",
-					Regex:  regexp.MustCompile("projects/foo"),
+					Regex:  regexp.MustCompile(`(?i)projects/foo`),
 				},
 			},
 		},
@@ -542,7 +542,18 @@ func TestLoadParams_ProjectApiKey(t *testing.T) {
 			Expected: []apikey.MapPattern{
 				{
 					ApiKey: "00000000-0000-4000-8000-000000000002",
-					Regex:  regexp.MustCompile(`^/home/user/projects/bar(\\d+)/`),
+					Regex:  regexp.MustCompile(`(?i)^/home/user/projects/bar(\\d+)/`),
+				},
+			},
+		},
+		"case insensitive": {
+			Entity: "/home/user/PROJECTS/foo/file",
+			Regex:  regexp.MustCompile("projects/foo"),
+			ApiKey: "00000000-0000-4000-8000-000000000001",
+			Expected: []apikey.MapPattern{
+				{
+					ApiKey: "00000000-0000-4000-8000-000000000001",
+					Regex:  regexp.MustCompile(`(?i)projects/foo`),
 				},
 			},
 		},
@@ -586,7 +597,7 @@ func TestLoadParams_ProjectApiKey_ParseConfig(t *testing.T) {
 	expected := []apikey.MapPattern{
 		{
 			ApiKey: "00000000-0000-4000-8000-000000000001",
-			Regex:  regex.MustCompile("/some/path"),
+			Regex:  regex.MustCompile("(?i)/some/path"),
 		},
 	}
 

--- a/pkg/apikey/apikey.go
+++ b/pkg/apikey/apikey.go
@@ -48,6 +48,7 @@ func WithReplacing(config Config) heartbeat.HandleOption {
 func MatchPattern(fp string, patterns []MapPattern) (string, bool) {
 	for _, pattern := range patterns {
 		if pattern.Regex.MatchString(fp) {
+			log.Debugf("api key matched %q", pattern.Regex.String())
 			return pattern.ApiKey, true
 		}
 	}


### PR DESCRIPTION
This PR makes all regex case insesitive for `project_api_key` setting by adding `(?i)` at the begining.

This fixes item 1 on https://github.com/wakatime/wakatime-cli/issues/713.