### PR TITLE
We dont need EntityRaw

### DIFF
--- a/pkg/api/auth.go
+++ b/pkg/api/auth.go
@@ -22,7 +22,9 @@ func (a BasicAuth) HeaderValue() (string, error) {
 		return fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString(
 			[]byte(a.User+":"),
 		)), nil
-	} else if a.User == "" {
+	}
+
+	if a.User == "" {
 		return fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString(
 			[]byte(a.Secret),
 		)), nil

--- a/pkg/heartbeat/heartbeat.go
+++ b/pkg/heartbeat/heartbeat.go
@@ -19,29 +19,29 @@ var remoteAddressRegex = regexp.MustCompile(`(?i)^((ssh|sftp)://)+(?P<credential
 
 // Heartbeat is a structure representing activity for a user on a some entity.
 type Heartbeat struct {
-	ApiKey              string     `json:"-"`
-	Branch              *string    `json:"branch"`
-	BranchAlternate     string     `json:"-"`
-	Category            Category   `json:"category"`
-	CursorPosition      *int       `json:"cursorpos"`
-	Dependencies        []string   `json:"dependencies"`
-	Entity              string     `json:"entity"`
-	EntityRaw           string     `json:"-"`
-	EntityType          EntityType `json:"type"`
-	IsUnsavedEntity     bool       `json:"-"`
-	IsWrite             *bool      `json:"is_write"`
-	Language            *string    `json:"language"`
-	LanguageAlternate   string     `json:"-"`
-	LineNumber          *int       `json:"lineno"`
-	Lines               *int       `json:"lines"`
-	LocalFile           string     `json:"-"`
-	Project             *string    `json:"project"`
-	ProjectAlternate    string     `json:"-"`
-	ProjectOverride     string     `json:"-"`
-	ProjectPath         string     `json:"-"`
-	ProjectPathOverride string     `json:"-"`
-	Time                float64    `json:"time"`
-	UserAgent           string     `json:"user_agent"`
+	ApiKey                string     `json:"-"`
+	Branch                *string    `json:"branch"`
+	BranchAlternate       string     `json:"-"`
+	Category              Category   `json:"category"`
+	CursorPosition        *int       `json:"cursorpos"`
+	Dependencies          []string   `json:"dependencies"`
+	Entity                string     `json:"entity"`
+	EntityType            EntityType `json:"type"`
+	IsUnsavedEntity       bool       `json:"-"`
+	IsWrite               *bool      `json:"is_write"`
+	Language              *string    `json:"language"`
+	LanguageAlternate     string     `json:"-"`
+	LineNumber            *int       `json:"lineno"`
+	Lines                 *int       `json:"lines"`
+	LocalFile             string     `json:"-"`
+	LocalFileNeedsCleanup bool       `json:"-"`
+	Project               *string    `json:"project"`
+	ProjectAlternate      string     `json:"-"`
+	ProjectOverride       string     `json:"-"`
+	ProjectPath           string     `json:"-"`
+	ProjectPathOverride   string     `json:"-"`
+	Time                  float64    `json:"time"`
+	UserAgent             string     `json:"user_agent"`
 }
 
 // New creates a new instance of Heartbeat with formatted entity

--- a/pkg/offline/offline.go
+++ b/pkg/offline/offline.go
@@ -464,10 +464,6 @@ func (q *Queue) PushMany(hh []heartbeat.Heartbeat) error {
 	}
 
 	for _, h := range hh {
-		if h.EntityRaw != "" {
-			h.Entity = h.EntityRaw
-		}
-
 		data, err := json.Marshal(h)
 		if err != nil {
 			return fmt.Errorf("failed to json marshal heartbeat: %s", err)

--- a/pkg/project/filter.go
+++ b/pkg/project/filter.go
@@ -29,7 +29,7 @@ func WithFiltering(config FilterConfig) heartbeat.HandleOption {
 				if err != nil {
 					log.Debugln(err.Error())
 
-					if h.EntityRaw != "" {
+					if h.LocalFileNeedsCleanup {
 						err = os.Remove(h.LocalFile)
 						if err != nil {
 							log.Warnf("unable to delete tmp file: %s", err)

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -216,7 +216,9 @@ func Detect(patterns []MapPattern, args ...DetecterArg) (Result, DetectorID) {
 			if err != nil {
 				log.Errorf("unexpected error occurred at %q: %s", p.ID().String(), err)
 				continue
-			} else if detected {
+			}
+
+			if detected {
 				return result, p.ID()
 			}
 		}

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -95,10 +95,8 @@ func WithDetection() heartbeat.HandleOption {
 					continue
 				}
 
-				// save original entity for offline handling
-				h.EntityRaw = h.Entity
-				// use downloaded file for stats and language detection
 				h.LocalFile = tmpFile.Name()
+				h.LocalFileNeedsCleanup = true
 
 				filtered = append(filtered, h)
 			}
@@ -116,7 +114,7 @@ func WithCleanup() heartbeat.HandleOption {
 			log.Debugln("execute remote cleanup")
 
 			for _, h := range hh {
-				if h.EntityRaw != "" {
+				if h.LocalFileNeedsCleanup {
 					log.Debugln("deleting temporary file: %s", h.LocalFile)
 
 					deleteLocalFile(h.LocalFile)

--- a/pkg/remote/remote_test.go
+++ b/pkg/remote/remote_test.go
@@ -96,13 +96,13 @@ func TestWithDetection_SshConfig_Hostname(t *testing.T) {
 		SendHeartbeatsFn: func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
 			assert.Equal(t, []heartbeat.Heartbeat{
 				{
-					Category:   heartbeat.CodingCategory,
-					Entity:     "ssh://user:pass@example.com:" + strconv.Itoa(port) + entity,
-					EntityRaw:  "ssh://user:pass@example.com:" + strconv.Itoa(port) + entity,
-					EntityType: heartbeat.FileType,
-					LocalFile:  hh[0].LocalFile,
-					Time:       1585598060,
-					UserAgent:  "wakatime/13.0.7",
+					Category:              heartbeat.CodingCategory,
+					Entity:                "ssh://user:pass@example.com:" + strconv.Itoa(port) + entity,
+					EntityType:            heartbeat.FileType,
+					LocalFile:             hh[0].LocalFile,
+					LocalFileNeedsCleanup: true,
+					Time:                  1585598060,
+					UserAgent:             "wakatime/13.0.7",
 				},
 			}, hh)
 			assert.Contains(t, hh[0].LocalFile, "main.go")
@@ -239,13 +239,13 @@ func TestWithDetection_SshConfig_UserKnownHostsFile_Match(t *testing.T) {
 		SendHeartbeatsFn: func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
 			assert.Equal(t, []heartbeat.Heartbeat{
 				{
-					Category:   heartbeat.CodingCategory,
-					Entity:     "ssh://user:pass@example.com:" + strconv.Itoa(port) + entity,
-					EntityRaw:  "ssh://user:pass@example.com:" + strconv.Itoa(port) + entity,
-					EntityType: heartbeat.FileType,
-					LocalFile:  hh[0].LocalFile,
-					Time:       1585598060,
-					UserAgent:  "wakatime/13.0.7",
+					Category:              heartbeat.CodingCategory,
+					Entity:                "ssh://user:pass@example.com:" + strconv.Itoa(port) + entity,
+					EntityType:            heartbeat.FileType,
+					LocalFile:             hh[0].LocalFile,
+					LocalFileNeedsCleanup: true,
+					Time:                  1585598060,
+					UserAgent:             "wakatime/13.0.7",
 				},
 			}, hh)
 			assert.Contains(t, hh[0].LocalFile, "main.go")
@@ -413,8 +413,8 @@ func TestWithCleanup(t *testing.T) {
 
 	_, err = handle([]heartbeat.Heartbeat{
 		{
-			LocalFile: tmpFile.Name(),
-			EntityRaw: "/some/remote/file",
+			LocalFile:             tmpFile.Name(),
+			LocalFileNeedsCleanup: true,
 		},
 	})
 	require.NoError(t, err)

--- a/pkg/windows/windows.go
+++ b/pkg/windows/windows.go
@@ -248,7 +248,9 @@ func parseNetUseColumns(line string) (netUseColumns, error) {
 
 	if cols.Local.Empty() {
 		return netUseColumns{}, errors.New("failed to parse local column")
-	} else if cols.Remote.Empty() {
+	}
+
+	if cols.Remote.Empty() {
 		return netUseColumns{}, errors.New("failed to parse remote column")
 	}
 


### PR DESCRIPTION
When pushing heartbeats to the offline db, we should save the entity after filtering & formatting. The same entity that we send to the API should be saved to the offline db, not the original entity from `EntityRaw`. That's because when we send offline heartbeats to API, we don't re-run filtering & formatting. If we save `EntityRaw` to offline db, then we miss filtering & formatting on that entity when sending to API later.

Also implements #750.