### PR TITLE
Skip unreconizable lines only for internal file

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,7 +19,6 @@ const defaultConfigSection = "settings"
 func NewRootCMD() *cobra.Command {
 	iniOption := viper.IniLoadOptions(ini.LoadOptions{
 		AllowPythonMultilineValues: true,
-		SkipUnrecognizableLines:    true,
 	})
 	v := viper.NewWithOptions(iniOption)
 


### PR DESCRIPTION
This PR sets skipping unreconizable lines **true** only for internal config file and allow the main one to fail if necessary. We also no longer need to call `fmt.Fprintf(os.Stderr, "....")` from `parseConfigFiles` since logging is being set before calling it.