### PR TITLE
Abort heartbeat handling if list is empty

### DIFF
--- a/cmd/heartbeat/heartbeat.go
+++ b/cmd/heartbeat/heartbeat.go
@@ -243,6 +243,7 @@ func initHandleOptions(params paramscmd.Params) []heartbeat.HandleOption {
 			ProjectPatterns:      params.Heartbeat.Sanitize.HideProjectNames,
 			RemoteAddressPattern: remote.RemoteAddressRegex,
 		}),
+		filter.WithLengthValidator(),
 	}
 }
 

--- a/cmd/offline/offline.go
+++ b/cmd/offline/offline.go
@@ -172,6 +172,7 @@ func initHandleOptions(params paramscmd.Params) []heartbeat.HandleOption {
 			ProjectPatterns:      params.Heartbeat.Sanitize.HideProjectNames,
 			RemoteAddressPattern: remote.RemoteAddressRegex,
 		}),
+		filter.WithLengthValidator(),
 	}
 }
 

--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -38,12 +38,22 @@ func WithFiltering(config Config) heartbeat.HandleOption {
 				filtered = append(filtered, h)
 			}
 
-			if len(filtered) == 0 {
+			return next(filtered)
+		}
+	}
+}
+
+// WithHeartbeatsLengthValidator initializes and returns a heartbeat handle option, which
+// can be used to abort execution if all heartbeats were filtered and the list is empty.
+func WithLengthValidator() heartbeat.HandleOption {
+	return func(next heartbeat.Handle) heartbeat.Handle {
+		return func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+			if len(hh) == 0 {
 				log.Debugln("no heartbeats left after filtering. abort heartbeat handling.")
 				return []heartbeat.Result{}, nil
 			}
 
-			return next(filtered)
+			return next(hh)
 		}
 	}
 }

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -63,13 +63,13 @@ func TestWithFiltering(t *testing.T) {
 	}, result)
 }
 
-func TestWithFiltering_AbortAllFiltered(t *testing.T) {
-	opt := filter.WithFiltering(filter.Config{})
+func TestWithLengthValidator(t *testing.T) {
+	opt := filter.WithLengthValidator()
 	h := opt(func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
 		return []heartbeat.Result{}, errors.New("this will should never be called")
 	})
 
-	result, err := h([]heartbeat.Heartbeat{testHeartbeat()})
+	result, err := h([]heartbeat.Heartbeat{})
 	require.NoError(t, err)
 
 	assert.Equal(t, result, []heartbeat.Result{})

--- a/pkg/project/filter.go
+++ b/pkg/project/filter.go
@@ -34,11 +34,6 @@ func WithFiltering(config FilterConfig) heartbeat.HandleOption {
 				filtered = append(filtered, h)
 			}
 
-			if len(filtered) == 0 {
-				log.Debugln("no heartbeat left after filtering. abort heartbeat handling.")
-				return []heartbeat.Result{}, nil
-			}
-
 			return next(filtered)
 		}
 	}


### PR DESCRIPTION
This PR adds a new handle option `filter.WithLengthValidator()` to abort heartbeat handling if list is empty. It has been added at the end of the chain to make sure all other filters/modifiers have been run.