### PR TITLE
Preserve windows network drives when counting slashes

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -22,8 +22,7 @@ import (
 )
 
 var (
-	backslashReplaceRegex = regexp.MustCompile(`[\\/]+`)
-	driveLetterRegex      = regexp.MustCompile(`^[a-zA-Z]:\\$`)
+	driveLetterRegex = regexp.MustCompile(`^[a-zA-Z]:\\$`)
 )
 
 const (
@@ -372,7 +371,7 @@ func CountSlashesInProjectFolder(directory string) int {
 		return 0
 	}
 
-	directory = backslashReplaceRegex.ReplaceAllString(directory, `/`)
+	directory = windows.FormatFilePath(directory)
 
 	// Add trailing slash if not present.
 	if !strings.HasSuffix(directory, `/`) {

--- a/pkg/project/project_test.go
+++ b/pkg/project/project_test.go
@@ -595,6 +595,10 @@ func TestCountSlashesInProjectFolder(t *testing.T) {
 			path:     `C:\folder\project`,
 			expected: 3,
 		},
+		"wsl path": {
+			path:     `\\wsl$/Ubuntu-22.04/home/folder/project`,
+			expected: 5,
+		},
 	}
 
 	for name, test := range tests {

--- a/pkg/windows/windows.go
+++ b/pkg/windows/windows.go
@@ -43,14 +43,14 @@ func FormatFilePath(fp string) string {
 
 	fp = backslashReplaceRegex.ReplaceAllString(fp, "/")
 
-	if windowsDriveRegex.MatchString(fp) {
-		fp = strings.ToUpper(fp[:1]) + fp[1:]
+	if isWindowsNetworkMount {
+		// Replace the first single slash with double backslash, since the regex
+		// will have replaced any double backslashes with single forward slash
+		fp = `\\` + fp[1:]
 	}
 
-	if isWindowsNetworkMount {
-		// Replace the first single slash with double backslash, since the previous modifications
-		// will have replaced any double slashes with single
-		fp = `\\` + fp[1:]
+	if windowsDriveRegex.MatchString(fp) {
+		fp = strings.ToUpper(fp[:1]) + fp[1:]
 	}
 
 	return fp


### PR DESCRIPTION
Re-using the `windows.FormatFilePath` function.