### PR TITLE
Skipping files is not an error

### DIFF
--- a/cmd/heartbeat/heartbeat_test.go
+++ b/cmd/heartbeat/heartbeat_test.go
@@ -420,6 +420,7 @@ func TestSendHeartbeats_NonExistingEntity(t *testing.T) {
 	v.Set("entity-type", "file")
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("log-file", logFile.Name())
+	v.Set("verbose", true)
 
 	cmd.SetupLogging(v)
 

--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -30,7 +30,7 @@ func WithFiltering(config Config) heartbeat.HandleOption {
 			for _, h := range hh {
 				err := Filter(h, config)
 				if err != nil {
-					log.Errorf(err.Error())
+					log.Debugf(err.Error())
 
 					continue
 				}


### PR DESCRIPTION
Should only log in debug mode when a file is skipped because of matching an exclude pattern.