### PR TITLE
Only count slashes if project folder is prefix of entity

### DIFF
--- a/cmd/heartbeat/testdata/api_heartbeats_request_is_unsaved_entity_template.json
+++ b/cmd/heartbeat/testdata/api_heartbeats_request_is_unsaved_entity_template.json
@@ -10,7 +10,6 @@
     "lineno": 11,
     "lines": 91,
     "project": "wakatime-cli",
-    "project_root_count": 1,
     "type": "file",
     "time": 1585598051,
     "user_agent": "%s"
@@ -26,7 +25,6 @@
     "lineno": 42,
     "lines": 45,
     "project": "wakatime-cli",
-    "project_root_count": 1,
     "type": "file",
     "time": 1585598052,
     "user_agent": "%s"

--- a/main_test.go
+++ b/main_test.go
@@ -43,14 +43,15 @@ func TestSendHeartbeats(t *testing.T) {
 }
 
 func TestSendHeartbeats_EntityFileInTempDir(t *testing.T) {
-	tmpDir := t.TempDir()
+	tmpDir, err := filepath.Abs(t.TempDir())
+	require.NoError(t, err)
+
+	tmpDir, err = realpath.Realpath(tmpDir)
+	require.NoError(t, err)
 
 	runCmd(exec.Command("cp", "./testdata/main.go", tmpDir), &bytes.Buffer{})
 
-	projectFolder, err := filepath.Abs(tmpDir)
-	require.NoError(t, err)
-
-	testSendHeartbeats(t, projectFolder, filepath.Join(tmpDir, "main.go"), "")
+	testSendHeartbeats(t, tmpDir, filepath.Join(tmpDir, "main.go"), "")
 }
 
 func testSendHeartbeats(t *testing.T, projectFolder, entity, p string) {

--- a/pkg/heartbeat/format.go
+++ b/pkg/heartbeat/format.go
@@ -51,16 +51,37 @@ func formatLinuxFilePath(h *Heartbeat) {
 	formatted, err := filepath.Abs(h.Entity)
 	if err != nil {
 		log.Debugf("failed to resolve absolute path for %q: %s", h.Entity, err)
-	} else {
-		h.Entity = formatted
+		return
 	}
+
+	h.Entity = formatted
 
 	// evaluate any symlinks
 	formatted, err = realpath.Realpath(h.Entity)
 	if err != nil {
 		log.Debugf("failed to resolve real path for %q: %s", h.Entity, err)
-	} else {
-		h.Entity = formatted
+		return
+	}
+
+	h.Entity = formatted
+
+	if h.ProjectPathOverride != "" {
+		formatted, err = filepath.Abs(h.ProjectPathOverride)
+		if err != nil {
+			log.Debugf("failed to resolve absolute path for %q: %s", h.ProjectPathOverride, err)
+			return
+		}
+
+		h.ProjectPathOverride = formatted
+
+		// evaluate any symlinks
+		formatted, err = realpath.Realpath(h.ProjectPathOverride)
+		if err != nil {
+			log.Debugf("failed to resolve real path for %q: %s", h.ProjectPathOverride, err)
+			return
+		}
+
+		h.ProjectPathOverride = formatted
 	}
 }
 

--- a/pkg/project/project_test.go
+++ b/pkg/project/project_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/wakatime/wakatime-cli/pkg/project"
 	"github.com/wakatime/wakatime-cli/pkg/regex"
 	"github.com/wakatime/wakatime-cli/pkg/windows"
+	"github.com/yookoala/realpath"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -90,10 +91,10 @@ func TestWithDetection_WakatimeProjectTakesPrecedence(t *testing.T) {
 
 	entity := filepath.Join(fp, "wakatime-cli/src/pkg/file.go")
 	projectPath := filepath.Join(fp, "wakatime-cli")
+	projectPath = project.FormatProjectFolder(projectPath)
 
 	if runtime.GOOS == "windows" {
 		entity = windows.FormatFilePath(entity)
-		projectPath = windows.FormatFilePath(projectPath)
 	}
 
 	copyFile(
@@ -102,26 +103,33 @@ func TestWithDetection_WakatimeProjectTakesPrecedence(t *testing.T) {
 		filepath.Join(fp, "wakatime-cli", ".wakatime-project"),
 	)
 
-	opt := project.WithDetection(project.Config{
-		HideProjectNames: []regex.Regex{regex.MustCompile(".*")},
-	})
+	opts := []heartbeat.HandleOption{
+		heartbeat.WithFormatting(),
+		project.WithDetection(project.Config{
+			HideProjectNames: []regex.Regex{regex.MustCompile(".*")},
+		}),
+	}
 
-	handle := opt(func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
-		assert.NotEmpty(t, hh[0].Project)
-		assert.Equal(t, []heartbeat.Heartbeat{
-			{
-				Branch:           heartbeat.PointerTo("master"),
-				Entity:           entity,
-				EntityType:       heartbeat.FileType,
-				Project:          heartbeat.PointerTo("Rough Surf 20"),
-				ProjectAlternate: "alternate",
-				ProjectPath:      projectPath,
-				ProjectRootCount: heartbeat.PointerTo(project.CountSlashesInProjectFolder(projectPath)),
-			},
-		}, hh)
+	sender := mockSender{
+		SendHeartbeatsFn: func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+			assert.NotEmpty(t, hh[0].Project)
+			assert.Equal(t, []heartbeat.Heartbeat{
+				{
+					Branch:           heartbeat.PointerTo("master"),
+					Entity:           entity,
+					EntityType:       heartbeat.FileType,
+					Project:          heartbeat.PointerTo("Rough Surf 20"),
+					ProjectAlternate: "alternate",
+					ProjectPath:      projectPath,
+					ProjectRootCount: heartbeat.PointerTo(project.CountSlashesInProjectFolder(projectPath)),
+				},
+			}, hh)
 
-		return nil, nil
-	})
+			return nil, nil
+		},
+	}
+
+	handle := heartbeat.NewHandle(&sender, opts...)
 
 	_, err := handle([]heartbeat.Heartbeat{
 		{
@@ -138,10 +146,10 @@ func TestWithDetection_OverrideTakesPrecedence(t *testing.T) {
 
 	entity := filepath.Join(fp, "wakatime-cli/src/pkg/file.go")
 	projectPath := filepath.Join(fp, "wakatime-cli")
+	projectPath = project.FormatProjectFolder(projectPath)
 
 	if runtime.GOOS == "windows" {
 		entity = windows.FormatFilePath(entity)
-		projectPath = windows.FormatFilePath(projectPath)
 	}
 
 	opt := project.WithDetection(project.Config{})
@@ -190,10 +198,10 @@ func TestWithDetection_OverrideTakesPrecedence_WithProjectPathOverride(t *testin
 				Entity:              entity,
 				EntityType:          heartbeat.FileType,
 				Project:             heartbeat.PointerTo("override"),
-				ProjectPath:         "/path/to/folder",
+				ProjectPath:         fp,
 				ProjectOverride:     "override",
-				ProjectPathOverride: "/path/to/folder",
-				ProjectRootCount:    heartbeat.PointerTo(4),
+				ProjectPathOverride: fp,
+				ProjectRootCount:    heartbeat.PointerTo(project.CountSlashesInProjectFolder(fp)),
 			},
 		}, hh)
 
@@ -205,7 +213,7 @@ func TestWithDetection_OverrideTakesPrecedence_WithProjectPathOverride(t *testin
 			EntityType:          heartbeat.FileType,
 			Entity:              entity,
 			ProjectOverride:     "override",
-			ProjectPathOverride: "/path/to/folder",
+			ProjectPathOverride: fp,
 		},
 	})
 	require.NoError(t, err)
@@ -217,28 +225,41 @@ func TestWithDetection_NoneDetected(t *testing.T) {
 
 	defer tmpFile.Close()
 
+	entity := tmpFile.Name()
+
 	projectPath := filepath.Dir(tmpFile.Name())
+	projectPath = project.FormatProjectFolder(projectPath)
 
 	if runtime.GOOS == "windows" {
-		projectPath = windows.FormatFilePath(projectPath)
+		entity = windows.FormatFilePath(entity)
+	} else {
+		entity, err = realpath.Realpath(entity)
+		require.NoError(t, err)
 	}
 
-	opt := project.WithDetection(project.Config{})
+	opts := []heartbeat.HandleOption{
+		heartbeat.WithFormatting(),
+		project.WithDetection(project.Config{}),
+	}
 
-	handle := opt(func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
-		assert.Equal(t, []heartbeat.Heartbeat{
-			{
-				Branch:           heartbeat.PointerTo(""),
-				Entity:           tmpFile.Name(),
-				EntityType:       heartbeat.FileType,
-				Project:          heartbeat.PointerTo(""),
-				ProjectPath:      projectPath,
-				ProjectRootCount: heartbeat.PointerTo(project.CountSlashesInProjectFolder(projectPath)),
-			},
-		}, hh)
+	sender := mockSender{
+		SendHeartbeatsFn: func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+			assert.Equal(t, []heartbeat.Heartbeat{
+				{
+					Branch:           heartbeat.PointerTo(""),
+					Entity:           entity,
+					EntityType:       heartbeat.FileType,
+					Project:          heartbeat.PointerTo(""),
+					ProjectPath:      projectPath,
+					ProjectRootCount: heartbeat.PointerTo(project.CountSlashesInProjectFolder(projectPath)),
+				},
+			}, hh)
 
-		return nil, nil
-	})
+			return nil, nil
+		},
+	}
+
+	handle := heartbeat.NewHandle(&sender, opts...)
 
 	_, err = handle([]heartbeat.Heartbeat{
 		{
@@ -255,30 +276,43 @@ func TestWithDetection_NoneDetected_AlternateTakesPrecedence(t *testing.T) {
 
 	defer tmpFile.Close()
 
+	entity := tmpFile.Name()
+
 	projectPath := filepath.Dir(tmpFile.Name())
+	projectPath = project.FormatProjectFolder(projectPath)
 
 	if runtime.GOOS == "windows" {
-		projectPath = windows.FormatFilePath(projectPath)
+		entity = windows.FormatFilePath(entity)
+	} else {
+		entity, err = realpath.Realpath(entity)
+		require.NoError(t, err)
 	}
 
-	opt := project.WithDetection(project.Config{})
+	opts := []heartbeat.HandleOption{
+		heartbeat.WithFormatting(),
+		project.WithDetection(project.Config{}),
+	}
 
-	handle := opt(func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
-		assert.Equal(t, []heartbeat.Heartbeat{
-			{
-				Branch:           heartbeat.PointerTo("alternate-branch"),
-				BranchAlternate:  "alternate-branch",
-				Entity:           tmpFile.Name(),
-				EntityType:       heartbeat.FileType,
-				Project:          heartbeat.PointerTo("alternate-project"),
-				ProjectAlternate: "alternate-project",
-				ProjectPath:      projectPath,
-				ProjectRootCount: heartbeat.PointerTo(project.CountSlashesInProjectFolder(projectPath)),
-			},
-		}, hh)
+	sender := mockSender{
+		SendHeartbeatsFn: func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+			assert.Equal(t, []heartbeat.Heartbeat{
+				{
+					Branch:           heartbeat.PointerTo("alternate-branch"),
+					BranchAlternate:  "alternate-branch",
+					Entity:           entity,
+					EntityType:       heartbeat.FileType,
+					Project:          heartbeat.PointerTo("alternate-project"),
+					ProjectAlternate: "alternate-project",
+					ProjectPath:      projectPath,
+					ProjectRootCount: heartbeat.PointerTo(project.CountSlashesInProjectFolder(projectPath)),
+				},
+			}, hh)
 
-		return nil, nil
-	})
+			return nil, nil
+		},
+	}
+
+	handle := heartbeat.NewHandle(&sender, opts...)
 
 	_, err = handle([]heartbeat.Heartbeat{
 		{
@@ -297,29 +331,42 @@ func TestWithDetection_NoneDetected_OverrideTakesPrecedence(t *testing.T) {
 
 	defer tmpFile.Close()
 
-	projectPath := filepath.Dir(tmpFile.Name())
+	entity := tmpFile.Name()
 
 	if runtime.GOOS == "windows" {
-		projectPath = windows.FormatFilePath(projectPath)
+		entity = windows.FormatFilePath(entity)
+	} else {
+		entity, err = realpath.Realpath(entity)
+		require.NoError(t, err)
 	}
 
-	opt := project.WithDetection(project.Config{})
+	projectPath := filepath.Dir(tmpFile.Name())
+	projectPath = project.FormatProjectFolder(projectPath)
 
-	handle := opt(func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
-		assert.Equal(t, []heartbeat.Heartbeat{
-			{
-				Branch:           heartbeat.PointerTo(""),
-				Entity:           tmpFile.Name(),
-				EntityType:       heartbeat.FileType,
-				Project:          heartbeat.PointerTo("override"),
-				ProjectOverride:  "override",
-				ProjectPath:      projectPath,
-				ProjectRootCount: heartbeat.PointerTo(project.CountSlashesInProjectFolder(projectPath)),
-			},
-		}, hh)
+	opts := []heartbeat.HandleOption{
+		heartbeat.WithFormatting(),
+		project.WithDetection(project.Config{}),
+	}
 
-		return nil, nil
-	})
+	sender := mockSender{
+		SendHeartbeatsFn: func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+			assert.Equal(t, []heartbeat.Heartbeat{
+				{
+					Branch:           heartbeat.PointerTo(""),
+					Entity:           entity,
+					EntityType:       heartbeat.FileType,
+					Project:          heartbeat.PointerTo("override"),
+					ProjectOverride:  "override",
+					ProjectPath:      projectPath,
+					ProjectRootCount: heartbeat.PointerTo(project.CountSlashesInProjectFolder(projectPath)),
+				},
+			}, hh)
+
+			return nil, nil
+		},
+	}
+
+	handle := heartbeat.NewHandle(&sender, opts...)
 
 	_, err = handle([]heartbeat.Heartbeat{
 		{
@@ -332,36 +379,55 @@ func TestWithDetection_NoneDetected_OverrideTakesPrecedence(t *testing.T) {
 }
 
 func TestWithDetection_NoneDetected_WithProjectPathOverride(t *testing.T) {
-	tmpFile, err := os.CreateTemp(t.TempDir(), "")
+	tmpDir := t.TempDir()
+	tmpFile, err := os.CreateTemp(tmpDir, "")
 	require.NoError(t, err)
 
 	defer tmpFile.Close()
 
-	opt := project.WithDetection(project.Config{})
+	opts := []heartbeat.HandleOption{
+		heartbeat.WithFormatting(),
+		project.WithDetection(project.Config{}),
+	}
 
-	handle := opt(func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
-		assert.Equal(t, []heartbeat.Heartbeat{
-			{
-				Branch:              heartbeat.PointerTo(""),
-				Entity:              tmpFile.Name(),
-				EntityType:          heartbeat.FileType,
-				Project:             heartbeat.PointerTo("overridden-project"),
-				ProjectOverride:     "overridden-project",
-				ProjectPath:         "/path/to/folder",
-				ProjectPathOverride: "/path/to/folder",
-				ProjectRootCount:    heartbeat.PointerTo(4),
-			},
-		}, hh)
+	entity := tmpFile.Name()
 
-		return nil, nil
-	})
+	if runtime.GOOS == "windows" {
+		entity = windows.FormatFilePath(entity)
+	} else {
+		entity, err = realpath.Realpath(entity)
+		require.NoError(t, err)
+	}
+
+	projectFolder := project.FormatProjectFolder(tmpDir)
+
+	sender := mockSender{
+		SendHeartbeatsFn: func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+			assert.Equal(t, []heartbeat.Heartbeat{
+				{
+					Branch:              heartbeat.PointerTo(""),
+					Entity:              entity,
+					EntityType:          heartbeat.FileType,
+					Project:             heartbeat.PointerTo("overridden-project"),
+					ProjectOverride:     "overridden-project",
+					ProjectPath:         projectFolder,
+					ProjectPathOverride: projectFolder,
+					ProjectRootCount:    heartbeat.PointerTo(project.CountSlashesInProjectFolder(projectFolder)),
+				},
+			}, hh)
+
+			return nil, nil
+		},
+	}
+
+	handle := heartbeat.NewHandle(&sender, opts...)
 
 	_, err = handle([]heartbeat.Heartbeat{
 		{
 			EntityType:          heartbeat.FileType,
 			Entity:              tmpFile.Name(),
 			ProjectOverride:     "overridden-project",
-			ProjectPathOverride: "/path/to/folder",
+			ProjectPathOverride: tmpDir,
 		},
 	})
 	require.NoError(t, err)
@@ -372,10 +438,10 @@ func TestWithDetection_ObfuscateProject(t *testing.T) {
 
 	entity := filepath.Join(fp, "wakatime-cli/src/pkg/file.go")
 	projectPath := filepath.Join(fp, "wakatime-cli")
+	projectPath = project.FormatProjectFolder(projectPath)
 
 	if runtime.GOOS == "windows" {
 		entity = windows.FormatFilePath(entity)
-		projectPath = windows.FormatFilePath(projectPath)
 	}
 
 	opt := project.WithDetection(project.Config{
@@ -566,4 +632,14 @@ func formatRegex(fp string) string {
 	}
 
 	return strings.ReplaceAll(fp, `\`, `\\`)
+}
+
+type mockSender struct {
+	SendHeartbeatsFn        func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error)
+	SendHeartbeatsFnInvoked bool
+}
+
+func (m *mockSender) SendHeartbeats(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+	m.SendHeartbeatsFnInvoked = true
+	return m.SendHeartbeatsFn(hh)
 }


### PR DESCRIPTION
The project folder slashes count doesn't make sense and is unusable when entity doesn't start with the project folder path.