### PR TITLE
Prevent downloading remote files when excluded

### DIFF
--- a/cmd/heartbeat/heartbeat.go
+++ b/cmd/heartbeat/heartbeat.go
@@ -206,16 +206,14 @@ func buildHeartbeats(params paramscmd.Params) []heartbeat.Heartbeat {
 
 func initHandleOptions(params paramscmd.Params) []heartbeat.HandleOption {
 	return []heartbeat.HandleOption{
-		heartbeat.WithFormatting(heartbeat.FormatConfig{
-			RemoteAddressPattern: remote.RemoteAddressRegex,
-		}),
+		heartbeat.WithFormatting(),
 		heartbeat.WithEntityModifer(),
-		remote.WithDetection(),
 		filter.WithFiltering(filter.Config{
 			Exclude:                    params.Heartbeat.Filter.Exclude,
 			Include:                    params.Heartbeat.Filter.Include,
 			IncludeOnlyWithProjectFile: params.Heartbeat.Filter.IncludeOnlyWithProjectFile,
 		}),
+		remote.WithDetection(),
 		apikey.WithReplacing(apikey.Config{
 			DefaultApiKey: params.API.Key,
 			MapPatterns:   params.API.KeyPatterns,
@@ -234,11 +232,10 @@ func initHandleOptions(params paramscmd.Params) []heartbeat.HandleOption {
 			ExcludeUnknownProject: params.Heartbeat.Filter.ExcludeUnknownProject,
 		}),
 		heartbeat.WithSanitization(heartbeat.SanitizeConfig{
-			BranchPatterns:       params.Heartbeat.Sanitize.HideBranchNames,
-			FilePatterns:         params.Heartbeat.Sanitize.HideFileNames,
-			HideProjectFolder:    params.Heartbeat.Sanitize.HideProjectFolder,
-			ProjectPatterns:      params.Heartbeat.Sanitize.HideProjectNames,
-			RemoteAddressPattern: remote.RemoteAddressRegex,
+			BranchPatterns:    params.Heartbeat.Sanitize.HideBranchNames,
+			FilePatterns:      params.Heartbeat.Sanitize.HideFileNames,
+			HideProjectFolder: params.Heartbeat.Sanitize.HideProjectFolder,
+			ProjectPatterns:   params.Heartbeat.Sanitize.HideProjectNames,
 		}),
 		remote.WithCleanup(),
 		filter.WithLengthValidator(),

--- a/cmd/offline/offline.go
+++ b/cmd/offline/offline.go
@@ -139,16 +139,14 @@ func buildHeartbeats(params paramscmd.Params) []heartbeat.Heartbeat {
 
 func initHandleOptions(params paramscmd.Params) []heartbeat.HandleOption {
 	return []heartbeat.HandleOption{
-		heartbeat.WithFormatting(heartbeat.FormatConfig{
-			RemoteAddressPattern: remote.RemoteAddressRegex,
-		}),
+		heartbeat.WithFormatting(),
 		heartbeat.WithEntityModifer(),
-		remote.WithDetection(),
 		filter.WithFiltering(filter.Config{
 			Exclude:                    params.Heartbeat.Filter.Exclude,
 			Include:                    params.Heartbeat.Filter.Include,
 			IncludeOnlyWithProjectFile: params.Heartbeat.Filter.IncludeOnlyWithProjectFile,
 		}),
+		remote.WithDetection(),
 		filestats.WithDetection(),
 		language.WithDetection(),
 		deps.WithDetection(deps.Config{
@@ -163,11 +161,10 @@ func initHandleOptions(params paramscmd.Params) []heartbeat.HandleOption {
 			ExcludeUnknownProject: params.Heartbeat.Filter.ExcludeUnknownProject,
 		}),
 		heartbeat.WithSanitization(heartbeat.SanitizeConfig{
-			BranchPatterns:       params.Heartbeat.Sanitize.HideBranchNames,
-			FilePatterns:         params.Heartbeat.Sanitize.HideFileNames,
-			HideProjectFolder:    params.Heartbeat.Sanitize.HideProjectFolder,
-			ProjectPatterns:      params.Heartbeat.Sanitize.HideProjectNames,
-			RemoteAddressPattern: remote.RemoteAddressRegex,
+			BranchPatterns:    params.Heartbeat.Sanitize.HideBranchNames,
+			FilePatterns:      params.Heartbeat.Sanitize.HideFileNames,
+			HideProjectFolder: params.Heartbeat.Sanitize.HideProjectFolder,
+			ProjectPatterns:   params.Heartbeat.Sanitize.HideProjectNames,
 		}),
 		remote.WithCleanup(),
 		filter.WithLengthValidator(),

--- a/pkg/filestats/filestats.go
+++ b/pkg/filestats/filestats.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 	"github.com/wakatime/wakatime-cli/pkg/log"
-	"github.com/wakatime/wakatime-cli/pkg/remote"
 )
 
 // Max file size supporting line number count stats. Files larger than this in
@@ -36,7 +35,7 @@ func WithDetection() heartbeat.HandleOption {
 					continue
 				}
 
-				if remote.RemoteAddressRegex.MatchString(h.Entity) {
+				if h.IsRemote() {
 					continue
 				}
 

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -175,13 +175,13 @@ func TestFilter_ExistingProjectFile(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestFilter_RemoteFile(t *testing.T) {
+func TestFilter_RemoteFileSkipsFiltering(t *testing.T) {
 	h := testHeartbeat()
 	h.LocalFile = h.Entity
 	h.Entity = "ssh://wakatime:1234@192.168.1.1/path/to/remote/main.go"
 
 	err := filter.Filter(h, filter.Config{})
-	assert.EqualError(t, err, "filter file: skipping because of non-existing file \"/tmp/main.go\"")
+	require.NoError(t, err)
 }
 
 func TestFilter_ErrNonExistingProjectFile(t *testing.T) {

--- a/pkg/heartbeat/format.go
+++ b/pkg/heartbeat/format.go
@@ -2,7 +2,6 @@ package heartbeat
 
 import (
 	"path/filepath"
-	"regexp"
 	"runtime"
 
 	"github.com/wakatime/wakatime-cli/pkg/log"
@@ -11,15 +10,9 @@ import (
 	"github.com/yookoala/realpath"
 )
 
-// FormatConfig defines how a heartbeat should be formatted.
-type FormatConfig struct {
-	// RemoteAddressPattern will be matched against a file entity's name and if matching will skip formatting.
-	RemoteAddressPattern *regexp.Regexp
-}
-
 // WithFormatting initializes and returns a heartbeat handle option, which
 // can be used in a heartbeat processing pipeline to format entity's filepath.
-func WithFormatting(config FormatConfig) HandleOption {
+func WithFormatting() HandleOption {
 	return func(next Handle) Handle {
 		return func(hh []Heartbeat) ([]Result, error) {
 			log.Debugln("execute heartbeat filepath formatting")
@@ -29,7 +22,7 @@ func WithFormatting(config FormatConfig) HandleOption {
 					continue
 				}
 
-				if config.RemoteAddressPattern != nil && config.RemoteAddressPattern.MatchString(h.Entity) {
+				if h.IsRemote() {
 					continue
 				}
 

--- a/pkg/heartbeat/format_test.go
+++ b/pkg/heartbeat/format_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestWithFormatting(t *testing.T) {
-	opt := heartbeat.WithFormatting(heartbeat.FormatConfig{})
+	opt := heartbeat.WithFormatting()
 
 	handle := opt(func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
 		entity, err := filepath.Abs(hh[0].Entity)

--- a/pkg/heartbeat/heartbeat.go
+++ b/pkg/heartbeat/heartbeat.go
@@ -3,6 +3,7 @@ package heartbeat
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"runtime"
 	"strings"
 
@@ -12,6 +13,9 @@ import (
 
 	"github.com/matishsiao/goInfo"
 )
+
+// remoteAddressRegex is a pattern for (ssh|sftp)://user:pass@host:port.
+var remoteAddressRegex = regexp.MustCompile(`(?i)^((ssh|sftp)://)+(?P<credentials>[^:@]+(:([^:@])+)?@)?[^:]+(:\d+)?`)
 
 // Heartbeat is a structure representing activity for a user on a some entity.
 type Heartbeat struct {
@@ -108,6 +112,19 @@ func (h Heartbeat) ID() string {
 		h.Entity,
 		isWrite,
 	)
+}
+
+// IsRemote returns true when entity is a remote file.
+func (h Heartbeat) IsRemote() bool {
+	if h.EntityType != FileType {
+		return false
+	}
+
+	if h.IsUnsavedEntity {
+		return false
+	}
+
+	return remoteAddressRegex.MatchString(h.Entity)
 }
 
 // Result represents a response from the wakatime api.

--- a/pkg/heartbeat/heartbeat_test.go
+++ b/pkg/heartbeat/heartbeat_test.go
@@ -243,6 +243,42 @@ func TestPluginFromUserAgent(t *testing.T) {
 	}
 }
 
+func TestRemoteAddressRegex(t *testing.T) {
+	tests := map[string]struct {
+		Heartbeat heartbeat.Heartbeat
+		Expected  bool
+	}{
+		"ssh full path": {
+			Heartbeat: heartbeat.Heartbeat{Entity: "ssh://user:1234@192.168.1.2/home/pi/unicorn-hat/examples/ascii_pic.py"},
+			Expected:  true,
+		},
+		"sftp full path": {
+			Heartbeat: heartbeat.Heartbeat{Entity: "sftp://user:1234@192.168.1.2/home/pi/unicorn-hat/examples/ascii_pic.py"},
+			Expected:  true,
+		},
+		"without path": {
+			Heartbeat: heartbeat.Heartbeat{Entity: "ssh://user:1234@192.168.1.2"},
+			Expected:  true,
+		},
+		"invalid ftp": {
+			Heartbeat: heartbeat.Heartbeat{Entity: "ftp://user:1234@192.168.1.2"},
+			Expected:  false,
+		},
+		"invalid": {
+			Heartbeat: heartbeat.Heartbeat{Entity: "http://192.168.1.2"},
+			Expected:  false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			result := test.Heartbeat.IsRemote()
+
+			assert.Equal(t, test.Expected, result)
+		})
+	}
+}
+
 type mockSender struct {
 	SendHeartbeatsFn        func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error)
 	SendHeartbeatsFnInvoked bool

--- a/pkg/heartbeat/sanitize_test.go
+++ b/pkg/heartbeat/sanitize_test.go
@@ -368,9 +368,7 @@ func TestSanitize_ObfuscateCredentials_RemoteFile(t *testing.T) {
 	h := testHeartbeat()
 	h.Entity = "ssh://wakatime:1234@192.168.1.1/path/to/remote/main.go"
 
-	r := heartbeat.Sanitize(h, heartbeat.SanitizeConfig{
-		RemoteAddressPattern: regexp.MustCompile(`(?i)^((ssh|sftp)://)+(?P<credentials>[^:@]+(:([^:@])+)?@)?[^:]+(:\d+)?`),
-	})
+	r := heartbeat.Sanitize(h, heartbeat.SanitizeConfig{})
 
 	assert.Equal(t, heartbeat.Heartbeat{
 		Branch:         heartbeat.PointerTo("heartbeat"),

--- a/pkg/offline/offline.go
+++ b/pkg/offline/offline.go
@@ -67,7 +67,7 @@ func WithQueue(filepath string) heartbeat.HandleOption {
 				requeueErr := pushHeartbeatsWithRetry(filepath, hh)
 				if requeueErr != nil {
 					return nil, fmt.Errorf(
-						"failed to push heatbeats to queue after api error: %s. error: %s",
+						"failed to push heartbeats to queue after api error: %s. error: %s",
 						requeueErr,
 						err)
 				}

--- a/pkg/project/filter.go
+++ b/pkg/project/filter.go
@@ -2,6 +2,7 @@ package project
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 	"github.com/wakatime/wakatime-cli/pkg/log"
@@ -27,6 +28,13 @@ func WithFiltering(config FilterConfig) heartbeat.HandleOption {
 				err := Filter(h, config)
 				if err != nil {
 					log.Debugln(err.Error())
+
+					if h.EntityRaw != "" {
+						err = os.Remove(h.LocalFile)
+						if err != nil {
+							log.Warnf("unable to delete tmp file: %s", err)
+						}
+					}
 
 					continue
 				}

--- a/pkg/remote/remote_test.go
+++ b/pkg/remote/remote_test.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
@@ -18,48 +19,13 @@ import (
 	"github.com/wakatime/wakatime-cli/pkg/filter"
 	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 	"github.com/wakatime/wakatime-cli/pkg/log"
+	"github.com/wakatime/wakatime-cli/pkg/regex"
 	"github.com/wakatime/wakatime-cli/pkg/remote"
 	"golang.org/x/crypto/ssh"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func TestRegex(t *testing.T) {
-	tests := map[string]struct {
-		RemoteAddress string
-		Expected      bool
-	}{
-		"ssh full path": {
-			RemoteAddress: "ssh://user:1234@192.168.1.2/home/pi/unicorn-hat/examples/ascii_pic.py",
-			Expected:      true,
-		},
-		"sftp full path": {
-			RemoteAddress: "sftp://user:1234@192.168.1.2/home/pi/unicorn-hat/examples/ascii_pic.py",
-			Expected:      true,
-		},
-		"without path": {
-			RemoteAddress: "ssh://user:1234@192.168.1.2",
-			Expected:      true,
-		},
-		"invalid ftp": {
-			RemoteAddress: "ftp://user:1234@192.168.1.2",
-			Expected:      false,
-		},
-		"invalid": {
-			RemoteAddress: "http://192.168.1.2",
-			Expected:      false,
-		},
-	}
-
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
-			ok := remote.RemoteAddressRegex.MatchString(test.RemoteAddress)
-
-			assert.Equal(t, test.Expected, ok)
-		})
-	}
-}
 
 func TestNewClient(t *testing.T) {
 	client, err := remote.NewClient("ssh://wakatime:1234@192.168.1.2:222/home/pi/unicorn-hat/examples/ascii_pic.py")
@@ -211,12 +177,10 @@ func TestWithDetection_SshConfig_UserKnownHostsFile_Mismatch(t *testing.T) {
 	}
 
 	opts := []heartbeat.HandleOption{
-		remote.WithDetection(),
 		filter.WithFiltering(filter.Config{
-			Exclude:                    nil,
-			Include:                    nil,
-			IncludeOnlyWithProjectFile: false,
+			IncludeOnlyWithProjectFile: true,
 		}),
+		remote.WithDetection(),
 	}
 
 	handle := heartbeat.NewHandle(&sender, opts...)
@@ -295,16 +259,16 @@ func TestWithDetection_SshConfig_UserKnownHostsFile_Match(t *testing.T) {
 	}
 
 	opts := []heartbeat.HandleOption{
-		remote.WithDetection(),
 		filter.WithFiltering(filter.Config{
 			Exclude:                    nil,
 			Include:                    nil,
 			IncludeOnlyWithProjectFile: true,
 		}),
+		remote.WithDetection(),
 	}
 
 	handle := heartbeat.NewHandle(&sender, opts...)
-	_, err = handle([]heartbeat.Heartbeat{
+	results, err := handle([]heartbeat.Heartbeat{
 		{
 			Category:   heartbeat.CodingCategory,
 			Entity:     "ssh://user:pass@example.com:" + strconv.Itoa(port) + entity,
@@ -314,6 +278,111 @@ func TestWithDetection_SshConfig_UserKnownHostsFile_Match(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
+	assert.Len(t, results, 1)
+}
+
+func TestWithDetection_Filtered(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping because OS is Windows.")
+	}
+
+	logs := bytes.NewBuffer(nil)
+
+	teardownLogCapture := captureLogs(logs)
+	defer teardownLogCapture()
+
+	shutdown, host, port := testServer(t, true)
+	defer shutdown()
+
+	tmpFile, err := os.CreateTemp(t.TempDir(), "")
+	require.NoError(t, err)
+
+	defer tmpFile.Close()
+
+	ssh_config.DefaultUserSettings = &ssh_config.UserSettings{
+		IgnoreErrors: false,
+	}
+
+	ssh_config.DefaultUserSettings.ConfigFinder(func() string {
+		return tmpFile.Name()
+	})
+
+	template, err := os.ReadFile("testdata/ssh_config_userknownhosts")
+	require.NoError(t, err)
+
+	knownHostsFile, err := filepath.Abs("./testdata/known_hosts")
+	require.NoError(t, err)
+
+	err = os.WriteFile(tmpFile.Name(), []byte(fmt.Sprintf(string(template), host, knownHostsFile)), 0600)
+	require.NoError(t, err)
+
+	entity, _ := filepath.Abs("./testdata/main.go")
+
+	sender := mockSender{
+		SendHeartbeatsFn: func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+			assert.Empty(t, hh)
+			return []heartbeat.Result{}, nil
+		},
+	}
+
+	opts := []heartbeat.HandleOption{
+		filter.WithFiltering(filter.Config{
+			Exclude:                    []regex.Regex{regexp.MustCompile(".*")},
+			Include:                    nil,
+			IncludeOnlyWithProjectFile: true,
+		}),
+		remote.WithDetection(),
+	}
+
+	handle := heartbeat.NewHandle(&sender, opts...)
+	results, err := handle([]heartbeat.Heartbeat{
+		{
+			Category:   heartbeat.CodingCategory,
+			Entity:     "ssh://user:pass@example.com:" + strconv.Itoa(port) + entity,
+			EntityType: heartbeat.FileType,
+			Time:       1585598060,
+			UserAgent:  "wakatime/13.0.7",
+		},
+	})
+	require.NoError(t, err)
+	assert.Empty(t, results)
+}
+
+func TestWithCleanup_NotTemporary(t *testing.T) {
+	tmpFile, err := os.CreateTemp(t.TempDir(), "")
+	require.NoError(t, err)
+
+	tmpFile.Close()
+
+	defer os.Remove(tmpFile.Name())
+
+	opts := []heartbeat.HandleOption{
+		remote.WithCleanup(),
+	}
+
+	sender := mockSender{
+		SendHeartbeatsFn: func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+			return []heartbeat.Result{
+				{
+					Status:    201,
+					Heartbeat: heartbeat.Heartbeat{},
+				},
+			}, nil
+		},
+	}
+
+	handle := heartbeat.NewHandle(&sender, opts...)
+
+	assert.FileExists(t, tmpFile.Name())
+
+	_, err = handle([]heartbeat.Heartbeat{
+		{
+			LocalFile: tmpFile.Name(),
+		},
+	})
+	require.NoError(t, err)
+
+	assert.FileExists(t, tmpFile.Name())
 }
 
 func TestWithCleanup(t *testing.T) {
@@ -339,6 +408,8 @@ func TestWithCleanup(t *testing.T) {
 	}
 
 	handle := heartbeat.NewHandle(&sender, opts...)
+
+	assert.FileExists(t, tmpFile.Name())
 
 	_, err = handle([]heartbeat.Heartbeat{
 		{


### PR DESCRIPTION
This PR prevents downloading remote files when the `entity` path matches an `exclude` filter, because we're throwing away the heartbeat anyway.