### PR TITLE
Fix project path if it was not auto-detected or alternate is taken

### DIFF
--- a/cmd/heartbeat/heartbeat.go
+++ b/cmd/heartbeat/heartbeat.go
@@ -219,8 +219,7 @@ func initHandleOptions(params paramscmd.Params) []heartbeat.HandleOption {
 			FilePatterns: params.Heartbeat.Sanitize.HideFileNames,
 		}),
 		project.WithDetection(project.Config{
-			ShouldObfuscateProject: heartbeat.ShouldSanitize(
-				params.Heartbeat.Entity, params.Heartbeat.Sanitize.HideProjectNames),
+			HideProjectNames:  params.Heartbeat.Sanitize.HideProjectNames,
 			MapPatterns:       params.Heartbeat.Project.MapPatterns,
 			SubmodulePatterns: params.Heartbeat.Project.DisableSubmodule,
 		}),

--- a/cmd/offline/offline.go
+++ b/cmd/offline/offline.go
@@ -156,8 +156,7 @@ func initHandleOptions(params paramscmd.Params) []heartbeat.HandleOption {
 			FilePatterns: params.Heartbeat.Sanitize.HideFileNames,
 		}),
 		project.WithDetection(project.Config{
-			ShouldObfuscateProject: heartbeat.ShouldSanitize(
-				params.Heartbeat.Entity, params.Heartbeat.Sanitize.HideProjectNames),
+			HideProjectNames:  params.Heartbeat.Sanitize.HideProjectNames,
 			MapPatterns:       params.Heartbeat.Project.MapPatterns,
 			SubmodulePatterns: params.Heartbeat.Project.DisableSubmodule,
 		}),

--- a/pkg/heartbeat/sanitize_internal_test.go
+++ b/pkg/heartbeat/sanitize_internal_test.go
@@ -24,6 +24,11 @@ func TestHideProjectFolder(t *testing.T) {
 			Entity:              "/usr/temp/project/main.go",
 			Expected:            "project/main.go",
 		},
+		"windows path": {
+			ProjectPath: `C:/Users/wakatime/programming/study/learn_flutter`,
+			Entity:      `C:/Users/wakatime/programming/study/learn_flutter/lib/main.dart`,
+			Expected:    `lib/main.dart`,
+		},
 	}
 
 	for name, test := range tests {
@@ -34,7 +39,7 @@ func TestHideProjectFolder(t *testing.T) {
 				ProjectPathOverride: test.ProjectPathOverride,
 			}, true)
 
-			assert.Equal(t, h.Entity, test.Expected)
+			assert.Equal(t, test.Expected, h.Entity)
 		})
 	}
 }

--- a/pkg/project/file.go
+++ b/pkg/project/file.go
@@ -86,7 +86,7 @@ func readFile(fp string, max int) ([]string, error) {
 	return lines, nil
 }
 
-// String returns its name.
-func (File) String() string {
-	return "project-file-detector"
+// ID returns its id.
+func (File) ID() DetectorID {
+	return FileDetector
 }

--- a/pkg/project/file_test.go
+++ b/pkg/project/file_test.go
@@ -143,10 +143,10 @@ func TestFindFileOrDirectory(t *testing.T) {
 	}
 }
 
-func TestFile_String(t *testing.T) {
+func TestFile_ID(t *testing.T) {
 	f := project.File{}
 
-	assert.Equal(t, "project-file-detector", f.String())
+	assert.Equal(t, project.FileDetector, f.ID())
 }
 
 func copyFile(t *testing.T, source, destination string) {

--- a/pkg/project/git.go
+++ b/pkg/project/git.go
@@ -256,7 +256,7 @@ func findGitBranch(fp string) (string, error) {
 	return "", nil
 }
 
-// String returns its name.
-func (Git) String() string {
-	return "git-detector"
+// ID returns its id.
+func (Git) ID() DetectorID {
+	return GitDetector
 }

--- a/pkg/project/map.go
+++ b/pkg/project/map.go
@@ -62,7 +62,7 @@ func matchPattern(fp string, patterns []MapPattern) (string, bool) {
 	return "", false
 }
 
-// String returns its name.
-func (Map) String() string {
-	return "project-map-detector"
+// ID returns its id.
+func (Map) ID() DetectorID {
+	return MapDetector
 }

--- a/pkg/project/map_test.go
+++ b/pkg/project/map_test.go
@@ -107,8 +107,8 @@ func TestMap_Detect_ZeroPatterns(t *testing.T) {
 	assert.False(t, detected)
 }
 
-func TestMap_String(t *testing.T) {
+func TestMap_ID(t *testing.T) {
 	m := project.Map{}
 
-	assert.Equal(t, "project-map-detector", m.String())
+	assert.Equal(t, project.MapDetector, m.ID())
 }

--- a/pkg/project/mercurial.go
+++ b/pkg/project/mercurial.go
@@ -65,7 +65,7 @@ func findHgBranch(fp string) (string, error) {
 	return "default", nil
 }
 
-// String returns its name.
-func (Mercurial) String() string {
-	return "mercurial-detector"
+// ID returns its id.
+func (Mercurial) ID() DetectorID {
+	return MercurialDetector
 }

--- a/pkg/project/mercurial_test.go
+++ b/pkg/project/mercurial_test.go
@@ -68,6 +68,12 @@ func TestMercurial_Detect_NoBranch(t *testing.T) {
 	}, result)
 }
 
+func TestMercurial_ID(t *testing.T) {
+	m := project.Mercurial{}
+
+	assert.Equal(t, project.MercurialDetector, m.ID())
+}
+
 func setupTestMercurial(t *testing.T) (fp string) {
 	tmpDir := t.TempDir()
 

--- a/pkg/project/subversion.go
+++ b/pkg/project/subversion.go
@@ -118,7 +118,7 @@ func resolveSvnInfo(info map[string]string, key string) string {
 	return ""
 }
 
-// String returns its name.
-func (Subversion) String() string {
-	return "svn-detector"
+// ID returns its id.
+func (Subversion) ID() DetectorID {
+	return SubversionDetector
 }

--- a/pkg/project/subversion_test.go
+++ b/pkg/project/subversion_test.go
@@ -52,6 +52,12 @@ func TestSubversion_Detect_Branch(t *testing.T) {
 	}, result)
 }
 
+func TestSubversion_ID(t *testing.T) {
+	s := project.Subversion{}
+
+	assert.Equal(t, project.SubversionDetector, s.ID())
+}
+
 func setupTestSvn(t *testing.T) (fp string) {
 	tmpDir := t.TempDir()
 

--- a/pkg/project/tfvc.go
+++ b/pkg/project/tfvc.go
@@ -39,7 +39,7 @@ func (t Tfvc) Detect() (Result, bool, error) {
 	}, true, nil
 }
 
-// String returns its name.
-func (Tfvc) String() string {
-	return "tfvc-detector"
+// ID returns its id.
+func (Tfvc) ID() DetectorID {
+	return TfvcDetector
 }

--- a/pkg/project/tfvc_test.go
+++ b/pkg/project/tfvc_test.go
@@ -57,6 +57,12 @@ func TestTfvc_Detect_Windows(t *testing.T) {
 	}, result)
 }
 
+func TestTfvc_ID(t *testing.T) {
+	s := project.Tfvc{}
+
+	assert.Equal(t, project.TfvcDetector, s.ID())
+}
+
 func setupTestTfvc(t *testing.T, tfFolderName string) (fp string) {
 	tmpDir := t.TempDir()
 


### PR DESCRIPTION
This PR fixes project path if it was not auto-detected by any rev control or alternate is taken.

Fixes https://github.com/wakatime/jetbrains-wakatime/issues/209.