### PR TITLE
Improve error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ build/
 vendor/
 
 .DS_Store
+.vscode/launch.json

--- a/cmd/logfile/error.go
+++ b/cmd/logfile/error.go
@@ -1,9 +1,0 @@
-package logfile
-
-// ErrLogFile handles a custom error for setting log file.
-type ErrLogFile string
-
-// Error implements error interface.
-func (e ErrLogFile) Error() string {
-	return string(e)
-}

--- a/cmd/logfile/logfile.go
+++ b/cmd/logfile/logfile.go
@@ -36,8 +36,7 @@ func LoadParams(v *viper.Viper) (Params, error) {
 	if ok {
 		p, err := homedir.Expand(logFile)
 		if err != nil {
-			return Params{},
-				ErrLogFile(fmt.Sprintf("failed expanding log file: %s", err))
+			return Params{}, fmt.Errorf("failed expanding log file: %s", err)
 		}
 
 		params.File = p

--- a/cmd/offlinesync/error.go
+++ b/cmd/offlinesync/error.go
@@ -1,9 +1,26 @@
 package offlinesync
 
+import (
+	"github.com/wakatime/wakatime-cli/pkg/exitcode"
+	"github.com/wakatime/wakatime-cli/pkg/wakaerror"
+)
+
 // ErrSyncDisabled represents when sync is disabled.
-type ErrSyncDisabled string
+type ErrSyncDisabled struct{}
+
+var _ wakaerror.Error = ErrSyncDisabled{}
 
 // Error method to implement error interface.
 func (e ErrSyncDisabled) Error() string {
-	return string(e)
+	return e.Message()
+}
+
+// ExitCode method to implement wakaerror.Error interface.
+func (ErrSyncDisabled) ExitCode() int {
+	return exitcode.Success
+}
+
+// Message method to implement wakaerror.Error interface.
+func (ErrSyncDisabled) Message() string {
+	return "sync offline activity is disabled"
 }

--- a/cmd/params/params.go
+++ b/cmd/params/params.go
@@ -183,11 +183,11 @@ func Load(v *viper.Viper) (Params, error) {
 func LoadAPIParams(v *viper.Viper) (API, error) {
 	apiKey, ok := vipertools.FirstNonEmptyString(v, "key", "settings.api_key", "settings.apikey")
 	if !ok {
-		return API{}, api.ErrAuth("failed to load api key")
+		return API{}, api.ErrAuth{Err: errors.New("failed to load api key")}
 	}
 
 	if !apiKeyRegex.MatchString(apiKey) {
-		return API{}, api.ErrAuth("invalid api key format")
+		return API{}, api.ErrAuth{Err: errors.New("invalid api key format")}
 	}
 
 	var apiKeyPatterns []apikey.MapPattern
@@ -207,7 +207,7 @@ func LoadAPIParams(v *viper.Viper) (API, error) {
 		}
 
 		if !apiKeyRegex.MatchString(s) {
-			return API{}, api.ErrAuth(fmt.Sprintf("invalid api key format for %q", k))
+			return API{}, api.ErrAuth{Err: fmt.Errorf("invalid api key format for %q", k)}
 		}
 
 		if s == apiKey {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -273,7 +273,7 @@ func runCmd(v *viper.Viper, verbose bool, cmd cmdFn) int {
 	// run command
 	exitCode, err := cmd(v)
 	if err != nil {
-		log.Errorf("failed to run command: %s", err.Error())
+		log.Errorf("failed to run command: %s", err)
 
 		resetLogs()
 

--- a/cmd/run_internal_test.go
+++ b/cmd/run_internal_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 
 	"github.com/wakatime/wakatime-cli/pkg/exitcode"
-	"github.com/wakatime/wakatime-cli/pkg/offline"
 	"github.com/wakatime/wakatime-cli/pkg/version"
 
 	"github.com/spf13/viper"
@@ -90,7 +89,7 @@ func TestRunCmd_ErrOfflineEnqueue(t *testing.T) {
 	v.Set("plugin", "vim")
 
 	ret := runCmd(v, true, func(v *viper.Viper) (int, error) {
-		return exitcode.ErrGeneric, offline.ErrOfflineEnqueue("fail")
+		return exitcode.ErrGeneric, errors.New("fail")
 	})
 
 	assert.Equal(t, exitcode.ErrGeneric, ret)

--- a/main_test.go
+++ b/main_test.go
@@ -23,10 +23,10 @@ import (
 	"github.com/wakatime/wakatime-cli/pkg/offline"
 	"github.com/wakatime/wakatime-cli/pkg/version"
 	"github.com/wakatime/wakatime-cli/pkg/windows"
+	"github.com/yookoala/realpath"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/yookoala/realpath"
 )
 
 // nolint:gochecknoinits
@@ -98,10 +98,10 @@ func testSendHeartbeats(t *testing.T, entity, project string) {
 
 	defer offlineQueueFile.Close()
 
-	tmpFile, err := os.CreateTemp(tmpDir, "wakatime.cfg")
+	tmpConfigFile, err := os.CreateTemp(tmpDir, "wakatime.cfg")
 	require.NoError(t, err)
 
-	defer tmpFile.Close()
+	defer tmpConfigFile.Close()
 
 	tmpInternalConfigFile, err := os.CreateTemp(tmpDir, "wakatime-internal.cfg")
 	require.NoError(t, err)
@@ -113,7 +113,7 @@ func testSendHeartbeats(t *testing.T, entity, project string) {
 		&bytes.Buffer{},
 		"--api-url", apiURL,
 		"--key", "00000000-0000-4000-8000-000000000000",
-		"--config", tmpFile.Name(),
+		"--config", tmpConfigFile.Name(),
 		"--internal-config", tmpInternalConfigFile.Name(),
 		"--entity", entity,
 		"--cursorpos", "12",
@@ -241,10 +241,10 @@ func TestSendHeartbeats_ExtraHeartbeats(t *testing.T) {
 
 	defer offlineQueueFile.Close()
 
-	tmpFile, err := os.CreateTemp(tmpDir, "wakatime.cfg")
+	tmpConfigFile, err := os.CreateTemp(tmpDir, "wakatime.cfg")
 	require.NoError(t, err)
 
-	defer tmpFile.Close()
+	defer tmpConfigFile.Close()
 
 	tmpInternalConfigFile, err := os.CreateTemp(tmpDir, "wakatime-internal.cfg")
 	require.NoError(t, err)
@@ -261,7 +261,7 @@ func TestSendHeartbeats_ExtraHeartbeats(t *testing.T) {
 		buffer,
 		"--api-url", apiURL,
 		"--key", "00000000-0000-4000-8000-000000000000",
-		"--config", tmpFile.Name(),
+		"--config", tmpConfigFile.Name(),
 		"--internal-config", tmpInternalConfigFile.Name(),
 		"--entity", "testdata/main.go",
 		"--extra-heartbeats", "true",
@@ -333,10 +333,10 @@ func TestSendHeartbeats_Err(t *testing.T) {
 
 	defer offlineQueueFile.Close()
 
-	tmpFile, err := os.CreateTemp(tmpDir, "wakatime.cfg")
+	tmpConfigFile, err := os.CreateTemp(tmpDir, "wakatime.cfg")
 	require.NoError(t, err)
 
-	defer tmpFile.Close()
+	defer tmpConfigFile.Close()
 
 	tmpInternalConfigFile, err := os.CreateTemp(tmpDir, "wakatime-internal.cfg")
 	require.NoError(t, err)
@@ -348,7 +348,7 @@ func TestSendHeartbeats_Err(t *testing.T) {
 		exitcode.ErrAPI,
 		"--api-url", apiURL,
 		"--key", "00000000-0000-4000-8000-000000000000",
-		"--config", tmpFile.Name(),
+		"--config", tmpConfigFile.Name(),
 		"--internal-config", tmpInternalConfigFile.Name(),
 		"--entity", "testdata/main.go",
 		"--cursorpos", "12",
@@ -370,10 +370,10 @@ func TestSendHeartbeats_Err(t *testing.T) {
 func TestSendHeartbeats_MalformedConfig(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	tmpFile, err := os.CreateTemp(tmpDir, "wakatime-internal.cfg")
+	tmpInternalConfigFile, err := os.CreateTemp(tmpDir, "wakatime-internal.cfg")
 	require.NoError(t, err)
 
-	defer tmpFile.Close()
+	defer tmpInternalConfigFile.Close()
 
 	offlineQueueFile, err := os.CreateTemp(tmpDir, "")
 	require.NoError(t, err)
@@ -385,7 +385,7 @@ func TestSendHeartbeats_MalformedConfig(t *testing.T) {
 		exitcode.ErrConfigFileParse,
 		"--entity", "testdata/main.go",
 		"--config", "./testdata/malformed.cfg",
-		"--internal-config", tmpFile.Name(),
+		"--internal-config", tmpInternalConfigFile.Name(),
 		"--offline-queue-file", offlineQueueFile.Name(),
 		"--verbose",
 	)
@@ -406,16 +406,16 @@ func TestSendHeartbeats_MalformedInternalConfig(t *testing.T) {
 
 	defer offlineQueueFile.Close()
 
-	tmpFile, err := os.CreateTemp(tmpDir, "wakatime.cfg")
+	tmpConfigFile, err := os.CreateTemp(tmpDir, "wakatime.cfg")
 	require.NoError(t, err)
 
-	defer tmpFile.Close()
+	defer tmpConfigFile.Close()
 
 	out := runWakatimeCliExpectErr(
 		t,
 		exitcode.ErrConfigFileParse,
 		"--entity", "testdata/main.go",
-		"--config", tmpFile.Name(),
+		"--config", tmpConfigFile.Name(),
 		"--internal-config", "./testdata/internal-malformed.cfg",
 		"--offline-queue-file", offlineQueueFile.Name(),
 		"--verbose",
@@ -437,10 +437,10 @@ func TestTodayGoal(t *testing.T) {
 
 	tmpDir := t.TempDir()
 
-	tmpFile, err := os.CreateTemp(tmpDir, "wakatime.cfg")
+	tmpConfigFile, err := os.CreateTemp(tmpDir, "wakatime.cfg")
 	require.NoError(t, err)
 
-	defer tmpFile.Close()
+	defer tmpConfigFile.Close()
 
 	tmpInternalConfigFile, err := os.CreateTemp(tmpDir, "wakatime-internal.cfg")
 	require.NoError(t, err)
@@ -471,7 +471,7 @@ func TestTodayGoal(t *testing.T) {
 		&bytes.Buffer{},
 		"--api-url", apiURL,
 		"--key", "00000000-0000-4000-8000-000000000000",
-		"--config", tmpFile.Name(),
+		"--config", tmpConfigFile.Name(),
 		"--internal-config", tmpInternalConfigFile.Name(),
 		"--today-goal", "11111111-1111-4111-8111-111111111111",
 		"--verbose",
@@ -490,10 +490,10 @@ func TestTodaySummary(t *testing.T) {
 
 	tmpDir := t.TempDir()
 
-	tmpFile, err := os.CreateTemp(tmpDir, "wakatime.cfg")
+	tmpConfigFile, err := os.CreateTemp(tmpDir, "wakatime.cfg")
 	require.NoError(t, err)
 
-	defer tmpFile.Close()
+	defer tmpConfigFile.Close()
 
 	tmpInternalConfigFile, err := os.CreateTemp(tmpDir, "wakatime-internal.cfg")
 	require.NoError(t, err)
@@ -523,7 +523,7 @@ func TestTodaySummary(t *testing.T) {
 		&bytes.Buffer{},
 		"--api-url", apiURL,
 		"--key", "00000000-0000-4000-8000-000000000000",
-		"--config", tmpFile.Name(),
+		"--config", tmpConfigFile.Name(),
 		"--internal-config", tmpInternalConfigFile.Name(),
 		"--today",
 		"--verbose",
@@ -551,10 +551,10 @@ func TestOfflineCount(t *testing.T) {
 
 	defer offlineQueueFile.Close()
 
-	tmpFile, err := os.CreateTemp(tmpDir, "wakatime.cfg")
+	tmpConfigFile, err := os.CreateTemp(tmpDir, "wakatime.cfg")
 	require.NoError(t, err)
 
-	defer tmpFile.Close()
+	defer tmpConfigFile.Close()
 
 	tmpInternalConfigFile, err := os.CreateTemp(tmpDir, "wakatime-internal.cfg")
 	require.NoError(t, err)
@@ -566,7 +566,7 @@ func TestOfflineCount(t *testing.T) {
 		exitcode.ErrAPI,
 		"--api-url", apiURL,
 		"--key", "00000000-0000-4000-8000-000000000000",
-		"--config", tmpFile.Name(),
+		"--config", tmpConfigFile.Name(),
 		"--internal-config", tmpInternalConfigFile.Name(),
 		"--entity", "testdata/main.go",
 		"--cursorpos", "12",
@@ -585,7 +585,7 @@ func TestOfflineCount(t *testing.T) {
 		t,
 		&bytes.Buffer{},
 		"--key", "00000000-0000-4000-8000-000000000000",
-		"--config", tmpFile.Name(),
+		"--config", tmpConfigFile.Name(),
 		"--internal-config", tmpInternalConfigFile.Name(),
 		"--offline-queue-file", offlineQueueFile.Name(),
 		"--offline-count",
@@ -630,17 +630,23 @@ func TestPrintOfflineHeartbeats(t *testing.T) {
 
 	defer offlineQueueFile.Close()
 
-	tmpFile, err := os.CreateTemp(tmpDir, "wakatime.cfg")
+	tmpConfigFile, err := os.CreateTemp(tmpDir, "wakatime.cfg")
 	require.NoError(t, err)
 
-	defer tmpFile.Close()
+	defer tmpConfigFile.Close()
+
+	tmpInternalConfigFile, err := os.CreateTemp(tmpDir, "wakatime-internal.cfg")
+	require.NoError(t, err)
+
+	defer tmpInternalConfigFile.Close()
 
 	out := runWakatimeCliExpectErr(
 		t,
 		exitcode.ErrAPI,
 		"--api-url", apiURL,
 		"--key", "00000000-0000-4000-8000-000000000000",
-		"--config", tmpFile.Name(),
+		"--config", tmpConfigFile.Name(),
+		"--internal-config", tmpInternalConfigFile.Name(),
 		"--entity", "testdata/main.go",
 		"--cursorpos", "12",
 		"--offline-queue-file", offlineQueueFile.Name(),

--- a/pkg/api/diagnostic.go
+++ b/pkg/api/diagnostic.go
@@ -59,23 +59,23 @@ func (c *Client) SendDiagnostics(plugin string, diagnostics ...diagnostic.Diagno
 
 	resp, err := c.Do(req)
 	if err != nil {
-		return Err(fmt.Sprintf("failed making request to %q: %s", url, err))
+		return Err{Err: fmt.Errorf("failed making request to %q: %s", url, err)}
 	}
 	defer resp.Body.Close()
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return Err(fmt.Sprintf("failed reading response body from %q: %s", url, err))
+		return Err{Err: fmt.Errorf("failed reading response body from %q: %s", url, err)}
 	}
 
 	if resp.StatusCode != http.StatusCreated {
-		return Err(fmt.Sprintf(
+		return Err{Err: fmt.Errorf(
 			"invalid response status from %q. got: %d, want: %d. body: %q",
 			url,
 			resp.StatusCode,
 			http.StatusCreated,
 			string(respBody),
-		))
+		)}
 	}
 
 	return nil

--- a/pkg/api/error.go
+++ b/pkg/api/error.go
@@ -1,33 +1,96 @@
 package api
 
+import (
+	"fmt"
+
+	"github.com/wakatime/wakatime-cli/pkg/exitcode"
+	"github.com/wakatime/wakatime-cli/pkg/wakaerror"
+)
+
 // Err represents a general api error.
-type Err string
+type Err struct {
+	Err error
+}
+
+var _ wakaerror.Error = Err{}
 
 // Error method to implement error interface.
 func (e Err) Error() string {
-	return string(e)
+	return string(e.Err.Error())
+}
+
+// ExitCode method to implement wakaerror.Error interface.
+func (Err) ExitCode() int {
+	return exitcode.ErrAPI
+}
+
+// Message method to implement wakaerror.Error interface.
+func (e Err) Message() string {
+	return fmt.Sprintf("api error: %s", e.Err)
 }
 
 // ErrAuth represents an authentication error.
-type ErrAuth string
+type ErrAuth struct {
+	Err error
+}
+
+var _ wakaerror.Error = ErrAuth{}
 
 // Error method to implement error interface.
 func (e ErrAuth) Error() string {
-	return string(e)
+	return string(e.Err.Error())
+}
+
+// ExitCode method to implement wakaerror.Error interface.
+func (ErrAuth) ExitCode() int {
+	return exitcode.ErrAuth
+}
+
+// Message method to implement wakaerror.Error interface.
+func (e ErrAuth) Message() string {
+	return fmt.Sprintf("invalid api key... find yours at wakatime.com/api-key. %s", e.Err)
 }
 
 // ErrBadRequest represents a 400 response from the API.
-type ErrBadRequest string
+type ErrBadRequest struct {
+	Err error
+}
+
+var _ wakaerror.Error = ErrBadRequest{}
 
 // Error method to implement error interface.
 func (e ErrBadRequest) Error() string {
-	return string(e)
+	return string(e.Err.Error())
+}
+
+// ExitCode method to implement wakaerror.Error interface.
+func (ErrBadRequest) ExitCode() int {
+	return exitcode.ErrGeneric
+}
+
+// Message method to implement wakaerror.Error interface.
+func (e ErrBadRequest) Message() string {
+	return fmt.Sprintf("bad request: %s", e.Err)
 }
 
 // ErrBackoff means we send later because currently rate limited.
-type ErrBackoff string
+type ErrBackoff struct {
+	Err error
+}
+
+var _ wakaerror.Error = ErrBackoff{}
 
 // Error method to implement error interface.
 func (e ErrBackoff) Error() string {
-	return string(e)
+	return string(e.Err.Error())
+}
+
+// ExitCode method to implement wakaerror.Error interface.
+func (ErrBackoff) ExitCode() int {
+	return exitcode.ErrBackoff
+}
+
+// Message method to implement wakaerror.Error interface.
+func (e ErrBackoff) Message() string {
+	return fmt.Sprintf("rate limited: %s", e.Err)
 }

--- a/pkg/api/goal.go
+++ b/pkg/api/goal.go
@@ -24,35 +24,35 @@ func (c *Client) Goal(id string) (*goal.Goal, error) {
 
 	resp, err := c.Do(req)
 	if err != nil {
-		return nil, Err(fmt.Sprintf("failed to make request to %q: %s", url, err))
+		return nil, Err{Err: fmt.Errorf("failed to make request to %q: %s", url, err)}
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, Err(fmt.Sprintf("failed to read response body from %q: %s", url, err))
+		return nil, Err{Err: fmt.Errorf("failed to read response body from %q: %s", url, err)}
 	}
 
 	switch resp.StatusCode {
 	case http.StatusOK:
 		break
 	case http.StatusUnauthorized:
-		return nil, ErrAuth(fmt.Sprintf("authentication failed at %q. body: %q", url, string(body)))
+		return nil, ErrAuth{Err: fmt.Errorf("authentication failed at %q. body: %q", url, string(body))}
 	case http.StatusBadRequest:
-		return nil, ErrBadRequest(fmt.Sprintf("bad request at %q", url))
+		return nil, ErrBadRequest{Err: fmt.Errorf("bad request at %q", url)}
 	default:
-		return nil, Err(fmt.Sprintf(
+		return nil, Err{Err: fmt.Errorf(
 			"invalid response status from %q. got: %d, want: %d. body: %q",
 			url,
 			resp.StatusCode,
 			http.StatusOK,
 			string(body),
-		))
+		)}
 	}
 
 	goal, err := ParseGoalResponse(body)
 	if err != nil {
-		return nil, Err(fmt.Sprintf("failed to parse results from %q: %s", url, err))
+		return nil, Err{Err: fmt.Errorf("failed to parse results from %q: %s", url, err)}
 	}
 
 	return goal, nil

--- a/pkg/api/heartbeat.go
+++ b/pkg/api/heartbeat.go
@@ -63,36 +63,36 @@ func (c *Client) sendHeartbeats(url string, heartbeats []heartbeat.Heartbeat) ([
 
 	resp, err := c.Do(req)
 	if err != nil {
-		return nil, Err(fmt.Sprintf("failed making request to %q: %s", url, err))
+		return nil, Err{Err: fmt.Errorf("failed making request to %q: %s", url, err)}
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, Err(fmt.Sprintf("failed reading response body from %q: %s", url, err))
+		return nil, Err{Err: fmt.Errorf("failed reading response body from %q: %s", url, err)}
 	}
 
 	switch resp.StatusCode {
 	case http.StatusCreated, http.StatusAccepted:
 		break
 	case http.StatusUnauthorized:
-		return nil, ErrAuth(fmt.Sprintf("authentication failed at %q", url))
+		return nil, ErrAuth{Err: fmt.Errorf("authentication failed at %q", url)}
 	case http.StatusBadRequest:
-		return nil, ErrBadRequest(fmt.Sprintf("bad request at %q", url))
+		return nil, ErrBadRequest{Err: fmt.Errorf("bad request at %q", url)}
 	default:
-		return nil, Err(fmt.Sprintf(
+		return nil, Err{Err: fmt.Errorf(
 			"invalid response status from %q. got: %d, want: %d/%d. body: %q",
 			url,
 			resp.StatusCode,
 			http.StatusCreated,
 			http.StatusAccepted,
 			string(body),
-		))
+		)}
 	}
 
 	results, err := ParseHeartbeatResponses(body)
 	if err != nil {
-		return nil, Err(fmt.Sprintf("failed parsing results from %q: %s", url, err))
+		return nil, Err{Err: fmt.Errorf("failed parsing results from %q: %s", url, err)}
 	}
 
 	return results, nil

--- a/pkg/api/summary.go
+++ b/pkg/api/summary.go
@@ -19,7 +19,7 @@ func (c *Client) Today() (*summary.Summary, error) {
 
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
-		return nil, Err(fmt.Sprintf("failed to create request: %s", err))
+		return nil, Err{fmt.Errorf("failed to create request: %s", err)}
 	}
 
 	q := req.URL.Query()
@@ -27,35 +27,35 @@ func (c *Client) Today() (*summary.Summary, error) {
 
 	resp, err := c.Do(req)
 	if err != nil {
-		return nil, Err(fmt.Sprintf("failed to make request to %q: %s", url, err))
+		return nil, Err{fmt.Errorf("failed to make request to %q: %s", url, err)}
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, Err(fmt.Sprintf("failed to read response body from %q: %s", url, err))
+		return nil, Err{fmt.Errorf("failed to read response body from %q: %s", url, err)}
 	}
 
 	switch resp.StatusCode {
 	case http.StatusOK:
 		break
 	case http.StatusUnauthorized:
-		return nil, ErrAuth(fmt.Sprintf("authentication failed at %q. body: %q", url, string(body)))
+		return nil, ErrAuth{Err: fmt.Errorf("authentication failed at %q. body: %q", url, string(body))}
 	case http.StatusBadRequest:
-		return nil, ErrBadRequest(fmt.Sprintf("bad request at %q", url))
+		return nil, ErrBadRequest{fmt.Errorf("bad request at %q", url)}
 	default:
-		return nil, Err(fmt.Sprintf(
+		return nil, Err{fmt.Errorf(
 			"invalid response status from %q. got: %d, want: %d. body: %q",
 			url,
 			resp.StatusCode,
 			http.StatusOK,
 			string(body),
-		))
+		)}
 	}
 
 	summary, err := ParseSummaryResponse(body)
 	if err != nil {
-		return nil, Err(fmt.Sprintf("failed to parse results from %q: %s", url, err))
+		return nil, Err{Err: fmt.Errorf("failed to parse results from %q: %s", url, err)}
 	}
 
 	return summary, nil

--- a/pkg/backoff/backoff.go
+++ b/pkg/backoff/backoff.go
@@ -1,6 +1,7 @@
 package backoff
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"strconv"
@@ -41,7 +42,7 @@ func WithBackoff(config Config) heartbeat.HandleOption {
 
 			should, reset := shouldBackoff(config.Retries, config.At)
 			if should {
-				return nil, api.ErrBackoff("won't send heartbeat due to backoff")
+				return nil, api.ErrBackoff{Err: errors.New("won't send heartbeat due to backoff")}
 			}
 
 			if reset {

--- a/pkg/filter/error.go
+++ b/pkg/filter/error.go
@@ -1,9 +1,0 @@
-package filter
-
-// Err is a heartbeat filtering error, signaling to skip the heartbeat.
-type Err string
-
-// Error implements error interface.
-func (e Err) Error() string {
-	return string(e)
-}

--- a/pkg/offline/error.go
+++ b/pkg/offline/error.go
@@ -1,9 +1,0 @@
-package offline
-
-// ErrOfflineEnqueue represents an enqueue to offline db error.
-type ErrOfflineEnqueue string
-
-// Error method to implement error interface.
-func (e ErrOfflineEnqueue) Error() string {
-	return string(e)
-}

--- a/pkg/offline/offline.go
+++ b/pkg/offline/offline.go
@@ -2,6 +2,7 @@ package offline
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"net/http"
@@ -39,7 +40,7 @@ type Noop struct{}
 
 // SendHeartbeats always returns an error.
 func (Noop) SendHeartbeats(_ []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
-	return nil, api.Err("skip sending heartbeats and only save to offline db")
+	return nil, api.Err{Err: errors.New("skip sending heartbeats and only save to offline db")}
 }
 
 // WithQueue initializes and returns a heartbeat handle option, which can be
@@ -65,10 +66,10 @@ func WithQueue(filepath string) heartbeat.HandleOption {
 
 				requeueErr := pushHeartbeatsWithRetry(filepath, hh)
 				if requeueErr != nil {
-					return nil, ErrOfflineEnqueue(fmt.Sprintf(
+					return nil, fmt.Errorf(
 						"failed to push heatbeats to queue after api error: %s. error: %s",
 						requeueErr,
-						err))
+						err)
 				}
 
 				return nil, err

--- a/pkg/project/error.go
+++ b/pkg/project/error.go
@@ -1,9 +1,0 @@
-package project
-
-// Err handles a custom error when finding for project and branch names.
-type Err string
-
-// Error implements error interface.
-func (e Err) Error() string {
-	return string(e)
-}

--- a/pkg/project/file.go
+++ b/pkg/project/file.go
@@ -2,6 +2,7 @@ package project
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -28,7 +29,7 @@ func (f File) Detect() (Result, bool, error) {
 
 	lines, err := readFile(fp, 2)
 	if err != nil {
-		return Result{}, false, Err(fmt.Sprintf("error reading file: %s", err))
+		return Result{}, false, fmt.Errorf("error reading file: %s", err)
 	}
 
 	result := Result{
@@ -55,12 +56,12 @@ func fileExists(fp string) bool {
 // readFile reads a file until max number of lines and return an array of lines.
 func readFile(fp string, max int) ([]string, error) {
 	if fp == "" {
-		return nil, Err("filepath cannot be empty")
+		return nil, errors.New("filepath cannot be empty")
 	}
 
 	file, err := os.Open(fp)
 	if err != nil {
-		return nil, Err(fmt.Errorf("failed while opening file %q: %w", fp, err).Error())
+		return nil, fmt.Errorf("failed while opening file %q: %s", fp, err)
 	}
 
 	defer file.Close()

--- a/pkg/project/git.go
+++ b/pkg/project/git.go
@@ -30,7 +30,7 @@ func (g Git) Detect() (Result, bool, error) {
 	// Find for submodule takes priority if enabled
 	gitdirSubmodule, ok, err := findSubmodule(fp, g.SubmodulePatterns)
 	if err != nil {
-		return Result{}, false, Err(fmt.Sprintf("failed to validate submodule: %s", err))
+		return Result{}, false, fmt.Errorf("failed to validate submodule: %s", err)
 	}
 
 	if ok {
@@ -84,14 +84,14 @@ func (g Git) Detect() (Result, bool, error) {
 	// Find for gitdir path
 	gitdir, err := findGitdir(gitConfigFile)
 	if err != nil {
-		return Result{}, false, Err(fmt.Sprintf("error finding gitdir: %s", err))
+		return Result{}, false, fmt.Errorf("error finding gitdir: %s", err)
 	}
 
 	// Commonly .git file is present when it's a worktree
 	// Find for commondir file
 	commondir, ok, err := findCommondir(gitdir)
 	if err != nil {
-		return Result{}, false, Err(fmt.Sprintf("error finding commondir: %s", err))
+		return Result{}, false, fmt.Errorf("error finding commondir: %s", err)
 	}
 
 	if ok {
@@ -149,7 +149,7 @@ func findSubmodule(fp string, patterns []regex.Regex) (string, bool, error) {
 	gitdir, err := findGitdir(gitConfigFile)
 	if err != nil {
 		return "", false,
-			Err(fmt.Sprintf("error finding gitdir for submodule: %s", err))
+			fmt.Errorf("error finding gitdir for submodule: %s", err)
 	}
 
 	if strings.Contains(gitdir, "modules") {
@@ -174,7 +174,7 @@ func shouldTakeSubmodule(fp string, patterns []regex.Regex) bool {
 func findGitdir(fp string) (string, error) {
 	lines, err := readFile(fp, 1)
 	if err != nil {
-		return "", Err(fmt.Sprintf("failed while opening file %q: %s", fp, err))
+		return "", fmt.Errorf("failed while opening file %q: %s", fp, err)
 	}
 
 	if len(lines) > 0 && strings.HasPrefix(lines[0], "gitdir: ") {
@@ -219,7 +219,7 @@ func resolveCommondir(fp string) (string, bool, error) {
 	lines, err := readFile(filepath.Join(fp, "commondir"), 1)
 	if err != nil {
 		return "", false,
-			Err(fmt.Sprintf("failed while opening file %q: %s", fp, err))
+			fmt.Errorf("failed while opening file %q: %s", fp, err)
 	}
 
 	if len(lines) == 0 {
@@ -229,7 +229,7 @@ func resolveCommondir(fp string) (string, bool, error) {
 	gitdir, err := filepath.Abs(filepath.Join(fp, lines[0]))
 	if err != nil {
 		return "", false,
-			Err(fmt.Sprintf("failed to get absolute path: %s", err))
+			fmt.Errorf("failed to get absolute path: %s", err)
 	}
 
 	if filepath.Base(gitdir) == ".git" {
@@ -246,7 +246,7 @@ func findGitBranch(fp string) (string, error) {
 
 	lines, err := readFile(fp, 1)
 	if err != nil {
-		return "", Err(fmt.Sprintf("failed while opening file %q: %s", fp, err))
+		return "", fmt.Errorf("failed while opening file %q: %s", fp, err)
 	}
 
 	if len(lines) > 0 && strings.HasPrefix(strings.TrimSpace(lines[0]), "ref: ") {

--- a/pkg/project/mercurial.go
+++ b/pkg/project/mercurial.go
@@ -55,7 +55,7 @@ func findHgBranch(fp string) (string, error) {
 
 	lines, err := readFile(p, 1)
 	if err != nil {
-		return "", Err(fmt.Sprintf("failed while opening file %q: %s", fp, err))
+		return "", fmt.Errorf("failed while opening file %q: %s", fp, err)
 	}
 
 	if len(lines) > 0 {

--- a/pkg/project/subversion.go
+++ b/pkg/project/subversion.go
@@ -39,7 +39,7 @@ func (s Subversion) Detect() (Result, bool, error) {
 
 	info, ok, err := svnInfo(filepath.Join(svnConfigFile, "..", ".."), binary)
 	if err != nil {
-		return Result{}, false, Err(fmt.Errorf("failed to get svn info: %w", err).Error())
+		return Result{}, false, fmt.Errorf("failed to get svn info: %s", err)
 	}
 
 	if !ok {
@@ -62,7 +62,7 @@ func svnInfo(fp string, binary string) (map[string]string, bool, error) {
 	out, err := cmd.Output()
 
 	if err != nil {
-		return nil, false, Err(fmt.Sprintf("error getting svn info: %s", err))
+		return nil, false, fmt.Errorf("error getting svn info: %s", err)
 	}
 
 	result := map[string]string{}

--- a/pkg/wakaerror/wakaerror.go
+++ b/pkg/wakaerror/wakaerror.go
@@ -1,0 +1,8 @@
+package wakaerror
+
+// Error is a custom error interface.
+type Error interface {
+	ExitCode() int
+	Message() string
+	error
+}


### PR DESCRIPTION
This PR creates an interface `Error` at `wakaerror` package to add more flexibility and extensibility on error handling. It also makes all custom errors to implement the new interface by verifying each of them right below struct declaration.