### PR TITLE
Update 'Vim script' to 'Vim Script'

### DIFF
--- a/pkg/heartbeat/language.go
+++ b/pkg/heartbeat/language.go
@@ -2249,7 +2249,7 @@ const (
 	languageVHDLStr                        = "VHDL"
 	languageVimHelpFileStr                 = "Vim Help File"
 	languageVimLStr                        = "VimL"
-	languageVimScriptStr                   = "Vim script"
+	languageVimScriptStr                   = "Vim Script"
 	languageVimSnippetStr                  = "Vim Snippet"
 	languageVisualBasicNet                 = "Visual Basic .NET"
 	languageVoltStr                        = "Volt"

--- a/pkg/heartbeat/language_test.go
+++ b/pkg/heartbeat/language_test.go
@@ -718,7 +718,7 @@ func languageTests() map[string]heartbeat.Language {
 		"VHDL":                             heartbeat.LanguageVHDL,
 		"Vim Help File":                    heartbeat.LanguageVimHelpFile,
 		"VimL":                             heartbeat.LanguageVimL,
-		"Vim script":                       heartbeat.LanguageVimScript,
+		"Vim Script":                       heartbeat.LanguageVimScript,
 		"Vim Snippet":                      heartbeat.LanguageVimSnippet,
 		"Volt":                             heartbeat.LanguageVolt,
 		"Vue.js":                           heartbeat.LanguageVueJS,


### PR DESCRIPTION
Update the name for the Vim language to conform to the newly updated name in [GitHub linguist](https://github.com/github/linguist/blob/master/lib/linguist/languages.yml#L6851).