### PR TITLE
Fix error on missing internal config file

### DIFF
--- a/cmd/configwrite/configwrite.go
+++ b/cmd/configwrite/configwrite.go
@@ -20,7 +20,7 @@ type Params struct {
 
 // Run loads wakatime config file and call Write().
 func Run(v *viper.Viper) (int, error) {
-	w, err := ini.NewIniWriter(v, ini.FilePath)
+	w, err := ini.NewWriter(v, ini.FilePath)
 	if err != nil {
 		return exitcode.ErrConfigFileParse, fmt.Errorf(
 			"failed to parse config file: %s",

--- a/cmd/configwrite/configwrite_test.go
+++ b/cmd/configwrite/configwrite_test.go
@@ -73,7 +73,7 @@ func TestWrite(t *testing.T) {
 	defer tmpFile.Close()
 
 	v := viper.New()
-	ini, err := ini.NewIniWriter(v, func(vp *viper.Viper) (string, error) {
+	ini, err := ini.NewWriter(v, func(vp *viper.Viper) (string, error) {
 		assert.Equal(t, v, vp)
 		return tmpFile.Name(), nil
 	})

--- a/pkg/backoff/backoff.go
+++ b/pkg/backoff/backoff.go
@@ -86,7 +86,7 @@ func shouldBackoff(retries int, at time.Time) bool {
 }
 
 func updateBackoffSettings(v *viper.Viper, retries int, at time.Time) error {
-	w, err := ini.NewIniWriter(v, ini.InternalFilePath)
+	w, err := ini.NewWriter(v, ini.InternalFilePath)
 	if err != nil {
 		return fmt.Errorf("failed to parse config file: %s", err)
 	}

--- a/pkg/backoff/backoff_internal_test.go
+++ b/pkg/backoff/backoff_internal_test.go
@@ -50,7 +50,7 @@ func TestUpdateBackoffSettings(t *testing.T) {
 	err = updateBackoffSettings(v, 2, at)
 	require.NoError(t, err)
 
-	writer, err := ini.NewIniWriter(v, func(vp *viper.Viper) (string, error) {
+	writer, err := ini.NewWriter(v, func(vp *viper.Viper) (string, error) {
 		assert.Equal(t, v, vp)
 		return tmpFile.Name(), nil
 	})
@@ -76,7 +76,7 @@ func TestUpdateBackoffSettings_NotInBackoff(t *testing.T) {
 	err = updateBackoffSettings(v, 0, time.Time{})
 	require.NoError(t, err)
 
-	writer, err := ini.NewIniWriter(v, func(vp *viper.Viper) (string, error) {
+	writer, err := ini.NewWriter(v, func(vp *viper.Viper) (string, error) {
 		assert.Equal(t, v, vp)
 		return tmpFile.Name(), nil
 	})

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -231,9 +231,9 @@ func generateProjectName() string {
 	str := []string{}
 
 	rand.Seed(time.Now().UnixNano())
-	str = append(str, strings.Title(adjectives[rand.Intn(len(adjectives))])) // nolint:gosec
+	str = append(str, strings.Title(adjectives[rand.Intn(len(adjectives))])) // nolint:gosec,staticcheck
 	rand.Seed(time.Now().UnixNano())
-	str = append(str, strings.Title(nouns[rand.Intn(len(nouns))])) // nolint:gosec
+	str = append(str, strings.Title(nouns[rand.Intn(len(nouns))])) // nolint:gosec,staticcheck
 	rand.Seed(time.Now().UnixNano())
 	str = append(str, strconv.Itoa(rand.Intn(100))) // nolint:gosec
 


### PR DESCRIPTION
This PR fixes a condition where `.wakatime-internal.cfg` is missing and would fail to update backoff settings. I also noticed the lack of logs during initialization which was fixed by placing `SetupLogging()` at the begining. It also replaces `NewiniWriter` to `NewWriter` to be conformed the standard. Few minor fixes were also introduced in this commit:

* `ini.ReadInConfig()` won't check for file existance
* `ini.NewWriter()` will create a file if it's missing
* While parsing config files it will skip if file does not exist
* Fix path for test files on `pkg/ini/ini_test.go`

```
{"caller":"pkg/backoff/backoff.go:48","func":"backoff.WithBackoff","level":"debug","message":"incrementing backoff due to error","now":"2022-05-08T11:44:48-03:00","version":"<local-build>"}
{"caller":"pkg/backoff/backoff.go:52","func":"backoff.WithBackoff","level":"warning","message":"failed to update backoff settings: failed to parse config file: error loading config file: open <path>/.wakatime-internal.cfg: no such file or directory","now":"2022-05-08T11:44:48-03:00","version":"<local-build>"}
```