### PR TITLE
All user-input regex are case insensitive

### DIFF
--- a/cmd/params/params.go
+++ b/cmd/params/params.go
@@ -414,6 +414,11 @@ func loadFilterParams(v *viper.Viper) FilterParams {
 	var excludePatterns []regex.Regex
 
 	for _, s := range exclude {
+		// make all regex case insensitive
+		if !strings.HasPrefix(s, "(?i)") {
+			s = "(?i)" + s
+		}
+
 		compiled, err := regex.Compile(s)
 		if err != nil {
 			log.Warnf("failed to compile exclude regex pattern %q", s)
@@ -429,6 +434,11 @@ func loadFilterParams(v *viper.Viper) FilterParams {
 	var includePatterns []regex.Regex
 
 	for _, s := range include {
+		// make all regex case insensitive
+		if !strings.HasPrefix(s, "(?i)") {
+			s = "(?i)" + s
+		}
+
 		compiled, err := regex.Compile(s)
 		if err != nil {
 			log.Warnf("failed to compile include regex pattern %q", s)
@@ -534,6 +544,11 @@ func loadProjectParams(v *viper.Viper) (ProjectParams, error) {
 	projectMap := vipertools.GetStringMapString(v, "projectmap")
 
 	for k, s := range projectMap {
+		// make all regex case insensitive
+		if !strings.HasPrefix(k, "(?i)") {
+			k = "(?i)" + k
+		}
+
 		compiled, err := regexp.Compile(k)
 		if err != nil {
 			log.Warnf("failed to compile projectmap regex pattern %q", k)

--- a/cmd/params/params_test.go
+++ b/cmd/params/params_test.go
@@ -486,7 +486,7 @@ func TestLoadParams_ProjectMap(t *testing.T) {
 			Expected: []project.MapPattern{
 				{
 					Name:  "My Awesome Project",
-					Regex: regexp.MustCompile("projects/foo"),
+					Regex: regexp.MustCompile("(?i)projects/foo"),
 				},
 			},
 		},
@@ -497,7 +497,7 @@ func TestLoadParams_ProjectMap(t *testing.T) {
 			Expected: []project.MapPattern{
 				{
 					Name:  "project{0}",
-					Regex: regexp.MustCompile(`^/home/user/projects/bar(\\d+)/`),
+					Regex: regexp.MustCompile(`(?i)^/home/user/projects/bar(\\d+)/`),
 				},
 			},
 		},
@@ -525,7 +525,6 @@ func TestLoadParams_ProjectApiKey(t *testing.T) {
 		Expected []apikey.MapPattern
 	}{
 		"simple regex": {
-			Entity: "/home/user/projects/foo/file",
 			Regex:  regexp.MustCompile("projects/foo"),
 			ApiKey: "00000000-0000-4000-8000-000000000001",
 			Expected: []apikey.MapPattern{
@@ -536,7 +535,6 @@ func TestLoadParams_ProjectApiKey(t *testing.T) {
 			},
 		},
 		"complex regex": {
-			Entity: "/home/user/projects/bar123/file",
 			Regex:  regexp.MustCompile(`^/home/user/projects/bar(\\d+)/`),
 			ApiKey: "00000000-0000-4000-8000-000000000002",
 			Expected: []apikey.MapPattern{
@@ -547,7 +545,6 @@ func TestLoadParams_ProjectApiKey(t *testing.T) {
 			},
 		},
 		"case insensitive": {
-			Entity: "/home/user/PROJECTS/foo/file",
 			Regex:  regexp.MustCompile("projects/foo"),
 			ApiKey: "00000000-0000-4000-8000-000000000001",
 			Expected: []apikey.MapPattern{
@@ -558,7 +555,6 @@ func TestLoadParams_ProjectApiKey(t *testing.T) {
 			},
 		},
 		"api key equal to default": {
-			Entity:   "/some/path",
 			Regex:    regexp.MustCompile(`/some/path`),
 			ApiKey:   "00000000-0000-4000-8000-000000000000",
 			Expected: nil,
@@ -569,7 +565,7 @@ func TestLoadParams_ProjectApiKey(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			v := viper.New()
 			v.Set("key", "00000000-0000-4000-8000-000000000000")
-			v.Set("entity", test.Entity)
+			// v.Set("entity", test.Entity)
 			v.Set(fmt.Sprintf("project_api_key.%s", test.Regex.String()), test.ApiKey)
 
 			params, err := paramscmd.LoadAPIParams(v)
@@ -638,12 +634,12 @@ func TestLoadParams_Filter_Exclude(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, params.Filter.Exclude, 6)
-	assert.Equal(t, ".*", params.Filter.Exclude[0].String())
-	assert.Equal(t, "wakatime.*", params.Filter.Exclude[1].String())
-	assert.Equal(t, ".+", params.Filter.Exclude[2].String())
-	assert.Equal(t, "wakatime.+", params.Filter.Exclude[3].String())
-	assert.Equal(t, ".?", params.Filter.Exclude[4].String())
-	assert.Equal(t, "wakatime.?", params.Filter.Exclude[5].String())
+	assert.Equal(t, "(?i).*", params.Filter.Exclude[0].String())
+	assert.Equal(t, "(?i)wakatime.*", params.Filter.Exclude[1].String())
+	assert.Equal(t, "(?i).+", params.Filter.Exclude[2].String())
+	assert.Equal(t, "(?i)wakatime.+", params.Filter.Exclude[3].String())
+	assert.Equal(t, "(?i).?", params.Filter.Exclude[4].String())
+	assert.Equal(t, "(?i)wakatime.?", params.Filter.Exclude[5].String())
 }
 
 func TestLoadParams_Filter_Exclude_Multiline(t *testing.T) {
@@ -655,8 +651,8 @@ func TestLoadParams_Filter_Exclude_Multiline(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, params.Filter.Exclude, 2)
-	assert.Equal(t, ".?", params.Filter.Exclude[0].String())
-	assert.Equal(t, "wakatime.?", params.Filter.Exclude[1].String())
+	assert.Equal(t, "(?i).?", params.Filter.Exclude[0].String())
+	assert.Equal(t, "(?i)wakatime.?", params.Filter.Exclude[1].String())
 }
 
 func TestLoadParams_Filter_Exclude_IgnoresInvalidRegex(t *testing.T) {
@@ -668,7 +664,7 @@ func TestLoadParams_Filter_Exclude_IgnoresInvalidRegex(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, params.Filter.Exclude, 1)
-	assert.Equal(t, ".*", params.Filter.Exclude[0].String())
+	assert.Equal(t, "(?i).*", params.Filter.Exclude[0].String())
 }
 
 func TestLoadParams_Filter_Exclude_PerlRegexPatterns(t *testing.T) {
@@ -687,7 +683,7 @@ func TestLoadParams_Filter_Exclude_PerlRegexPatterns(t *testing.T) {
 			require.NoError(t, err)
 
 			require.Len(t, params.Filter.Exclude, 1)
-			assert.Equal(t, pattern, params.Filter.Exclude[0].String())
+			assert.Equal(t, "(?i)"+pattern, params.Filter.Exclude[0].String())
 		})
 	}
 }
@@ -725,10 +721,10 @@ func TestLoadParams_Filter_Include(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, params.Filter.Include, 4)
-	assert.Equal(t, ".*", params.Filter.Include[0].String())
-	assert.Equal(t, "wakatime.*", params.Filter.Include[1].String())
-	assert.Equal(t, ".+", params.Filter.Include[2].String())
-	assert.Equal(t, "wakatime.+", params.Filter.Include[3].String())
+	assert.Equal(t, "(?i).*", params.Filter.Include[0].String())
+	assert.Equal(t, "(?i)wakatime.*", params.Filter.Include[1].String())
+	assert.Equal(t, "(?i).+", params.Filter.Include[2].String())
+	assert.Equal(t, "(?i)wakatime.+", params.Filter.Include[3].String())
 }
 
 func TestLoadParams_Filter_Include_IgnoresInvalidRegex(t *testing.T) {
@@ -740,7 +736,7 @@ func TestLoadParams_Filter_Include_IgnoresInvalidRegex(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, params.Filter.Include, 1)
-	assert.Equal(t, ".*", params.Filter.Include[0].String())
+	assert.Equal(t, "(?i).*", params.Filter.Include[0].String())
 }
 
 func TestLoadParams_Filter_Include_PerlRegexPatterns(t *testing.T) {
@@ -759,7 +755,7 @@ func TestLoadParams_Filter_Include_PerlRegexPatterns(t *testing.T) {
 			require.NoError(t, err)
 
 			require.Len(t, params.Filter.Include, 1)
-			assert.Equal(t, pattern, params.Filter.Include[0].String())
+			assert.Equal(t, "(?i)"+pattern, params.Filter.Include[0].String())
 		})
 	}
 }

--- a/pkg/apikey/apikey_test.go
+++ b/pkg/apikey/apikey_test.go
@@ -10,10 +10,10 @@ import (
 
 	"github.com/wakatime/wakatime-cli/pkg/apikey"
 	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
-	"github.com/yookoala/realpath"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/yookoala/realpath"
 )
 
 func TestWithReplacing(t *testing.T) {


### PR DESCRIPTION
This PR makes all user-input regex case insesitive by adding `(?i)` at the begining. Can't simply remove dependency to `github.com/dlclark/regexp2` due to lack of native support for negative/positive lookahead, affected testes are:

* TestLoadParams_Filter_Exclude_PerlRegexPatterns/negative_lookahead
* TestLoadParams_Filter_Exclude_PerlRegexPatterns/positive_lookahead
* TestLoadParams_Filter_Include_PerlRegexPatterns/negative_lookahead
* TestLoadParams_Filter_Include_PerlRegexPatterns/positive_lookahead

Closes https://github.com/wakatime/wakatime-cli/issues/714