### PR TITLE
Backoff exit code 112 to prevent sending diagnostics when rate limited

### DIFF
--- a/cmd/heartbeat/heartbeat.go
+++ b/cmd/heartbeat/heartbeat.go
@@ -50,6 +50,14 @@ func Run(v *viper.Viper) (int, error) {
 			)
 		}
 
+		var errBackoff api.ErrBackoff
+		if errors.As(err, &errBackoff) {
+			return exitcode.ErrBackoff, fmt.Errorf(
+				"sending heartbeat(s) later because currently rate limited: %w",
+				err,
+			)
+		}
+
 		var errapi api.Err
 		if errors.As(err, &errapi) {
 			return exitcode.ErrAPI, fmt.Errorf(

--- a/cmd/offlinesync/offlinesync.go
+++ b/cmd/offlinesync/offlinesync.go
@@ -27,6 +27,7 @@ func Run(v *viper.Viper) (int, error) {
 	}
 
 	err = SyncOfflineActivity(v, queueFilepath)
+	// nolint:nestif
 	if err != nil {
 		var errauth api.ErrAuth
 		if errors.As(err, &errauth) {
@@ -40,6 +41,14 @@ func Run(v *viper.Viper) (int, error) {
 		if errors.As(err, &errbadRequest) {
 			return exitcode.ErrGeneric, fmt.Errorf(
 				"offline sync failed: bad request: %s",
+				err,
+			)
+		}
+
+		var errBackoff api.ErrBackoff
+		if errors.As(err, &errBackoff) {
+			return exitcode.ErrBackoff, fmt.Errorf(
+				"offline sync failed: rate limited: %s",
 				err,
 			)
 		}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -277,7 +277,7 @@ func runCmd(v *viper.Viper, verbose bool, cmd cmdFn) int {
 
 		resetLogs()
 
-		if exitCode != exitcode.ErrAuth && verbose {
+		if exitCode != exitcode.ErrAuth && exitCode != exitcode.ErrBackoff && verbose {
 			if err := sendDiagnostics(v, logs.String(), string(debug.Stack())); err != nil {
 				log.Warnf("failed to send diagnostics: %s", err)
 			}

--- a/cmd/today/today.go
+++ b/cmd/today/today.go
@@ -34,6 +34,14 @@ func Run(v *viper.Viper) (int, error) {
 			)
 		}
 
+		var errBackoff api.ErrBackoff
+		if errors.As(err, &errBackoff) {
+			return exitcode.ErrBackoff, fmt.Errorf(
+				"today fetch failed: rate limited: %s",
+				err,
+			)
+		}
+
 		var errbadRequest api.ErrBadRequest
 		if errors.As(err, &errbadRequest) {
 			return exitcode.ErrGeneric, fmt.Errorf(

--- a/cmd/todaygoal/todaygoal.go
+++ b/cmd/todaygoal/todaygoal.go
@@ -43,6 +43,14 @@ func Run(v *viper.Viper) (int, error) {
 			)
 		}
 
+		var errBackoff api.ErrBackoff
+		if errors.As(err, &errBackoff) {
+			return exitcode.ErrBackoff, fmt.Errorf(
+				"today goal fetch failed: rate limited: %s",
+				err,
+			)
+		}
+
 		var errapi api.Err
 		if errors.As(err, &errapi) {
 			return exitcode.ErrAPI, fmt.Errorf(

--- a/pkg/api/error.go
+++ b/pkg/api/error.go
@@ -23,3 +23,11 @@ type ErrBadRequest string
 func (e ErrBadRequest) Error() string {
 	return string(e)
 }
+
+// ErrBackoff means we send later because currently rate limited.
+type ErrBackoff string
+
+// Error method to implement error interface.
+func (e ErrBackoff) Error() string {
+	return string(e)
+}

--- a/pkg/backoff/backoff.go
+++ b/pkg/backoff/backoff.go
@@ -41,7 +41,7 @@ func WithBackoff(config Config) heartbeat.HandleOption {
 
 			should, reset := shouldBackoff(config.Retries, config.At)
 			if should {
-				return nil, api.Err("won't send heartbeat due to backoff")
+				return nil, api.ErrBackoff("won't send heartbeat due to backoff")
 			}
 
 			if reset {

--- a/pkg/exitcode/exitcode.go
+++ b/pkg/exitcode/exitcode.go
@@ -15,4 +15,6 @@ const (
 	ErrConfigFileRead = 110
 	// ErrConfigFileWrite is used for errors of config write command.
 	ErrConfigFileWrite = 111
+	// ErrBackoff is used when sending heartbeats postponed because we're currently rate limited.
+	ErrBackoff = 112
 )


### PR DESCRIPTION
We should skip sending diagnostics for expected errors, such as being rate limited.