### PR TITLE
Add ssh instructions to troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,13 @@ See [Usage][usage] or the [WakaTime FAQ][faq] for more details.
 Pull requests and issues are welcome!
 See [Contributing][contributing] for more details.
 
+## Troubleshooting
+
+See [Troubleshooting][troubleshooting] for more details.
+
 Many thanks to all [contributors][authors]!
 
 Made with :heart: by the WakaTime Team.
-
 
 [wakatime]: http://wakatime.com
 [editors]: http://wakatime.com/editors
@@ -37,4 +40,5 @@ Made with :heart: by the WakaTime Team.
 [faq]: https://wakatime.com/faq
 [usage]: USAGE.md
 [contributing]: CONTRIBUTING.md
+[troubleshooting]: TROUBLESHOOTING.md
 [authors]: AUTHORS

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -43,4 +43,4 @@ Useful Resources:
 
 ## SSH configuration
 
-If you are connected to a remote host using the [ssh extension](https://code.visualstudio.com/docs/remote/ssh) you might want to force WakaTime to run locally instead on the server. This configuration is needed when the server you connect is shared among other people. Please follow [this](https://code.visualstudio.com/docs/remote/ssh#_advanced-forcing-an-extension-to-run-locally-remotely) guide.
+If you’re connected to a remote host using the [ssh extension](https://code.visualstudio.com/docs/remote/ssh) you might want to force WakaTime to run locally, for example when the server you connect to is shared among multiple people. Please follow [this guide](https://code.visualstudio.com/docs/remote/ssh#_advanced-forcing-an-extension-to-run-locally-remotely).

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -4,7 +4,7 @@ First, read [How to debug WakaTime plugins][faq debug plugins].
 
 Set `debug=true` in your `~/.wakatime.cfg` file to enable verbose logging.
 
-The common wakatime-cli program logs to your User `$HOME` directory `~/.wakatime.log`.
+The common wakatime-cli program logs to your user `$HOME` directory `~/.wakatime.log`.
 
 Each plugin also has its own log file:
 
@@ -37,7 +37,10 @@ Useful Resources:
 * [More Troubleshooting Info][faq debug plugins]
 * [Official API Docs][api docs]
 
-
 [faq debug plugins]: https://wakatime.com/faq#debug-plugins
 [api docs]: https://wakatime.com/developers/
 [locating IDE log files]: https://intellij-support.jetbrains.com/hc/en-us/articles/207241085-Locating-IDE-log-files
+
+## SSH configuration
+
+If you are connected to a remote host using the [ssh extension](https://code.visualstudio.com/docs/remote/ssh) you might want to force WakaTime to run locally instead on the server. This configuration is needed when the server you connect is shared among other people. Please follow [this](https://code.visualstudio.com/docs/remote/ssh#_advanced-forcing-an-extension-to-run-locally-remotely) guide.


### PR DESCRIPTION
This PR adds a dedicated section to help developers who might want to use WakaTime while connected to shared remote servers.