### PR TITLE
Read api key from any command line vault

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -8,7 +8,8 @@ on:
     tags-ignore: "**"
 
 env:
-  GO_VERSION: "1.19"
+  GO_VERSION_FILE: "go.mod"
+  CHECK_LATEST: true
   TEST_VERSION: "<local-build>"
 
 jobs:
@@ -22,7 +23,8 @@ jobs:
       -
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: ${{ env.GO_VERSION_FILE }}
+          check-latest: ${{ env.CHECK_LATEST }}
       -
         name: Pull dependencies
         run: make install-go-modules
@@ -52,7 +54,8 @@ jobs:
       -
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: ${{ env.GO_VERSION_FILE }}
+          check-latest: ${{ env.CHECK_LATEST }}
       -
         name: Pull dependencies
         run: make install-go-modules
@@ -75,7 +78,8 @@ jobs:
       -
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: ${{ env.GO_VERSION_FILE }}
+          check-latest: ${{ env.CHECK_LATEST }}
       -
         name: Pull dependencies
         run: make install-go-modules
@@ -96,7 +100,8 @@ jobs:
       -
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: ${{ env.GO_VERSION_FILE }}
+          check-latest: ${{ env.CHECK_LATEST }}
       -
         name: Pull dependencies
         run: make install-go-modules
@@ -119,7 +124,8 @@ jobs:
       -
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: ${{ env.GO_VERSION_FILE }}
+          check-latest: ${{ env.CHECK_LATEST }}
       -
         name: Pull dependencies
         run: make install-go-modules
@@ -137,7 +143,8 @@ jobs:
       -
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: ${{ env.GO_VERSION_FILE }}
+          check-latest: ${{ env.CHECK_LATEST }}
       -
         name: Pull dependencies
         run: make install-go-modules
@@ -228,7 +235,8 @@ jobs:
         name: Setup go
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: ${{ env.GO_VERSION_FILE }}
+          check-latest: ${{ env.CHECK_LATEST }}
       -
         name: Build binaries
         env:
@@ -267,7 +275,8 @@ jobs:
         name: Setup go
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: ${{ env.GO_VERSION_FILE }}
+          check-latest: ${{ env.CHECK_LATEST }}
       -
         name: Build binaries
         env:
@@ -306,7 +315,8 @@ jobs:
         name: Setup go
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: ${{ env.GO_VERSION_FILE }}
+          check-latest: ${{ env.CHECK_LATEST }}
       -
         name: Build binaries
         env:
@@ -345,7 +355,8 @@ jobs:
         name: Setup go
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: ${{ env.GO_VERSION_FILE }}
+          check-latest: ${{ env.CHECK_LATEST }}
       -
         name: Build binaries
         env:
@@ -384,7 +395,8 @@ jobs:
         name: Setup go
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: ${{ env.GO_VERSION_FILE }}
+          check-latest: ${{ env.CHECK_LATEST }}
       -
         name: Build binaries
         env:
@@ -423,7 +435,8 @@ jobs:
         name: Setup go
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: ${{ env.GO_VERSION_FILE }}
+          check-latest: ${{ env.CHECK_LATEST }}
       -
         name: Build binaries
         env:

--- a/USAGE.md
+++ b/USAGE.md
@@ -13,6 +13,7 @@ Here's an example `$WAKATIME_HOME/.wakatime.cfg` config file with all available 
 [settings]
 debug = false
 api_key = your-api-key
+api_key_vault_cmd = any shell command to get your api key from vault
 api_url = https://api.wakatime.com/api/v1
 hide_file_names = false
 hide_project_names = false

--- a/cmd/params/params_test.go
+++ b/cmd/params/params_test.go
@@ -600,6 +600,23 @@ func TestLoadParams_ProjectApiKey_ParseConfig(t *testing.T) {
 	assert.Equal(t, expected, params.API.KeyPatterns)
 }
 
+func TestLoadParams_ApiKey_FromVault(t *testing.T) {
+	v := viper.New()
+	v.Set("config", "testdata/.wakatime-vault.cfg")
+	v.Set("entity", "testdata/heartbeat_go.json")
+
+	configFile, err := inipkg.FilePath(v)
+	require.NoError(t, err)
+
+	err = inipkg.ReadInConfig(v, configFile)
+	require.NoError(t, err)
+
+	params, err := paramscmd.Load(v)
+	require.NoError(t, err)
+
+	assert.Equal(t, "00000000-0000-4000-8000-000000000000", params.API.Key)
+}
+
 func TestLoadParams_Time(t *testing.T) {
 	v := viper.New()
 	v.Set("entity", "/path/to/file")

--- a/cmd/params/testdata/.wakatime-vault.cfg
+++ b/cmd/params/testdata/.wakatime-vault.cfg
@@ -1,0 +1,2 @@
+[settings]
+api_key_vault_cmd = echo 00000000-0000-4000-8000-000000000000

--- a/cmd/today/today_test.go
+++ b/cmd/today/today_test.go
@@ -165,7 +165,7 @@ func TestToday_ErrAuth_UnsetAPIKey(t *testing.T) {
 	var errauth api.ErrAuth
 
 	assert.True(t, errors.As(err, &errauth))
-	assert.Equal(t, "failed to load API parameters: failed to load api key", err.Error())
+	assert.Equal(t, "failed to load API parameters: api key not found or empty", err.Error())
 }
 
 func setupTestServer() (string, *http.ServeMux, func()) {

--- a/cmd/todaygoal/todaygoal_test.go
+++ b/cmd/todaygoal/todaygoal_test.go
@@ -176,7 +176,7 @@ func TestGoal_ErrAuth_UnsetAPIKey(t *testing.T) {
 	assert.True(t, errors.As(err, &errauth))
 	assert.Equal(
 		t,
-		"failed to load command parameters: failed to load API parameters: failed to load api key",
+		"failed to load command parameters: failed to load API parameters: api key not found or empty",
 		err.Error(),
 	)
 }


### PR DESCRIPTION
This PR adds a new option to `.wakatime.cfg` file to read api key from any command line that returns a single line. Tests were done using [pass](https://www.passwordstore.org/) but should work smoothly with other vendors.

```ini
[settings]
api_key_vault_cmd = pass wakatime-api-key
```

Closes #781 