### PR TITLE
Cleanup temporary directories for remote files

### DIFF
--- a/cmd/heartbeat/heartbeat.go
+++ b/cmd/heartbeat/heartbeat.go
@@ -243,6 +243,7 @@ func initHandleOptions(params paramscmd.Params) []heartbeat.HandleOption {
 			ProjectPatterns:      params.Heartbeat.Sanitize.HideProjectNames,
 			RemoteAddressPattern: remote.RemoteAddressRegex,
 		}),
+		remote.WithCleanup(),
 		filter.WithLengthValidator(),
 	}
 }

--- a/cmd/offline/offline.go
+++ b/cmd/offline/offline.go
@@ -172,6 +172,7 @@ func initHandleOptions(params paramscmd.Params) []heartbeat.HandleOption {
 			ProjectPatterns:      params.Heartbeat.Sanitize.HideProjectNames,
 			RemoteAddressPattern: remote.RemoteAddressRegex,
 		}),
+		remote.WithCleanup(),
 		filter.WithLengthValidator(),
 	}
 }

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -111,6 +111,29 @@ func WithDetection() heartbeat.HandleOption {
 	}
 }
 
+// WithCleanup initializes and returns a heartbeat handle option, which
+// deletes a local temporary file if downloaded from a remote file.
+func WithCleanup() heartbeat.HandleOption {
+	return func(next heartbeat.Handle) heartbeat.Handle {
+		return func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+			log.Debugln("execute remote cleanup")
+
+			for _, h := range hh {
+				if h.EntityRaw != "" {
+					log.Debugln("deleting temporary file: %s", h.LocalFile)
+
+					err := os.Remove(h.LocalFile)
+					if err != nil {
+						log.Warnf("failed to delete temporary file: %s", err)
+					}
+				}
+			}
+
+			return next(hh)
+		}
+	}
+}
+
 // NewClient initializes a new remote client.
 func NewClient(address string) (Client, error) {
 	parsedURL, err := url.Parse(address)


### PR DESCRIPTION
This PR adds `remote.WithCleanup()` to make sure any file that was downloaded during remote detection has been purged. It uses `EntityRaw` attribute from Heartbeat since it's only set when a remote file is downloaded. 