### PR TITLE
Support api keys with waka prefix

### DIFF
--- a/cmd/params/params.go
+++ b/cmd/params/params.go
@@ -35,7 +35,7 @@ const errMsgTemplate = "invalid url %q. Must be in format" +
 
 var (
 	// nolint
-	apiKeyRegex = regexp.MustCompile("^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$")
+	apiKeyRegex = regexp.MustCompile("^(waka_)?[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$")
 	// nolint
 	matchAllRegex = regexp.MustCompile(".*")
 	// nolint

--- a/cmd/params/params_test.go
+++ b/cmd/params/params_test.go
@@ -2149,3 +2149,11 @@ func TestStatusBar_String(t *testing.T) {
 		statusbar.String(),
 	)
 }
+
+func TestLoadParams_APIKeyPrefixSupported(t *testing.T) {
+	v := viper.New()
+	v.Set("key", "waka_00000000-0000-4000-8000-000000000000")
+
+	_, err := paramscmd.LoadAPIParams(v)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
https://docs.github.com/en/code-security/secret-scanning/secret-scanning-patterns#supported-secrets-for-partner-patterns