### PR TITLE
Add --alternate-branch flag

### DIFF
--- a/cmd/heartbeat/heartbeat.go
+++ b/cmd/heartbeat/heartbeat.go
@@ -151,6 +151,7 @@ func buildHeartbeats(params paramscmd.Params) []heartbeat.Heartbeat {
 	}
 
 	heartbeats = append(heartbeats, heartbeat.New(
+		params.Heartbeat.Project.BranchAlternate,
 		params.Heartbeat.Category,
 		params.Heartbeat.CursorPosition,
 		params.Heartbeat.Entity,
@@ -174,6 +175,7 @@ func buildHeartbeats(params paramscmd.Params) []heartbeat.Heartbeat {
 
 		for _, h := range params.Heartbeat.ExtraHeartbeats {
 			heartbeats = append(heartbeats, heartbeat.New(
+				h.BranchAlternate,
 				h.Category,
 				h.CursorPosition,
 				h.Entity,

--- a/cmd/offline/offline.go
+++ b/cmd/offline/offline.go
@@ -92,6 +92,7 @@ func buildHeartbeats(params paramscmd.Params) []heartbeat.Heartbeat {
 	}
 
 	heartbeats = append(heartbeats, heartbeat.New(
+		params.Heartbeat.Project.BranchAlternate,
 		params.Heartbeat.Category,
 		params.Heartbeat.CursorPosition,
 		params.Heartbeat.Entity,
@@ -115,6 +116,7 @@ func buildHeartbeats(params paramscmd.Params) []heartbeat.Heartbeat {
 
 		for _, h := range params.Heartbeat.ExtraHeartbeats {
 			heartbeats = append(heartbeats, heartbeat.New(
+				h.BranchAlternate,
 				h.Category,
 				h.CursorPosition,
 				h.Entity,

--- a/cmd/params/params.go
+++ b/cmd/params/params.go
@@ -68,6 +68,7 @@ type (
 
 	// ExtraHeartbeat contains extra heartbeat.
 	ExtraHeartbeat struct {
+		BranchAlternate   string             `json:"alternate_branch"`
 		Category          heartbeat.Category `json:"category"`
 		CursorPosition    interface{}        `json:"cursorpos"`
 		Entity            string             `json:"entity"`
@@ -123,6 +124,7 @@ type (
 
 	// ProjectParams params for project name sanitization.
 	ProjectParams struct {
+		BranchAlternate  string
 		Alternate        string
 		DisableSubmodule []regex.Regex
 		MapPatterns      []project.MapPattern
@@ -574,6 +576,7 @@ func loadProjectParams(v *viper.Viper) (ProjectParams, error) {
 
 	return ProjectParams{
 		Alternate:        vipertools.GetString(v, "alternate-project"),
+		BranchAlternate:  vipertools.GetString(v, "alternate-branch"),
 		DisableSubmodule: disableSubmodule,
 		MapPatterns:      mapPatterns,
 		Override:         vipertools.GetString(v, "project"),
@@ -798,10 +801,12 @@ func parseExtraHeartbeat(h ExtraHeartbeat) (*heartbeat.Heartbeat, error) {
 	}
 
 	return &heartbeat.Heartbeat{
+		BranchAlternate:   h.BranchAlternate,
 		Category:          h.Category,
 		CursorPosition:    cursorPosition,
 		Entity:            h.Entity,
 		EntityType:        entityType,
+		IsUnsavedEntity:   isUnsavedEntity,
 		IsWrite:           isWrite,
 		Language:          h.Language,
 		LanguageAlternate: h.LanguageAlternate,
@@ -810,7 +815,6 @@ func parseExtraHeartbeat(h ExtraHeartbeat) (*heartbeat.Heartbeat, error) {
 		ProjectAlternate:  h.ProjectAlternate,
 		ProjectOverride:   h.Project,
 		Time:              timestampParsed,
-		IsUnsavedEntity:   isUnsavedEntity,
 	}, nil
 }
 
@@ -860,8 +864,8 @@ func (p API) String() string {
 
 	return fmt.Sprintf(
 		"api key: '%s', api url: '%s', backoff at: '%s', backoff retries: %d,"+
-			" hostname: '%s', key patterns: '%s', plugin: '%s', timeout: %s,"+
-			" disable ssl verify: %t, proxy url: '%s', ssl cert filepath: '%s'",
+			" hostname: '%s', key patterns: '%s', plugin: '%s', proxy url: '%s',"+
+			" timeout: %s, disable ssl verify: %t, ssl cert filepath: '%s'",
 		apiKey,
 		p.URL,
 		backoffAt,
@@ -869,9 +873,9 @@ func (p API) String() string {
 		p.Hostname,
 		keyPatterns,
 		p.Plugin,
+		p.ProxyURL,
 		p.Timeout,
 		p.DisableSSLVerify,
-		p.ProxyURL,
 		p.SSLCertFilepath,
 	)
 }
@@ -937,8 +941,9 @@ func (p Heartbeat) String() string {
 // String implements fmt.Stringer interface.
 func (p Offline) String() string {
 	return fmt.Sprintf(
-		"disabled: %t, queue file: '%s', num sync max: %d",
+		"disabled: %t, print max: %d, queue file: '%s', num sync max: %d",
 		p.Disabled,
+		p.PrintMax,
 		p.QueueFile,
 		p.SyncMax,
 	)
@@ -957,8 +962,9 @@ func (p Params) String() string {
 
 func (p ProjectParams) String() string {
 	return fmt.Sprintf(
-		"alternate: '%s', disable submodule: '%s', map patterns: '%s', override: '%s'",
+		"alternate: '%s', branch alternate: '%s', disable submodule: '%s', map patterns: '%s', override: '%s'",
 		p.Alternate,
+		p.BranchAlternate,
 		p.DisableSubmodule,
 		p.MapPatterns,
 		p.Override,

--- a/cmd/params/params_test.go
+++ b/cmd/params/params_test.go
@@ -1932,3 +1932,140 @@ func TestLoadParams_Hostname_DefaultFromSystem(t *testing.T) {
 
 	assert.Equal(t, expected, params.Hostname)
 }
+
+func TestAPI_String(t *testing.T) {
+	backoffat, err := time.Parse(inipkg.DateFormat, "2021-08-30T18:50:42-03:00")
+	require.NoError(t, err)
+
+	api := paramscmd.API{
+		BackoffAt:        backoffat,
+		BackoffRetries:   5,
+		DisableSSLVerify: true,
+		Hostname:         "my-machine",
+		Key:              "00000000-0000-4000-8000-000000000000",
+		KeyPatterns: []apikey.MapPattern{
+			{
+				ApiKey: "00000000-0000-4000-8000-000000000001",
+				Regex:  regex.MustCompile("^/api/v1/"),
+			},
+		},
+		Plugin:          "my-plugin",
+		ProxyURL:        "https://example.org:23",
+		SSLCertFilepath: "/path/to/cert.pem",
+		Timeout:         time.Second * 10,
+		URL:             "https://example.org:23",
+	}
+
+	assert.Equal(
+		t,
+		"api key: '<hidden>0000', api url: 'https://example.org:23', backoff at: '2021-08-30T18:50:42-03:00',"+
+			" backoff retries: 5, hostname: 'my-machine', key patterns: '[{<hidden>0001 ^/api/v1/}]', plugin: 'my-plugin',"+
+			" proxy url: 'https://example.org:23', timeout: 10s, disable ssl verify: true,"+
+			" ssl cert filepath: '/path/to/cert.pem'",
+		api.String(),
+	)
+}
+
+func TestFilterParams_String(t *testing.T) {
+	filterparams := paramscmd.FilterParams{
+		Exclude:                    []regex.Regex{regex.MustCompile("^/exclude")},
+		ExcludeUnknownProject:      true,
+		Include:                    []regex.Regex{regex.MustCompile("^/include")},
+		IncludeOnlyWithProjectFile: true,
+	}
+
+	assert.Equal(
+		t,
+		"exclude: '[^/exclude]', exclude unknown project: true, include: '[^/include]',"+
+			" include only with project file: true",
+		filterparams.String(),
+	)
+}
+
+func TestHeartbeat_String(t *testing.T) {
+	heartbeat := paramscmd.Heartbeat{
+		Category:        heartbeat.CodingCategory,
+		CursorPosition:  heartbeat.PointerTo(15),
+		Entity:          "path/to/entity.go",
+		EntityType:      heartbeat.FileType,
+		ExtraHeartbeats: make([]heartbeat.Heartbeat, 3),
+		IsUnsavedEntity: true,
+		IsWrite:         heartbeat.PointerTo(true),
+		Language:        heartbeat.PointerTo("Golang"),
+		LineNumber:      heartbeat.PointerTo(4),
+		LinesInFile:     heartbeat.PointerTo(56),
+		Time:            1585598059,
+	}
+
+	assert.Equal(
+		t,
+		"category: 'coding', cursor position: '15', entity: 'path/to/entity.go', entity type: 'file',"+
+			" num extra heartbeats: 3, is unsaved entity: true, is write: true, language: 'Golang', line number: '4',"+
+			" lines in file: '56', time: 1585598059.00000, filter params: (exclude: '[]', exclude unknown project: false,"+
+			" include: '[]', include only with project file: false), project params: (alternate: '', branch alternate: '',"+
+			" disable submodule: '[]', map patterns: '[]', override: ''), sanitize params: (hide branch names: '[]',"+
+			" hide project folder: false, hide file names: '[]', hide project names: '[]', project path override: '')",
+		heartbeat.String(),
+	)
+}
+
+func TestOffline_String(t *testing.T) {
+	offline := paramscmd.Offline{
+		Disabled:  true,
+		PrintMax:  6,
+		QueueFile: "/path/to/queue.file",
+		SyncMax:   12,
+	}
+
+	assert.Equal(
+		t,
+		"disabled: true, print max: 6, queue file: '/path/to/queue.file', num sync max: 12",
+		offline.String(),
+	)
+}
+
+func TestProjectParams_String(t *testing.T) {
+	projectparams := paramscmd.ProjectParams{
+		Alternate:        "alternate",
+		BranchAlternate:  "branch-alternate",
+		DisableSubmodule: []regex.Regex{regexp.MustCompile(".*")},
+		MapPatterns:      []project.MapPattern{{Name: "project-1", Regex: regex.MustCompile("^/regex")}},
+		Override:         "override",
+	}
+
+	assert.Equal(
+		t,
+		"alternate: 'alternate', branch alternate: 'branch-alternate', disable submodule: '[.*]',"+
+			" map patterns: '[{project-1 ^/regex}]', override: 'override'",
+		projectparams.String(),
+	)
+}
+
+func TestSanitizeParams_String(t *testing.T) {
+	sanitizeparams := paramscmd.SanitizeParams{
+		HideBranchNames:     []regex.Regex{regex.MustCompile("^/hide")},
+		HideProjectFolder:   true,
+		HideFileNames:       []regex.Regex{regex.MustCompile("^/hide")},
+		HideProjectNames:    []regex.Regex{regex.MustCompile("^/hide")},
+		ProjectPathOverride: "path/to/project",
+	}
+
+	assert.Equal(
+		t,
+		"hide branch names: '[^/hide]', hide project folder: true, hide file names: '[^/hide]',"+
+			" hide project names: '[^/hide]', project path override: 'path/to/project'",
+		sanitizeparams.String(),
+	)
+}
+
+func TestStatusBar_String(t *testing.T) {
+	statusbar := paramscmd.StatusBar{
+		HideCategories: true,
+	}
+
+	assert.Equal(
+		t,
+		"hide categories: true",
+		statusbar.String(),
+	)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,6 +38,7 @@ func NewRootCMD() *cobra.Command {
 
 func setFlags(cmd *cobra.Command, v *viper.Viper) {
 	flags := cmd.Flags()
+	flags.String("alternate-branch", "", "Optional alternate branch name. Auto-detected branch takes priority.")
 	flags.String("alternate-language", "", "Optional alternate language name. Auto-detected language takes priority.")
 	flags.String("alternate-project", "", "Optional alternate project name. Auto-detected project takes priority.")
 	flags.String(

--- a/pkg/heartbeat/heartbeat.go
+++ b/pkg/heartbeat/heartbeat.go
@@ -16,6 +16,7 @@ import (
 type Heartbeat struct {
 	ApiKey              string     `json:"-"`
 	Branch              *string    `json:"branch"`
+	BranchAlternate     string     `json:"-"`
 	Category            Category   `json:"category"`
 	CursorPosition      *int       `json:"cursorpos"`
 	Dependencies        []string   `json:"dependencies"`
@@ -41,6 +42,7 @@ type Heartbeat struct {
 // New creates a new instance of Heartbeat with formatted entity
 // and local file paths for file type heartbeats.
 func New(
+	branchAlternate string,
 	category Category,
 	cursorPosition *int,
 	entity string,
@@ -59,6 +61,7 @@ func New(
 	userAgent string,
 ) Heartbeat {
 	return Heartbeat{
+		BranchAlternate:     branchAlternate,
 		Category:            category,
 		CursorPosition:      cursorPosition,
 		Entity:              entity,

--- a/pkg/heartbeat/heartbeat_test.go
+++ b/pkg/heartbeat/heartbeat_test.go
@@ -19,6 +19,7 @@ import (
 
 func TestNew(t *testing.T) {
 	h := heartbeat.New(
+		"feature/branch",
 		heartbeat.CodingCategory,
 		heartbeat.PointerTo(12),
 		"testdata/main.go",
@@ -40,6 +41,7 @@ func TestNew(t *testing.T) {
 	assert.True(t, strings.HasSuffix(h.Entity, "testdata/main.go"))
 
 	assert.Equal(t, heartbeat.Heartbeat{
+		BranchAlternate:     "feature/branch",
 		Category:            heartbeat.CodingCategory,
 		CursorPosition:      heartbeat.PointerTo(12),
 		EntityType:          heartbeat.FileType,
@@ -83,20 +85,19 @@ func TestHeartbeat_ID_NilFields(t *testing.T) {
 
 func TestHeartbeat_JSON(t *testing.T) {
 	h := heartbeat.Heartbeat{
-		Branch:            heartbeat.PointerTo("heartbeat"),
-		Category:          heartbeat.CodingCategory,
-		CursorPosition:    heartbeat.PointerTo(12),
-		Dependencies:      []string{"dep1", "dep2"},
-		Entity:            "/tmp/main.go",
-		EntityType:        heartbeat.FileType,
-		IsWrite:           heartbeat.PointerTo(true),
-		Language:          heartbeat.PointerTo("Go"),
-		LanguageAlternate: "Golang",
-		LineNumber:        heartbeat.PointerTo(42),
-		Lines:             heartbeat.PointerTo(100),
-		Project:           heartbeat.PointerTo("wakatime"),
-		Time:              1585598060.1,
-		UserAgent:         "wakatime/13.0.7",
+		Branch:         heartbeat.PointerTo("heartbeat"),
+		Category:       heartbeat.CodingCategory,
+		CursorPosition: heartbeat.PointerTo(12),
+		Dependencies:   []string{"dep1", "dep2"},
+		Entity:         "/tmp/main.go",
+		EntityType:     heartbeat.FileType,
+		IsWrite:        heartbeat.PointerTo(true),
+		Language:       heartbeat.PointerTo("Go"),
+		LineNumber:     heartbeat.PointerTo(42),
+		Lines:          heartbeat.PointerTo(100),
+		Project:        heartbeat.PointerTo("wakatime"),
+		Time:           1585598060.1,
+		UserAgent:      "wakatime/13.0.7",
 	}
 
 	jsonEncoded, err := json.Marshal(h)

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -159,10 +159,15 @@ func WithDetection(config Config) heartbeat.HandleOption {
 					result.Folder = firstNonEmptyString(h.ProjectPathOverride, result.Folder)
 				}
 
-				// fifth, use project folder found or entity's path
+				// fifth, use alternate branch
+				if result.Branch == "" && h.BranchAlternate != "" {
+					result.Branch = h.BranchAlternate
+				}
+
+				// sixth, use project folder found or entity's path
 				result.Folder = firstNonEmptyString(result.Folder, h.ProjectPathOverride)
 
-				// sixth, if no folder is found, use entity's directory
+				// seventh, if no folder is found, use entity's directory
 				if h.EntityType == heartbeat.FileType && result.Folder == "" {
 					result.Folder = filepath.Dir(h.Entity)
 				}

--- a/pkg/project/project_test.go
+++ b/pkg/project/project_test.go
@@ -262,12 +262,13 @@ func TestWithDetection_NoneDetected_AlternateTakesPrecedence(t *testing.T) {
 	handle := opt(func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
 		assert.Equal(t, []heartbeat.Heartbeat{
 			{
-				Branch:           heartbeat.PointerTo(""),
+				Branch:           heartbeat.PointerTo("alternate-branch"),
+				BranchAlternate:  "alternate-branch",
 				Entity:           tmpFile.Name(),
 				EntityType:       heartbeat.FileType,
-				Project:          heartbeat.PointerTo("alternate"),
+				Project:          heartbeat.PointerTo("alternate-project"),
 				ProjectPath:      projectPath,
-				ProjectAlternate: "alternate",
+				ProjectAlternate: "alternate-project",
 			},
 		}, hh)
 
@@ -276,9 +277,10 @@ func TestWithDetection_NoneDetected_AlternateTakesPrecedence(t *testing.T) {
 
 	_, err = handle([]heartbeat.Heartbeat{
 		{
+			BranchAlternate:  "alternate-branch",
 			EntityType:       heartbeat.FileType,
 			Entity:           tmpFile.Name(),
-			ProjectAlternate: "alternate",
+			ProjectAlternate: "alternate-project",
 		},
 	})
 	require.NoError(t, err)


### PR DESCRIPTION
This PR adds `--alternate-branch` flag. It also adds missing tests for String funcs inside params package.

Closes https://github.com/wakatime/wakatime-cli/issues/735

First reported here https://github.com/wakatime/jetbrains-wakatime/issues/80