### PR TITLE
Detect Android operating system when running in Termux

### DIFF
--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -80,11 +80,7 @@ func newClient(params paramscmd.API, opts ...api.Option) (*api.Client, error) {
 		}
 	}
 
-	if params.Plugin != "" {
-		opts = append(opts, api.WithUserAgent(params.Plugin))
-	} else {
-		opts = append(opts, api.WithUserAgentUnknownPlugin())
-	}
+	opts = append(opts, api.WithUserAgent(params.Plugin))
 
 	return api.NewClient(params.URL, opts...), nil
 }

--- a/cmd/heartbeat/heartbeat.go
+++ b/cmd/heartbeat/heartbeat.go
@@ -153,10 +153,7 @@ func SendHeartbeats(v *viper.Viper, queueFilepath string) error {
 func buildHeartbeats(params paramscmd.Params) []heartbeat.Heartbeat {
 	heartbeats := []heartbeat.Heartbeat{}
 
-	userAgent := heartbeat.UserAgentUnknownPlugin()
-	if params.API.Plugin != "" {
-		userAgent = heartbeat.UserAgent(params.API.Plugin)
-	}
+	userAgent := heartbeat.UserAgent(params.API.Plugin)
 
 	heartbeats = append(heartbeats, heartbeat.New(
 		params.Heartbeat.Project.BranchAlternate,

--- a/cmd/offline/offline.go
+++ b/cmd/offline/offline.go
@@ -86,10 +86,7 @@ func loadParams(v *viper.Viper) (paramscmd.Params, error) {
 func buildHeartbeats(params paramscmd.Params) []heartbeat.Heartbeat {
 	heartbeats := []heartbeat.Heartbeat{}
 
-	userAgent := heartbeat.UserAgentUnknownPlugin()
-	if params.API.Plugin != "" {
-		userAgent = heartbeat.UserAgent(params.API.Plugin)
-	}
+	userAgent := heartbeat.UserAgent(params.API.Plugin)
 
 	heartbeats = append(heartbeats, heartbeat.New(
 		params.Heartbeat.Project.BranchAlternate,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -215,7 +215,7 @@ func setFlags(cmd *cobra.Command, v *viper.Viper) {
 		"Prints time for the given goal id Today, then exits"+
 			" Visit wakatime.com/api/v1/users/current/goals to find your goal id.")
 	flags.Bool(
-		"useragent",
+		"user-agent",
 		false,
 		"(internal) Prints the wakatime-cli useragent, as it will be sent to the api, then exits.",
 	)
@@ -233,7 +233,7 @@ func setFlags(cmd *cobra.Command, v *viper.Viper) {
 
 	// hide internal flags
 	_ = flags.MarkHidden("offline-queue-file")
-	_ = flags.MarkHidden("useragent")
+	_ = flags.MarkHidden("user-agent")
 
 	err := v.BindPFlags(flags)
 	if err != nil {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -63,16 +63,10 @@ func Run(cmd *cobra.Command, v *viper.Viper) {
 	// setup logging again to use config file settings
 	logFileParams := SetupLogging(v)
 
-	if v.GetBool("useragent") {
-		log.Debugln("command: useragent")
+	if v.GetBool("user-agent") {
+		log.Debugln("command: user-agent")
 
-		if plugin := vipertools.GetString(v, "plugin"); plugin != "" {
-			fmt.Println(heartbeat.UserAgent(plugin))
-
-			os.Exit(exitcode.Success)
-		}
-
-		fmt.Println(heartbeat.UserAgentUnknownPlugin())
+		fmt.Println(heartbeat.UserAgent(vipertools.GetString(v, "plugin")))
 
 		os.Exit(exitcode.Success)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -60,7 +60,7 @@ func testSendHeartbeats(t *testing.T, entity, project string) {
 		assert.Equal(t, []string{"application/json"}, req.Header["Accept"])
 		assert.Equal(t, []string{"application/json"}, req.Header["Content-Type"])
 		assert.Equal(t, []string{"Basic MDAwMDAwMDAtMDAwMC00MDAwLTgwMDAtMDAwMDAwMDAwMDAw"}, req.Header["Authorization"])
-		assert.Equal(t, []string{heartbeat.UserAgentUnknownPlugin()}, req.Header["User-Agent"])
+		assert.Equal(t, []string{heartbeat.UserAgent("")}, req.Header["User-Agent"])
 
 		// check body
 		expectedBodyTpl, err := os.ReadFile("testdata/api_heartbeats_request_template.json")
@@ -74,7 +74,7 @@ func testSendHeartbeats(t *testing.T, entity, project string) {
 			string(expectedBodyTpl),
 			entityPath,
 			project,
-			heartbeat.UserAgentUnknownPlugin(),
+			heartbeat.UserAgent(""),
 		)
 
 		body, err := io.ReadAll(req.Body)
@@ -144,7 +144,7 @@ func TestSendHeartbeats_SecondaryApiKey(t *testing.T) {
 		assert.Equal(t, []string{"application/json"}, req.Header["Accept"])
 		assert.Equal(t, []string{"application/json"}, req.Header["Content-Type"])
 		assert.Equal(t, []string{"Basic MDAwMDAwMDAtMDAwMC00MDAwLTgwMDAtMDAwMDAwMDAwMDAx"}, req.Header["Authorization"])
-		assert.Equal(t, []string{heartbeat.UserAgentUnknownPlugin()}, req.Header["User-Agent"])
+		assert.Equal(t, []string{heartbeat.UserAgent("")}, req.Header["User-Agent"])
 
 		// check body
 		expectedBodyTpl, err := os.ReadFile("testdata/api_heartbeats_request_template.json")
@@ -158,7 +158,7 @@ func TestSendHeartbeats_SecondaryApiKey(t *testing.T) {
 			string(expectedBodyTpl),
 			entityPath,
 			"wakatime-cli",
-			heartbeat.UserAgentUnknownPlugin(),
+			heartbeat.UserAgent(""),
 		)
 
 		body, err := io.ReadAll(req.Body)
@@ -223,7 +223,7 @@ func TestSendHeartbeats_ExtraHeartbeats(t *testing.T) {
 		assert.Equal(t, []string{"application/json"}, req.Header["Accept"])
 		assert.Equal(t, []string{"application/json"}, req.Header["Content-Type"])
 		assert.Equal(t, []string{"Basic MDAwMDAwMDAtMDAwMC00MDAwLTgwMDAtMDAwMDAwMDAwMDAw"}, req.Header["Authorization"])
-		assert.Equal(t, []string{heartbeat.UserAgentUnknownPlugin()}, req.Header["User-Agent"])
+		assert.Equal(t, []string{heartbeat.UserAgent("")}, req.Header["User-Agent"])
 
 		// write response
 		f, err := os.Open("testdata/api_heartbeats_response_extra_heartbeats.json")
@@ -300,7 +300,7 @@ func TestSendHeartbeats_Err(t *testing.T) {
 		assert.Equal(t, []string{"application/json"}, req.Header["Accept"])
 		assert.Equal(t, []string{"application/json"}, req.Header["Content-Type"])
 		assert.Equal(t, []string{"Basic MDAwMDAwMDAtMDAwMC00MDAwLTgwMDAtMDAwMDAwMDAwMDAw"}, req.Header["Authorization"])
-		assert.Equal(t, []string{heartbeat.UserAgentUnknownPlugin()}, req.Header["User-Agent"])
+		assert.Equal(t, []string{heartbeat.UserAgent("")}, req.Header["User-Agent"])
 
 		// check body
 		expectedBodyTpl, err := os.ReadFile("testdata/api_heartbeats_request_template.json")
@@ -314,7 +314,7 @@ func TestSendHeartbeats_Err(t *testing.T) {
 			string(expectedBodyTpl),
 			entityPath,
 			project,
-			heartbeat.UserAgentUnknownPlugin(),
+			heartbeat.UserAgent(""),
 		)
 
 		body, err := io.ReadAll(req.Body)
@@ -455,7 +455,7 @@ func TestTodayGoal(t *testing.T) {
 			assert.Equal(t, http.MethodGet, req.Method)
 			assert.Equal(t, []string{"application/json"}, req.Header["Accept"])
 			assert.Equal(t, []string{"Basic MDAwMDAwMDAtMDAwMC00MDAwLTgwMDAtMDAwMDAwMDAwMDAw"}, req.Header["Authorization"])
-			assert.Equal(t, []string{heartbeat.UserAgentUnknownPlugin()}, req.Header["User-Agent"])
+			assert.Equal(t, []string{heartbeat.UserAgent("")}, req.Header["User-Agent"])
 
 			// write response
 			f, err := os.Open("testdata/api_goals_id_response.json")
@@ -507,7 +507,7 @@ func TestTodaySummary(t *testing.T) {
 		assert.Equal(t, http.MethodGet, req.Method)
 		assert.Equal(t, []string{"application/json"}, req.Header["Accept"])
 		assert.Equal(t, []string{"Basic MDAwMDAwMDAtMDAwMC00MDAwLTgwMDAtMDAwMDAwMDAwMDAw"}, req.Header["Authorization"])
-		assert.Equal(t, []string{heartbeat.UserAgentUnknownPlugin()}, req.Header["User-Agent"])
+		assert.Equal(t, []string{heartbeat.UserAgent("")}, req.Header["User-Agent"])
 
 		// write response
 		f, err := os.Open("testdata/api_statusbar_today_response.json")
@@ -682,19 +682,19 @@ func TestPrintOfflineHeartbeats(t *testing.T) {
 
 	offlineHeartbeatStr := fmt.Sprintf(
 		string(offlineHeartbeat),
-		entity, heartbeat.UserAgentUnknownPlugin(),
+		entity, heartbeat.UserAgent(""),
 	)
 
 	assert.Equal(t, offlineHeartbeatStr+"\n", out)
 }
 
 func TestUserAgent(t *testing.T) {
-	out := runWakatimeCli(t, &bytes.Buffer{}, "--useragent")
-	assert.Equal(t, fmt.Sprintf("%s\n", heartbeat.UserAgentUnknownPlugin()), out)
+	out := runWakatimeCli(t, &bytes.Buffer{}, "--user-agent")
+	assert.Equal(t, fmt.Sprintf("%s\n", heartbeat.UserAgent("")), out)
 }
 
 func TestUserAgentWithPlugin(t *testing.T) {
-	out := runWakatimeCli(t, &bytes.Buffer{}, "--useragent", "--plugin", "Wakatime/1.0.4")
+	out := runWakatimeCli(t, &bytes.Buffer{}, "--user-agent", "--plugin", "Wakatime/1.0.4")
 
 	assert.Equal(t, fmt.Sprintf("%s\n", heartbeat.UserAgent("Wakatime/1.0.4")), out)
 }

--- a/pkg/api/option.go
+++ b/pkg/api/option.go
@@ -170,12 +170,6 @@ func WithTimezone(timezone string) Option {
 	}
 }
 
-// WithUserAgentUnknownPlugin sets the User-Agent header on all requests,
-// including default value for plugin.
-func WithUserAgentUnknownPlugin() Option {
-	return WithUserAgent("Unknown/0")
-}
-
 // WithUserAgent sets the User-Agent header on all requests, including the passed
 // in value for plugin.
 func WithUserAgent(plugin string) Option {

--- a/pkg/api/option_test.go
+++ b/pkg/api/option_test.go
@@ -282,7 +282,7 @@ func TestOption_WithUserAgentUnknownPlugin(t *testing.T) {
 		numCalls++
 	})
 
-	opts := []api.Option{api.WithUserAgentUnknownPlugin()}
+	opts := []api.Option{api.WithUserAgent("")}
 
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	require.NoError(t, err)

--- a/pkg/heartbeat/heartbeat.go
+++ b/pkg/heartbeat/heartbeat.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/wakatime/wakatime-cli/pkg/log"
+	"github.com/wakatime/wakatime-cli/pkg/system"
 	"github.com/wakatime/wakatime-cli/pkg/version"
 
 	"github.com/matishsiao/goInfo"
@@ -148,12 +149,6 @@ func NewHandle(sender Sender, opts ...HandleOption) Handle {
 	}
 }
 
-// UserAgentUnknownPlugin generates a user agent from various system infos, including
-// a default value for plugin.
-func UserAgentUnknownPlugin() string {
-	return UserAgent("Unknown/0")
-}
-
 // UserAgent generates a user agent from various system infos, including a
 // a passed in value for plugin.
 func UserAgent(plugin string) string {
@@ -162,10 +157,14 @@ func UserAgent(plugin string) string {
 		log.Debugf("goInfo.GetInfo error: %s", err)
 	}
 
+	if plugin == "" {
+		plugin = "Unknown/0"
+	}
+
 	return fmt.Sprintf(
 		"wakatime/%s (%s-%s-%s) %s %s",
 		version.Version,
-		runtime.GOOS,
+		system.OSName(),
 		info.Core,
 		info.Platform,
 		runtime.Version(),

--- a/pkg/heartbeat/heartbeat_test.go
+++ b/pkg/heartbeat/heartbeat_test.go
@@ -197,7 +197,7 @@ func TestUserAgentUnknownPlugin(t *testing.T) {
 		runtime.Version(),
 	)
 
-	assert.Equal(t, expected, heartbeat.UserAgentUnknownPlugin())
+	assert.Equal(t, expected, heartbeat.UserAgent(""))
 }
 
 func TestUserAgent(t *testing.T) {

--- a/pkg/system/system_linux.go
+++ b/pkg/system/system_linux.go
@@ -1,0 +1,44 @@
+//go:build linux
+
+package system
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+	"syscall"
+
+	"github.com/wakatime/wakatime-cli/pkg/log"
+)
+
+// OSName returns the runtime machine's operating system name.
+func OSName() string {
+	os := runtime.GOOS
+
+	var buf syscall.Utsname
+
+	err := syscall.Uname(&buf)
+	if err != nil {
+		log.Debugf("Uname error: %s", err)
+
+		return os
+	}
+
+	arr := buf.Sysname[:]
+	output := make([]byte, 0, len(arr))
+
+	for _, c := range arr {
+		if c == 0x00 {
+			break
+		}
+
+		output = append(output, byte(c))
+	}
+
+	alternateOS := string(output)
+	if alternateOS != "" && !strings.EqualFold(alternateOS, os) {
+		return fmt.Sprintf("%s-%s", alternateOS, os)
+	}
+
+	return os
+}

--- a/pkg/system/system_other.go
+++ b/pkg/system/system_other.go
@@ -1,0 +1,12 @@
+//go:build !linux
+
+package system
+
+import (
+	"runtime"
+)
+
+// OSName returns the runtime machine's operating system name.
+func OSName() string {
+	return runtime.GOOS
+}


### PR DESCRIPTION
When running in [Termux](https://play.google.com/store/apps/details?id=com.termux&hl=en_US&gl=US), for example when coding with an Android Tablet, the output from `wakatime-cli --user-agent` should look like:

`wakatime/v1.49.0 (Android-linux-5.4.0-104-generic-x86_64) go1.18.3 vim/800 vim-wakatime/9.0.1`

Previously, it would not include `Android` in the user agent string:

`wakatime/v1.49.0 (linux-5.4.0-104-generic-x86_64) go1.18.3 vim/800 vim-wakatime/9.0.1`