### PR TITLE
More lax extra heartbeats parsing

### DIFF
--- a/cmd/params/params.go
+++ b/cmd/params/params.go
@@ -703,12 +703,12 @@ func readExtraHeartbeats() ([]heartbeat.Heartbeat, error) {
 
 	input, err := in.ReadString('\n')
 	if err != nil {
-		return nil, fmt.Errorf("failed to read data from stdin: %s", err)
+		log.Debugf("failed to read data from stdin: %s", err)
 	}
 
 	heartbeats, err := parseExtraHeartbeats(input)
 	if err != nil {
-		return nil, fmt.Errorf("failed to json decode: %s", err)
+		return nil, fmt.Errorf("failed parsing: %s", err)
 	}
 
 	return heartbeats, nil

--- a/pkg/heartbeat/format.go
+++ b/pkg/heartbeat/format.go
@@ -50,7 +50,7 @@ func Format(h Heartbeat) Heartbeat {
 func formatLinuxFilePath(h *Heartbeat) {
 	formatted, err := filepath.Abs(h.Entity)
 	if err != nil {
-		log.Warnf("failed to resolve absolute path for %q: %s", h.Entity, err)
+		log.Debugf("failed to resolve absolute path for %q: %s", h.Entity, err)
 	} else {
 		h.Entity = formatted
 	}
@@ -58,7 +58,7 @@ func formatLinuxFilePath(h *Heartbeat) {
 	// evaluate any symlinks
 	formatted, err = realpath.Realpath(h.Entity)
 	if err != nil {
-		log.Warnf("failed to resolve real path for %q: %s", h.Entity, err)
+		log.Debugf("failed to resolve real path for %q: %s", h.Entity, err)
 	} else {
 		h.Entity = formatted
 	}
@@ -72,7 +72,7 @@ func formatWindowsFilePath(h *Heartbeat) {
 
 		h.LocalFile, err = windows.FormatLocalFilePath(h.LocalFile, h.Entity)
 		if err != nil {
-			log.Warnf("failed to format local file path: %s", err)
+			log.Debugf("failed to format local file path: %s", err)
 		}
 	}
 


### PR DESCRIPTION
Was seeing a lot of these error messages, meaning the JSON was probably valid but being discarded so we lost extra heartbeats:

```
{"caller":"cmd/params/params.go:395","func":"params.LoadHeartbeatParams","level":"error","message":"failed to read extra heartbeats: failed to read data from stdin: EOF","now":"2022-12-03T21:47:03+01:00","os/arch":"darwin/amd64","version":"v1.60.1"}
```

We should continue trying to parse the JSON even when `in.ReadString('\n')` returns an error because it still could return valid JSON data.