### PR TITLE
Sort map keys to avoid randomly read map

### DIFF
--- a/pkg/api/heartbeat.go
+++ b/pkg/api/heartbeat.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strings"
 
 	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
@@ -28,9 +29,10 @@ func (c *Client) SendHeartbeats(heartbeats []heartbeat.Heartbeat) ([]heartbeat.R
 	var results []heartbeat.Result
 
 	grouped := groupByApiKey(heartbeats)
+	keys := sortKeys(grouped)
 
-	for _, hh := range grouped {
-		res, err := c.sendHeartbeats(url, hh)
+	for _, k := range keys {
+		res, err := c.sendHeartbeats(url, grouped[k])
 		if err != nil {
 			return nil, err
 		}
@@ -220,6 +222,20 @@ func groupByApiKey(hh []heartbeat.Heartbeat) map[string][]heartbeat.Heartbeat {
 	}
 
 	return grouped
+}
+
+func sortKeys[K string, V any](m map[K]V) []K {
+	keys := make([]K, len(m))
+	i := 0
+
+	for k := range m {
+		keys[i] = k
+		i++
+	}
+
+	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
+
+	return keys
 }
 
 func setAuthHeader(req *http.Request, apiKey string) {

--- a/pkg/api/heartbeat_test.go
+++ b/pkg/api/heartbeat_test.go
@@ -136,6 +136,8 @@ func TestClient_SendHeartbeats_MultipleApiKey(t *testing.T) {
 
 	_, err := c.SendHeartbeats(hh)
 	require.NoError(t, err)
+
+	assert.Eventually(t, func() bool { return numCalls == 2 }, time.Second, 50*time.Millisecond)
 }
 
 func TestClient_SendHeartbeats_Err(t *testing.T) {


### PR DESCRIPTION
This PR sorts grouped heartbeats to always run ordered and to not break tests.