### PR TITLE
Use internal config when writing backoff

### DIFF
--- a/pkg/api/heartbeat.go
+++ b/pkg/api/heartbeat.go
@@ -65,8 +65,6 @@ func (c *Client) sendHeartbeats(url string, heartbeats []heartbeat.Heartbeat) ([
 	}
 	defer resp.Body.Close()
 
-	log.Debugf("request headers: %+v", req.Header)
-
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, Err(fmt.Sprintf("failed reading response body from %q: %s", url, err))

--- a/pkg/apikey/apikey.go
+++ b/pkg/apikey/apikey.go
@@ -48,9 +48,11 @@ func WithReplacing(config Config) heartbeat.HandleOption {
 func MatchPattern(fp string, patterns []MapPattern) (string, bool) {
 	for _, pattern := range patterns {
 		if pattern.Regex.MatchString(fp) {
-			log.Debugf("api key matched %q", pattern.Regex.String())
+			log.Debugf("api key pattern %q matched path %q", pattern.Regex.String(), fp)
 			return pattern.ApiKey, true
 		}
+
+		log.Debugf("api key pattern %q did not match path %q", pattern.Regex.String(), fp)
 	}
 
 	return "", false

--- a/pkg/backoff/backoff.go
+++ b/pkg/backoff/backoff.go
@@ -86,7 +86,7 @@ func shouldBackoff(retries int, at time.Time) bool {
 }
 
 func updateBackoffSettings(v *viper.Viper, retries int, at time.Time) error {
-	w, err := ini.NewIniWriter(v, ini.FilePath)
+	w, err := ini.NewIniWriter(v, ini.InternalFilePath)
 	if err != nil {
 		return fmt.Errorf("failed to parse config file: %s", err)
 	}

--- a/pkg/deps/deps.go
+++ b/pkg/deps/deps.go
@@ -67,7 +67,7 @@ func WithDetection(c Config) heartbeat.HandleOption {
 
 				dependencies, err := Detect(filepath, language)
 				if err != nil {
-					log.Warnf("error detecting dependencies of heartbeat: %s", err)
+					log.Warnf("error detecting dependencies: %s", err)
 					continue
 				}
 
@@ -121,9 +121,6 @@ func Detect(filepath string, language heartbeat.Language) ([]string, error) {
 	case heartbeat.LanguageVBNet:
 		parser = &ParserVbNet{}
 	default:
-		log.Debugf(
-			"no parser has been found for language %q. Using Unknown parser to detect dependencies.", language)
-
 		parser = &ParserUnknown{}
 	}
 


### PR DESCRIPTION
This fixes a bug where the `~/.wakatime.cfg` file was being used when writing `[internal]` backoff settings after an api error.

It also removes request header logging, because the API Key is logged fully as base64 text as part of the Authorization header.

Finally, it adds logging when api key pattern matching fails to match because we still have some bugs around it. We can remove that logging and only log when a match is found after the bugs are fixed.