### PR TITLE
Fix linter rules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,7 +29,6 @@ linters-settings:
       - name: blank-imports
       - name: duplicated-imports
       - name: dot-imports
-      - name: package-comments
       - name: exported
       - name: superfluous-else
       - name: indent-error-flow
@@ -49,5 +48,11 @@ linters-settings:
       - name: unused-parameter
       - name: unused-receiver
 issues:
+  exclude-use-default: false
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - errcheck
+        - gosec
   include:
     - EXC0002

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -206,7 +206,7 @@ func SetupLogging(v *viper.Viper) *logfile.Params {
 	logFile := os.Stdout
 
 	if !logfileParams.ToStdout {
-		logFile, err = os.OpenFile(logfileParams.File, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0666)
+		logFile, err = os.OpenFile(logfileParams.File, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error opening log file: %s", err)
 			log.Fatalf("error opening log file: %s", err)

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -104,7 +104,11 @@ func isLocalIPv6() bool {
 		return true
 	}
 
-	defer conn.Close()
+	defer func() {
+		if err := conn.Close(); err != nil {
+			log.Debugf("failed to close connection to api wakatime: %s", err)
+		}
+	}()
 
 	localAddr := conn.LocalAddr().(*net.UDPAddr)
 

--- a/pkg/api/diagnostic.go
+++ b/pkg/api/diagnostic.go
@@ -61,7 +61,7 @@ func (c *Client) SendDiagnostics(plugin string, diagnostics ...diagnostic.Diagno
 	if err != nil {
 		return Err{Err: fmt.Errorf("failed making request to %q: %s", url, err)}
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() // nolint:errcheck
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/pkg/api/goal.go
+++ b/pkg/api/goal.go
@@ -26,7 +26,7 @@ func (c *Client) Goal(id string) (*goal.Goal, error) {
 	if err != nil {
 		return nil, Err{Err: fmt.Errorf("failed to make request to %q: %s", url, err)}
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() // nolint:errcheck
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/pkg/api/heartbeat.go
+++ b/pkg/api/heartbeat.go
@@ -65,7 +65,7 @@ func (c *Client) sendHeartbeats(url string, heartbeats []heartbeat.Heartbeat) ([
 	if err != nil {
 		return nil, Err{Err: fmt.Errorf("failed making request to %q: %s", url, err)}
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() // nolint:errcheck
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/pkg/api/option.go
+++ b/pkg/api/option.go
@@ -129,7 +129,7 @@ func WithProxy(proxyURL string) (Option, error) {
 
 // WithSSLCertFile overrides the default CA certs file to trust specified cert file.
 func WithSSLCertFile(filepath string) (Option, error) {
-	caCert, err := os.ReadFile(filepath)
+	caCert, err := os.ReadFile(filepath) // nolint:gosec
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/api/summary.go
+++ b/pkg/api/summary.go
@@ -29,7 +29,8 @@ func (c *Client) Today() (*summary.Summary, error) {
 	if err != nil {
 		return nil, Err{fmt.Errorf("failed to make request to %q: %s", url, err)}
 	}
-	defer resp.Body.Close()
+
+	defer resp.Body.Close() // nolint:errcheck
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/pkg/api/transport_windows.go
+++ b/pkg/api/transport_windows.go
@@ -45,7 +45,7 @@ func loadSystemRoots() (*x509.CertPool, error) {
 			break
 		}
 		// Copy the buf, since ParseCertificate does not create its own copy.
-		buf := (*[1 << 20]byte)(unsafe.Pointer(cert.EncodedCert))[:cert.Length:cert.Length]
+		buf := (*[1 << 20]byte)(unsafe.Pointer(cert.EncodedCert))[:cert.Length:cert.Length] // nolint:gosec
 		buf2 := make([]byte, cert.Length)
 		copy(buf2, buf)
 

--- a/pkg/deps/c.go
+++ b/pkg/deps/c.go
@@ -7,6 +7,8 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/wakatime/wakatime-cli/pkg/log"
+
 	"github.com/alecthomas/chroma"
 	"github.com/alecthomas/chroma/lexers/c"
 )
@@ -32,12 +34,16 @@ type ParserC struct {
 
 // Parse parses dependencies from C file content using the C lexer.
 func (p *ParserC) Parse(filepath string) ([]string, error) {
-	reader, err := os.Open(filepath)
+	reader, err := os.Open(filepath) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
 	}
 
-	defer reader.Close()
+	defer func() {
+		if err := reader.Close(); err != nil {
+			log.Debugf("failed to close file: %s", err)
+		}
+	}()
 
 	p.init()
 	defer p.init()

--- a/pkg/deps/csharp.go
+++ b/pkg/deps/csharp.go
@@ -7,6 +7,8 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/wakatime/wakatime-cli/pkg/log"
+
 	"github.com/alecthomas/chroma"
 	"github.com/alecthomas/chroma/lexers/c"
 )
@@ -33,12 +35,16 @@ type ParserCSharp struct {
 
 // Parse parses dependencies from C# file content using the chroma C# lexer.
 func (p *ParserCSharp) Parse(filepath string) ([]string, error) {
-	reader, err := os.Open(filepath)
+	reader, err := os.Open(filepath) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
 	}
 
-	defer reader.Close()
+	defer func() {
+		if err := reader.Close(); err != nil {
+			log.Debugf("failed to close file: %s", err)
+		}
+	}()
 
 	p.init()
 	defer p.init()

--- a/pkg/deps/elm.go
+++ b/pkg/deps/elm.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/wakatime/wakatime-cli/pkg/log"
+
 	"github.com/alecthomas/chroma"
 	"github.com/alecthomas/chroma/lexers/e"
 )
@@ -29,12 +31,16 @@ type ParserElm struct {
 
 // Parse parses dependencies from Elm file content using the chroma Elm lexer.
 func (p *ParserElm) Parse(filepath string) ([]string, error) {
-	reader, err := os.Open(filepath)
+	reader, err := os.Open(filepath) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
 	}
 
-	defer reader.Close()
+	defer func() {
+		if err := reader.Close(); err != nil {
+			log.Debugf("failed to close file: %s", err)
+		}
+	}()
 
 	p.init()
 	defer p.init()

--- a/pkg/deps/golang.go
+++ b/pkg/deps/golang.go
@@ -7,6 +7,8 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/wakatime/wakatime-cli/pkg/log"
+
 	"github.com/alecthomas/chroma"
 	"github.com/alecthomas/chroma/lexers/g"
 )
@@ -33,12 +35,16 @@ type ParserGo struct {
 
 // Parse parses dependencies from Golang file content using the chroma Golang lexer.
 func (p *ParserGo) Parse(filepath string) ([]string, error) {
-	reader, err := os.Open(filepath)
+	reader, err := os.Open(filepath) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
 	}
 
-	defer reader.Close()
+	defer func() {
+		if err := reader.Close(); err != nil {
+			log.Debugf("failed to close file: %s", err)
+		}
+	}()
 
 	p.init()
 	defer p.init()

--- a/pkg/deps/haskell.go
+++ b/pkg/deps/haskell.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/wakatime/wakatime-cli/pkg/log"
+
 	"github.com/alecthomas/chroma"
 	"github.com/alecthomas/chroma/lexers/h"
 )
@@ -29,12 +31,16 @@ type ParserHaskell struct {
 
 // Parse parses dependencies from Haskell file content using the chroma Haskell lexer.
 func (p *ParserHaskell) Parse(filepath string) ([]string, error) {
-	reader, err := os.Open(filepath)
+	reader, err := os.Open(filepath) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
 	}
 
-	defer reader.Close()
+	defer func() {
+		if err := reader.Close(); err != nil {
+			log.Debugf("failed to close file: %s", err)
+		}
+	}()
 
 	p.init()
 	defer p.init()

--- a/pkg/deps/haxe.go
+++ b/pkg/deps/haxe.go
@@ -7,11 +7,12 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/wakatime/wakatime-cli/pkg/log"
+
 	"github.com/alecthomas/chroma"
 	"github.com/alecthomas/chroma/lexers/h"
 )
 
-// nolint:noglobal
 var haxeExcludeRegex = regexp.MustCompile(`(?i)^haxe$`)
 
 // StateHaxe is a token parsing state.
@@ -33,12 +34,16 @@ type ParserHaxe struct {
 
 // Parse parses dependencies from Haxe file content using the chroma Haxe lexer.
 func (p *ParserHaxe) Parse(filepath string) ([]string, error) {
-	reader, err := os.Open(filepath)
+	reader, err := os.Open(filepath) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
 	}
 
-	defer reader.Close()
+	defer func() {
+		if err := reader.Close(); err != nil {
+			log.Debugf("failed to close file: %s", err)
+		}
+	}()
 
 	p.init()
 	defer p.init()

--- a/pkg/deps/html.go
+++ b/pkg/deps/html.go
@@ -7,6 +7,8 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/wakatime/wakatime-cli/pkg/log"
+
 	"github.com/alecthomas/chroma"
 	"github.com/alecthomas/chroma/lexers/h"
 )
@@ -34,12 +36,16 @@ type ParserHTML struct {
 
 // Parse parses dependencies from HTML file content via ReadCloser using the chroma HTML lexer.
 func (p *ParserHTML) Parse(filepath string) ([]string, error) {
-	reader, err := os.Open(filepath)
+	reader, err := os.Open(filepath) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
 	}
 
-	defer reader.Close()
+	defer func() {
+		if err := reader.Close(); err != nil {
+			log.Debugf("failed to close file: %s", err)
+		}
+	}()
 
 	p.init()
 	defer p.init()

--- a/pkg/deps/java.go
+++ b/pkg/deps/java.go
@@ -7,6 +7,8 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/wakatime/wakatime-cli/pkg/log"
+
 	"github.com/alecthomas/chroma"
 	"github.com/alecthomas/chroma/lexers/j"
 )
@@ -35,12 +37,16 @@ type ParserJava struct {
 
 // Parse parses dependencies from Java file content using the chroma Java lexer.
 func (p *ParserJava) Parse(filepath string) ([]string, error) {
-	reader, err := os.Open(filepath)
+	reader, err := os.Open(filepath) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
 	}
 
-	defer reader.Close()
+	defer func() {
+		if err := reader.Close(); err != nil {
+			log.Debugf("failed to close file: %s", err)
+		}
+	}()
 
 	p.init()
 	defer p.init()

--- a/pkg/deps/javascript.go
+++ b/pkg/deps/javascript.go
@@ -7,11 +7,12 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/wakatime/wakatime-cli/pkg/log"
+
 	"github.com/alecthomas/chroma"
 	"github.com/alecthomas/chroma/lexers/j"
 )
 
-// nolint:noglobal
 var javaScriptExtensionRegex = regexp.MustCompile(`\.\w{1,4}$`)
 
 // StateJavaScript is a token parsing state.
@@ -33,12 +34,16 @@ type ParserJavaScript struct {
 
 // Parse parses dependencies from JavaScript file content using the chroma JavaScript lexer.
 func (p *ParserJavaScript) Parse(filepath string) ([]string, error) {
-	reader, err := os.Open(filepath)
+	reader, err := os.Open(filepath) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
 	}
 
-	defer reader.Close()
+	defer func() {
+		if err := reader.Close(); err != nil {
+			log.Debugf("failed to close file: %s", err)
+		}
+	}()
 
 	p.init()
 	defer p.init()

--- a/pkg/deps/json.go
+++ b/pkg/deps/json.go
@@ -7,11 +7,13 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/wakatime/wakatime-cli/pkg/log"
+
 	"github.com/alecthomas/chroma"
 	"github.com/alecthomas/chroma/lexers/j"
 )
 
-// nolint: gochecknoglobals
+// nolint:gochecknoglobals
 var filesJSON = map[string]struct {
 	exact      bool
 	dependency string
@@ -41,12 +43,16 @@ type ParserJSON struct {
 
 // Parse parses dependencies from JSON file content using the chroma JSON lexer.
 func (p *ParserJSON) Parse(filepath string) ([]string, error) {
-	reader, err := os.Open(filepath)
+	reader, err := os.Open(filepath) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
 	}
 
-	defer reader.Close()
+	defer func() {
+		if err := reader.Close(); err != nil {
+			log.Debugf("failed to close file: %s", err)
+		}
+	}()
 
 	p.init()
 	defer p.init()

--- a/pkg/deps/kotlin.go
+++ b/pkg/deps/kotlin.go
@@ -7,6 +7,8 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/wakatime/wakatime-cli/pkg/log"
+
 	"github.com/alecthomas/chroma"
 	"github.com/alecthomas/chroma/lexers/k"
 )
@@ -32,12 +34,16 @@ type ParserKotlin struct {
 
 // Parse parses dependencies from Kotlin file content using the chroma Kotlin lexer.
 func (p *ParserKotlin) Parse(filepath string) ([]string, error) {
-	reader, err := os.Open(filepath)
+	reader, err := os.Open(filepath) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
 	}
 
-	defer reader.Close()
+	defer func() {
+		if err := reader.Close(); err != nil {
+			log.Debugf("failed to close file: %s", err)
+		}
+	}()
 
 	p.init()
 	defer p.init()

--- a/pkg/deps/objectivec.go
+++ b/pkg/deps/objectivec.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/wakatime/wakatime-cli/pkg/log"
+
 	"github.com/alecthomas/chroma"
 	"github.com/alecthomas/chroma/lexers/o"
 )
@@ -29,12 +31,16 @@ type ParserObjectiveC struct {
 
 // Parse parses dependencies from Objective-C file content using the chroma Objective-C lexer.
 func (p *ParserObjectiveC) Parse(filepath string) ([]string, error) {
-	reader, err := os.Open(filepath)
+	reader, err := os.Open(filepath) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
 	}
 
-	defer reader.Close()
+	defer func() {
+		if err := reader.Close(); err != nil {
+			log.Debugf("failed to close file: %s", err)
+		}
+	}()
 
 	p.init()
 	defer p.init()

--- a/pkg/deps/php.go
+++ b/pkg/deps/php.go
@@ -7,11 +7,12 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/wakatime/wakatime-cli/pkg/log"
+
 	"github.com/alecthomas/chroma"
 	"github.com/alecthomas/chroma/lexers/circular"
 )
 
-// nolint:noglobals
 var phpExcludeRegex = regexp.MustCompile(`(?i)(^app|app\.php)$`)
 
 // StatePHP is a token parsing state.
@@ -39,12 +40,16 @@ type ParserPHP struct {
 
 // Parse parses dependencies from PHP file content using the chroma PHP lexer.
 func (p *ParserPHP) Parse(filepath string) ([]string, error) {
-	reader, err := os.Open(filepath)
+	reader, err := os.Open(filepath) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
 	}
 
-	defer reader.Close()
+	defer func() {
+		if err := reader.Close(); err != nil {
+			log.Debugf("failed to close file: %s", err)
+		}
+	}()
 
 	p.init()
 	defer p.init()

--- a/pkg/deps/python.go
+++ b/pkg/deps/python.go
@@ -7,11 +7,12 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/wakatime/wakatime-cli/pkg/log"
+
 	"github.com/alecthomas/chroma"
 	lp "github.com/alecthomas/chroma/lexers/p"
 )
 
-// nolint:noglobal
 var pythonExcludeRegex = regexp.MustCompile(`(?i)^(os|sys|__[a-z]+__)$`)
 
 // StatePython is a token parsing state.
@@ -36,12 +37,16 @@ type ParserPython struct {
 
 // Parse parses dependencies from Python file content using the chroma Python lexer.
 func (p *ParserPython) Parse(filepath string) ([]string, error) {
-	reader, err := os.Open(filepath)
+	reader, err := os.Open(filepath) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
 	}
 
-	defer reader.Close()
+	defer func() {
+		if err := reader.Close(); err != nil {
+			log.Debugf("failed to close file: %s", err)
+		}
+	}()
 
 	p.init()
 	defer p.init()

--- a/pkg/deps/rust.go
+++ b/pkg/deps/rust.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/wakatime/wakatime-cli/pkg/log"
+
 	"github.com/alecthomas/chroma"
 	"github.com/alecthomas/chroma/lexers/r"
 )
@@ -31,12 +33,16 @@ type ParserRust struct {
 
 // Parse parses dependencies from Rust file content using the chroma Rust lexer.
 func (p *ParserRust) Parse(filepath string) ([]string, error) {
-	reader, err := os.Open(filepath)
+	reader, err := os.Open(filepath) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
 	}
 
-	defer reader.Close()
+	defer func() {
+		if err := reader.Close(); err != nil {
+			log.Debugf("failed to close file: %s", err)
+		}
+	}()
 
 	p.init()
 	defer p.init()

--- a/pkg/deps/scala.go
+++ b/pkg/deps/scala.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/wakatime/wakatime-cli/pkg/log"
+
 	"github.com/alecthomas/chroma"
 	"github.com/alecthomas/chroma/lexers/s"
 )
@@ -29,12 +31,16 @@ type ParserScala struct {
 
 // Parse parses dependencies from Scala file content using the chroma Scala lexer.
 func (p *ParserScala) Parse(filepath string) ([]string, error) {
-	reader, err := os.Open(filepath)
+	reader, err := os.Open(filepath) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
 	}
 
-	defer reader.Close()
+	defer func() {
+		if err := reader.Close(); err != nil {
+			log.Debugf("failed to close file: %s", err)
+		}
+	}()
 
 	p.init()
 	defer p.init()

--- a/pkg/deps/swift.go
+++ b/pkg/deps/swift.go
@@ -7,11 +7,12 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/wakatime/wakatime-cli/pkg/log"
+
 	"github.com/alecthomas/chroma"
 	"github.com/alecthomas/chroma/lexers/s"
 )
 
-// nolint:noglobals
 var swiftExcludeRegex = regexp.MustCompile(`(?i)^foundation$`)
 
 // StateSwift is a token parsing state.
@@ -33,12 +34,16 @@ type ParserSwift struct {
 
 // Parse parses dependencies from Swift file content using the chroma Swift lexer.
 func (p *ParserSwift) Parse(filepath string) ([]string, error) {
-	reader, err := os.Open(filepath)
+	reader, err := os.Open(filepath) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
 	}
 
-	defer reader.Close()
+	defer func() {
+		if err := reader.Close(); err != nil {
+			log.Debugf("failed to close file: %s", err)
+		}
+	}()
 
 	p.init()
 	defer p.init()

--- a/pkg/deps/vbnet.go
+++ b/pkg/deps/vbnet.go
@@ -7,6 +7,8 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/wakatime/wakatime-cli/pkg/log"
+
 	"github.com/alecthomas/chroma"
 	"github.com/alecthomas/chroma/lexers/v"
 )
@@ -33,12 +35,16 @@ type ParserVbNet struct {
 
 // Parse parses dependencies from VB.Net file content using the chroma VB.Net lexer.
 func (p *ParserVbNet) Parse(filepath string) ([]string, error) {
-	reader, err := os.Open(filepath)
+	reader, err := os.Open(filepath) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
 	}
 
-	defer reader.Close()
+	defer func() {
+		if err := reader.Close(); err != nil {
+			log.Debugf("failed to close file: %s", err)
+		}
+	}()
 
 	p.init()
 	defer p.init()

--- a/pkg/filestats/filestats.go
+++ b/pkg/filestats/filestats.go
@@ -75,11 +75,16 @@ func WithDetection() heartbeat.HandleOption {
 }
 
 func countLineNumbers(filepath string) (int, error) {
-	f, err := os.Open(filepath)
+	f, err := os.Open(filepath) //nolint:gosec
 	if err != nil {
 		return 0, fmt.Errorf("failed to open file: %s", err)
 	}
-	defer f.Close()
+
+	defer func() {
+		if err := f.Close(); err != nil {
+			log.Debugf("failed to close file: %s", err)
+		}
+	}()
 
 	buf := make([]byte, 32*1024)
 	count := 0

--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -43,7 +43,7 @@ func WithFiltering(config Config) heartbeat.HandleOption {
 	}
 }
 
-// WithHeartbeatsLengthValidator initializes and returns a heartbeat handle option, which
+// WithLengthValidator initializes and returns a heartbeat handle option, which
 // can be used to abort execution if all heartbeats were filtered and the list is empty.
 func WithLengthValidator() heartbeat.HandleOption {
 	return func(next heartbeat.Handle) heartbeat.Handle {

--- a/pkg/heartbeat/heartbeat.go
+++ b/pkg/heartbeat/heartbeat.go
@@ -139,7 +139,7 @@ type Sender interface {
 	SendHeartbeats(hh []Heartbeat) ([]Result, error)
 }
 
-// Sender is a noop api client, used to always skip sending to the API.
+// Noop is a noop api client, used to always skip sending to the API.
 type Noop struct{}
 
 // SendHeartbeats always returns nil.

--- a/pkg/ini/ini.go
+++ b/pkg/ini/ini.go
@@ -52,12 +52,14 @@ func NewWriter(v *viper.Viper, filepathFn func(v *viper.Viper) (string, error)) 
 	if !fileExists(configFilepath) {
 		log.Debugf("it will create missing config file %q", configFilepath)
 
-		f, err := os.Create(configFilepath)
+		f, err := os.Create(configFilepath) // nolint:gosec
 		if err != nil {
 			return nil, fmt.Errorf("failed creating file: %s", err)
 		}
 
-		f.Close()
+		if err = f.Close(); err != nil {
+			return nil, fmt.Errorf("failed to close file: %s", err)
+		}
 	}
 
 	ini, err := ini.LoadSources(ini.LoadOptions{

--- a/pkg/language/chroma.go
+++ b/pkg/language/chroma.go
@@ -203,12 +203,16 @@ func selectByCustomizedPriority(filepath string, lexers chroma.PrioritisedLexers
 
 // fileHead returns the first `maxFileSize` bytes of the file's content.
 func fileHead(filepath string) ([]byte, error) {
-	f, err := os.Open(filepath)
+	f, err := os.Open(filepath) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file: %s", err)
 	}
 
-	defer f.Close()
+	defer func() {
+		if err := f.Close(); err != nil {
+			log.Debugf("failed to close file '%s': %s", filepath, err)
+		}
+	}()
 
 	data := make([]byte, maxFileSize)
 

--- a/pkg/offline/offline.go
+++ b/pkg/offline/offline.go
@@ -235,7 +235,11 @@ func popHeartbeats(filepath string, limit int) ([]heartbeat.Heartbeat, error) {
 		return nil, fmt.Errorf("failed to open db connection: %s", err)
 	}
 
-	defer db.Close()
+	defer func() {
+		if err := db.Close(); err != nil {
+			log.Debugf("failed to close db file: %s", err)
+		}
+	}()
 
 	tx, err := db.Begin(true)
 	if err != nil {
@@ -305,7 +309,11 @@ func pushHeartbeats(filepath string, hh []heartbeat.Heartbeat) error {
 		return fmt.Errorf("failed to open db connection: %s", err)
 	}
 
-	defer db.Close()
+	defer func() {
+		if err := db.Close(); err != nil {
+			log.Debugf("failed to close db file: %s", err)
+		}
+	}()
 
 	tx, err := db.Begin(true)
 	if err != nil {
@@ -333,7 +341,11 @@ func CountHeartbeats(filepath string) (int, error) {
 		return 0, fmt.Errorf("failed to open db connection: %s", err)
 	}
 
-	defer db.Close()
+	defer func() {
+		if err := db.Close(); err != nil {
+			log.Debugf("failed to close db file: %s", err)
+		}
+	}()
 
 	tx, err := db.Begin(true)
 	if err != nil {
@@ -364,7 +376,11 @@ func ReadHeartbeats(filepath string, limit int) ([]heartbeat.Heartbeat, error) {
 		return nil, fmt.Errorf("failed to open db connection: %s", err)
 	}
 
-	defer db.Close()
+	defer func() {
+		if err := db.Close(); err != nil {
+			log.Debugf("failed to close db file: %s", err)
+		}
+	}()
 
 	tx, err := db.Begin(true)
 	if err != nil {

--- a/pkg/project/file.go
+++ b/pkg/project/file.go
@@ -59,12 +59,16 @@ func readFile(fp string, max int) ([]string, error) {
 		return nil, errors.New("filepath cannot be empty")
 	}
 
-	file, err := os.Open(fp)
+	file, err := os.Open(fp) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed while opening file %q: %s", fp, err)
 	}
 
-	defer file.Close()
+	defer func() {
+		if err := file.Close(); err != nil {
+			log.Debugf("failed to close file '%s': %s", file.Name(), err)
+		}
+	}()
 
 	scanner := bufio.NewScanner(file)
 	scanner.Split(bufio.ScanLines)

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -17,7 +17,6 @@ import (
 	"github.com/wakatime/wakatime-cli/pkg/windows"
 )
 
-// nolint:gochecknoglobals
 var driveLetterRegex = regexp.MustCompile(`^[a-zA-Z]:\\$`)
 
 const (
@@ -84,6 +83,7 @@ type (
 		ID() DetectorID
 	}
 
+	// DetecterArg determines for a given path if it needs to run.
 	DetecterArg struct {
 		Filepath  string
 		ShouldRun bool

--- a/pkg/project/subversion.go
+++ b/pkg/project/subversion.go
@@ -85,7 +85,7 @@ func findSvnBinary() (string, bool) {
 	}
 
 	for _, loc := range locations {
-		cmd := exec.Command(loc, "--version")
+		cmd := exec.Command(loc, "--version") // nolint:gosec
 
 		err := cmd.Run()
 		if err != nil {


### PR DESCRIPTION
This PR fixes linter rules disabled by default when migrated to go 1.19.

* `Error return value of `reader.Close` is not checked (errcheck)` - Message will be logged as debug.
* `Error return value of `resp.Body.Close` is not checked (errcheck)` - The response variable is used only in the context it created so it's safe to ignore it.
* `G304: Potential file inclusion via variable (gosec)`
* `gochecknoglobals` has an exception for variables assigned from regexp.MustCompile(). [reference](https://github.com/leighmcculloch/gochecknoglobals#exceptions).
