### PR TITLE
Sanitize project root count with other data

### DIFF
--- a/cmd/heartbeat/heartbeat_test.go
+++ b/cmd/heartbeat/heartbeat_test.go
@@ -397,11 +397,6 @@ func TestSendHeartbeats_ExtraHeartbeats_Sanitize(t *testing.T) {
 		plugin,
 	)
 
-	projectFolder, err := filepath.Abs("../..")
-	require.NoError(t, err)
-
-	subfolders := project.CountSlashesInProjectFolder(projectFolder)
-
 	assert.Equal(t, []heartbeat.Heartbeat{
 		{
 			Branch:           nil,
@@ -415,7 +410,7 @@ func TestSendHeartbeats_ExtraHeartbeats_Sanitize(t *testing.T) {
 			LineNumber:       nil,
 			Lines:            nil,
 			Project:          heartbeat.PointerTo("wakatime-cli"),
-			ProjectRootCount: &subfolders,
+			ProjectRootCount: nil,
 			Time:             1585598059,
 			UserAgent:        userAgent,
 		}}, hh)

--- a/pkg/heartbeat/sanitize.go
+++ b/pkg/heartbeat/sanitize.go
@@ -88,6 +88,8 @@ func hideProjectFolder(h Heartbeat, hideProjectFolder bool) Heartbeat {
 
 		if strings.HasPrefix(h.Entity, h.ProjectPath) {
 			h.Entity = strings.TrimPrefix(h.Entity, h.ProjectPath)
+			h.ProjectRootCount = nil
+
 			return h
 		}
 	}
@@ -99,6 +101,7 @@ func hideProjectFolder(h Heartbeat, hideProjectFolder bool) Heartbeat {
 		}
 
 		h.Entity = strings.TrimPrefix(h.Entity, h.ProjectPathOverride)
+		h.ProjectRootCount = nil
 	}
 
 	return h
@@ -131,6 +134,7 @@ func santizeMetaData(h Heartbeat) Heartbeat {
 	h.Dependencies = nil
 	h.LineNumber = nil
 	h.Lines = nil
+	h.ProjectRootCount = nil
 
 	return h
 }


### PR DESCRIPTION
We need to remove `project_root_count` from heartbeat when hiding file names or when using relative file paths.