### PR TITLE
Fix backoff reset

### DIFF
--- a/cmd/params/params.go
+++ b/cmd/params/params.go
@@ -243,7 +243,17 @@ func LoadAPIParams(v *viper.Viper) (API, error) {
 		}
 	}
 
-	backoffRetries, _ := vipertools.FirstNonEmptyInt(v, "internal.backoff_retries")
+	var backoffRetries = 0
+
+	backoffRetriesStr := vipertools.GetString(v, "internal.backoff_retries")
+	if backoffRetriesStr != "" {
+		parsed, err := strconv.Atoi(backoffRetriesStr)
+		if err != nil {
+			log.Warnf("failed to parse backoff_retries: %s", err)
+		} else {
+			backoffRetries = parsed
+		}
+	}
 
 	var (
 		hostname string

--- a/pkg/backoff/backoff_internal_test.go
+++ b/pkg/backoff/backoff_internal_test.go
@@ -15,23 +15,35 @@ import (
 func TestShouldBackoff(t *testing.T) {
 	at := time.Now().Add(time.Second * -1)
 
-	should := shouldBackoff(1, at)
+	should, reset := shouldBackoff(1, at)
 
 	assert.True(t, should)
+	assert.False(t, reset)
 }
 
 func TestShouldBackoff_AfterResetTime(t *testing.T) {
-	at := time.Now().Add((resetAfter + 1) * time.Second)
+	at := time.Now().Add(time.Second * -1)
 
-	should := shouldBackoff(0, at)
+	should, reset := shouldBackoff(8, at)
 
 	assert.False(t, should)
+	assert.True(t, reset)
+}
+
+func TestShouldBackoff_AfterResetTime_ZeroRetries(t *testing.T) {
+	at := time.Now().Add((resetAfter + 1) * time.Second)
+
+	should, reset := shouldBackoff(0, at)
+
+	assert.False(t, should)
+	assert.True(t, reset)
 }
 
 func TestShouldBackoff_NegateBackoff(t *testing.T) {
-	should := shouldBackoff(0, time.Time{})
+	should, reset := shouldBackoff(0, time.Time{})
 
 	assert.False(t, should)
+	assert.True(t, reset)
 }
 
 func TestUpdateBackoffSettings(t *testing.T) {

--- a/pkg/backoff/backoff_test.go
+++ b/pkg/backoff/backoff_test.go
@@ -6,15 +6,15 @@ import (
 	"testing"
 	"time"
 
-	"github.com/spf13/viper"
 	"github.com/wakatime/wakatime-cli/pkg/backoff"
 	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestWithRetry(t *testing.T) {
+func TestWithBackoff(t *testing.T) {
 	v := viper.New()
 
 	tmpFile, err := os.CreateTemp(t.TempDir(), "wakatime")
@@ -22,7 +22,7 @@ func TestWithRetry(t *testing.T) {
 
 	defer tmpFile.Close()
 
-	v.Set("config", tmpFile.Name())
+	v.Set("internal-config", tmpFile.Name())
 
 	opt := backoff.WithBackoff(backoff.Config{
 		V: v,
@@ -40,7 +40,7 @@ func TestWithRetry(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestWithRetry_BeforeNextBackoff(t *testing.T) {
+func TestWithBackoff_BeforeNextBackoff(t *testing.T) {
 	backoffAt := time.Now().Add(time.Second * -1)
 
 	opt := backoff.WithBackoff(backoff.Config{
@@ -62,7 +62,7 @@ func TestWithRetry_BeforeNextBackoff(t *testing.T) {
 	assert.Equal(t, "won't send heartbeat due to backoff", err.Error())
 }
 
-func TestWithRetry_ApiError(t *testing.T) {
+func TestWithBackoff_ApiError(t *testing.T) {
 	v := viper.New()
 
 	tmpFile, err := os.CreateTemp(t.TempDir(), "wakatime")
@@ -70,7 +70,7 @@ func TestWithRetry_ApiError(t *testing.T) {
 
 	defer tmpFile.Close()
 
-	v.Set("config", tmpFile.Name())
+	v.Set("internal-config", tmpFile.Name())
 
 	opt := backoff.WithBackoff(backoff.Config{
 		V: v,


### PR DESCRIPTION
This PR fixes backoff reset not being applied correctly and wrongly showing debug message. In this fix I added to `shouldBackoff` a boolean value indicating wether it should be reset according to current reset amount of 3600 seconds.

First reported [here](https://github.com/wakatime/jetbrains-wakatime/issues/210).