### PR TITLE
Add vulnerability scan

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -33,6 +33,9 @@ jobs:
         name: Linter
         run: make lint
       -
+        name: Vulnerability scan
+        run: make vulncheck
+      -
         name: Coverage
         uses: codecov/codecov-action@v2
         with:

--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,11 @@ install-go-modules:
 lint: install-linter
 	golangci-lint run ./...
 
+.PHONY: vulncheck
+vulncheck:
+	go install golang.org/x/vuln/cmd/govulncheck@latest
+	govulncheck ./...
+
 .PHONY: test
 test:
 	go test -race -covermode=atomic -coverprofile=coverage.out ./...

--- a/cmd/params/params_test.go
+++ b/cmd/params/params_test.go
@@ -1520,7 +1520,7 @@ func TestLoad_OfflineSyncMax_NegativeNumber(t *testing.T) {
 	_, err := paramscmd.LoadOfflineParams(v)
 	require.Error(t, err)
 
-	assert.Equal(t, err.Error(), "argument --sync-offline-activity must be \"none\" or a positive integer number")
+	assert.EqualError(t, err, "argument --sync-offline-activity must be \"none\" or a positive integer number")
 }
 
 func TestLoad_OfflineSyncMax_NonIntegerValue(t *testing.T) {


### PR DESCRIPTION
This PR adds vulnerability scan to the source code using the new tooling provided from Go security team. Blog post [here](https://go.dev/blog/vuln) .