### PR TITLE
Ignore errors when parsing internal config file

### DIFF
--- a/cmd/configwrite/configwrite.go
+++ b/cmd/configwrite/configwrite.go
@@ -20,7 +20,7 @@ type Params struct {
 
 // Run loads wakatime config file and call Write().
 func Run(v *viper.Viper) (int, error) {
-	w, err := ini.NewWriter(v, ini.FilePath)
+	w, err := ini.NewWriter(v, false, ini.FilePath)
 	if err != nil {
 		return exitcode.ErrConfigFileParse, fmt.Errorf(
 			"failed to parse config file: %s",

--- a/cmd/configwrite/configwrite_test.go
+++ b/cmd/configwrite/configwrite_test.go
@@ -73,7 +73,7 @@ func TestWrite(t *testing.T) {
 	defer tmpFile.Close()
 
 	v := viper.New()
-	ini, err := ini.NewWriter(v, func(vp *viper.Viper) (string, error) {
+	ini, err := ini.NewWriter(v, false, func(vp *viper.Viper) (string, error) {
 		assert.Equal(t, v, vp)
 		return tmpFile.Name(), nil
 	})

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -152,7 +152,6 @@ func parseConfigFiles(v *viper.Viper) error {
 	var configFilesFn = []func(v *viper.Viper) (string, error){
 		ini.FilePath,
 		ini.ImportFilePath,
-		ini.InternalFilePath,
 	}
 
 	for _, c := range configFilesFn {
@@ -178,6 +177,27 @@ func parseConfigFiles(v *viper.Viper) error {
 
 			return fmt.Errorf("failed to load configuration file: %s", err)
 		}
+	}
+
+	configFile, err := ini.InternalFilePath(v)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error getting config file path: %s", err)
+
+		return fmt.Errorf("error getting config file path: %s", err)
+	}
+
+	if configFile == "" {
+		return nil
+	}
+
+	// check if file exists
+	if _, err := os.Stat(configFile); os.IsNotExist(err) {
+		log.Debugf("config file %q not present or not accessible", configFile)
+		return nil
+	}
+
+	if err := ini.ReadInConfig(v, configFile); err != nil {
+		log.Debugf("failed to load configuration file: %s", err)
 	}
 
 	return nil

--- a/pkg/backoff/backoff.go
+++ b/pkg/backoff/backoff.go
@@ -104,7 +104,7 @@ func shouldBackoff(retries int, at time.Time) (bool, bool) {
 }
 
 func updateBackoffSettings(v *viper.Viper, retries int, at time.Time) error {
-	w, err := ini.NewWriter(v, ini.InternalFilePath)
+	w, err := ini.NewWriter(v, true, ini.InternalFilePath)
 	if err != nil {
 		return fmt.Errorf("failed to parse config file: %s", err)
 	}

--- a/pkg/backoff/backoff_internal_test.go
+++ b/pkg/backoff/backoff_internal_test.go
@@ -62,7 +62,7 @@ func TestUpdateBackoffSettings(t *testing.T) {
 	err = updateBackoffSettings(v, 2, at)
 	require.NoError(t, err)
 
-	writer, err := ini.NewWriter(v, func(vp *viper.Viper) (string, error) {
+	writer, err := ini.NewWriter(v, false, func(vp *viper.Viper) (string, error) {
 		assert.Equal(t, v, vp)
 		return tmpFile.Name(), nil
 	})
@@ -88,7 +88,7 @@ func TestUpdateBackoffSettings_NotInBackoff(t *testing.T) {
 	err = updateBackoffSettings(v, 0, time.Time{})
 	require.NoError(t, err)
 
-	writer, err := ini.NewWriter(v, func(vp *viper.Viper) (string, error) {
+	writer, err := ini.NewWriter(v, false, func(vp *viper.Viper) (string, error) {
 		assert.Equal(t, v, vp)
 		return tmpFile.Name(), nil
 	})

--- a/pkg/ini/ini.go
+++ b/pkg/ini/ini.go
@@ -42,7 +42,7 @@ type WriterConfig struct {
 }
 
 // NewWriter creates a new writer instance.
-func NewWriter(v *viper.Viper, filepathFn func(v *viper.Viper) (string, error)) (*WriterConfig, error) {
+func NewWriter(v *viper.Viper, force bool, filepathFn func(v *viper.Viper) (string, error)) (*WriterConfig, error) {
 	configFilepath, err := filepathFn(v)
 	if err != nil {
 		return nil, fmt.Errorf("error getting filepath: %s", err)
@@ -61,7 +61,7 @@ func NewWriter(v *viper.Viper, filepathFn func(v *viper.Viper) (string, error)) 
 	}
 
 	ini, err := ini.LoadSources(ini.LoadOptions{AllowPythonMultilineValues: true}, configFilepath)
-	if err != nil {
+	if err != nil && !force {
 		return nil, fmt.Errorf("error loading config file: %s", err)
 	}
 

--- a/pkg/ini/ini_test.go
+++ b/pkg/ini/ini_test.go
@@ -187,7 +187,7 @@ func TestInternalFilePath(t *testing.T) {
 func TestNewWriter(t *testing.T) {
 	v := viper.New()
 
-	w, err := ini.NewWriter(v, func(vp *viper.Viper) (string, error) {
+	w, err := ini.NewWriter(v, false, func(vp *viper.Viper) (string, error) {
 		assert.Equal(t, v, vp)
 		return "testdata/wakatime.cfg", nil
 	})
@@ -200,7 +200,7 @@ func TestNewWriter(t *testing.T) {
 func TestNewWriterErr(t *testing.T) {
 	v := viper.New()
 
-	_, err := ini.NewWriter(v, func(vp *viper.Viper) (string, error) {
+	_, err := ini.NewWriter(v, false, func(vp *viper.Viper) (string, error) {
 		assert.Equal(t, v, vp)
 		return "", errors.New("error")
 	})
@@ -214,7 +214,7 @@ func TestNewWriter_MissingFile(t *testing.T) {
 
 	tmpDir := t.TempDir()
 
-	w, err := ini.NewWriter(v, func(vp *viper.Viper) (string, error) {
+	w, err := ini.NewWriter(v, false, func(vp *viper.Viper) (string, error) {
 		assert.Equal(t, v, vp)
 		return filepath.Join(tmpDir, "missing.cfg"), nil
 	})
@@ -278,7 +278,7 @@ func TestWrite_NoMultilineSideEffects(t *testing.T) {
 
 	copyFile(t, "testdata/wakatime-multiline.cfg", tmpFile.Name())
 
-	w, err := ini.NewWriter(v, func(vp *viper.Viper) (string, error) {
+	w, err := ini.NewWriter(v, false, func(vp *viper.Viper) (string, error) {
 		assert.Equal(t, v, vp)
 		return tmpFile.Name(), nil
 	})
@@ -311,7 +311,7 @@ func TestWrite_NullsRemoved(t *testing.T) {
 
 	copyFile(t, "testdata/wakatime-nulls.cfg", tmpFile.Name())
 
-	w, err := ini.NewWriter(v, func(vp *viper.Viper) (string, error) {
+	w, err := ini.NewWriter(v, false, func(vp *viper.Viper) (string, error) {
 		assert.Equal(t, v, vp)
 		return tmpFile.Name(), nil
 	})


### PR DESCRIPTION
Because the IDE plugins can write to `~/.wakatime-internal.cfg` at the same time as wakatime-cli, the file can become corrupted. This causes the plugin to stop tracking time and exit with a config parsing error. In this case, we want to just discard the internal configs and continue running.