### PR TITLE
Preserve original DNS error when retrying request fails

### DIFF
--- a/pkg/api/transport.go
+++ b/pkg/api/transport.go
@@ -24,7 +24,7 @@ func NewTransport() *http.Transport {
 }
 
 // NewTransportWithHostVerificationDisabled initializes a new http.Transport with disabled host verification.
-func NewTransportWithHostVerificationDisabled() (*http.Transport, error) {
+func NewTransportWithHostVerificationDisabled() *http.Transport {
 	t := NewTransport()
 
 	t.TLSClientConfig = &tls.Config{
@@ -33,7 +33,7 @@ func NewTransportWithHostVerificationDisabled() (*http.Transport, error) {
 		ServerName: serverName,
 	}
 
-	return t, nil
+	return t
 }
 
 // LazyCreateNewTransport uses the client's Transport if exists, or creates a new one.


### PR DESCRIPTION
When the dns retry fails we lose the original DNS error:
```
{"caller":"pkg/api/api.go:106","func":"api.isLocalIPv6","level":"warning","message":"failed dialing to detect default local ip address: dial udp 143.244.210.202:80: connect: network is unreachable","now":"2022-10-01T14:19:02-03:00","version":"v1.55.1"}
{"caller":"pkg/api/api.go:95","func":"api.(*Client)","level":"warning","message":"dns error, it will retry with host ip address '2604:a880:4:1d0::2a7:b000'","now":"2022-10-01T14:19:02-03:00","version":"v1.55.1"}
{"caller":"cmd/run.go:270","func":"cmd.runCmd","level":"error","message":"failed to run command: sending heartbeat(s) later due to api error: failed making request to \"https://api.wakatime.com/api/v1/users/current/heartbeats.bulk\": Post \"https://2604:a880:4:1d0::2a7:b000/api/v1/users/current/heartbeats.bulk\": dial tcp [2604:a880:4:1d0::2a7:b000]:443: connect: no route to host","now":"2022-10-01T14:19:02-03:00","version":"v1.55.1"}
```

This PR preserves and concats the original DNS error message to the retry error message.