### PR TITLE
New flag --send-diagnostics-on-errors

### DIFF
--- a/cmd/logfile/logfile.go
+++ b/cmd/logfile/logfile.go
@@ -15,21 +15,26 @@ const defaultFile = ".wakatime.log"
 
 // Params contains log file parameters.
 type Params struct {
-	File     string
-	ToStdout bool
-	Verbose  bool
+	File              string
+	SendDiagsOnErrors bool
+	ToStdout          bool
+	Verbose           bool
 }
 
 // LoadParams loads needed data from the configuration file.
 func LoadParams(v *viper.Viper) (Params, error) {
-	var debug bool
-	if b := v.GetBool("settings.debug"); v.IsSet("settings.debug") {
-		debug = b
-	}
-
 	params := Params{
+		SendDiagsOnErrors: vipertools.FirstNonEmptyBool(
+			v,
+			"send-diagnostics-on-errors",
+			"settings.send_diagnostics_on_errors",
+		),
 		ToStdout: v.GetBool("log-to-stdout"),
-		Verbose:  v.GetBool("verbose") || debug,
+		Verbose: vipertools.FirstNonEmptyBool(
+			v,
+			"verbose",
+			"settings.debug",
+		),
 	}
 
 	logFile, ok := vipertools.FirstNonEmptyString(v, "log-file", "logfile", "settings.log_file")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -189,6 +189,11 @@ func setFlags(cmd *cobra.Command, v *viper.Viper) {
 			" For example: 'https://user:pass@host:port' or 'socks5://user:pass@host:port'"+
 			" or 'domain\\user:pass'",
 	)
+	flags.Bool(
+		"send-diagnostics-on-errors",
+		false,
+		"When --verbose or debug enabled, also sends diagnostics on any error not just crashes.",
+	)
 	flags.String(
 		"ssl-certs-file",
 		"",
@@ -227,7 +232,7 @@ func setFlags(cmd *cobra.Command, v *viper.Viper) {
 		false,
 		"(internal) Prints the wakatime-cli useragent, as it will be sent to the api, then exits.",
 	)
-	flags.Bool("verbose", false, "Turns on debug messages in log file.")
+	flags.Bool("verbose", false, "Turns on debug messages in log file, and sends diagnostics if a crash occurs.")
 	flags.Bool("version", false, "Prints the wakatime-cli version number, then exits.")
 	flags.Bool("write", false, "When set, tells api this heartbeat was triggered from writing to a file.")
 

--- a/cmd/run_internal_test.go
+++ b/cmd/run_internal_test.go
@@ -21,7 +21,7 @@ import (
 func TestRunCmd(t *testing.T) {
 	v := viper.New()
 
-	ret := runCmd(v, false, func(v *viper.Viper) (int, error) {
+	ret := runCmd(v, false, false, func(v *viper.Viper) (int, error) {
 		return exitcode.Success, nil
 	})
 
@@ -31,7 +31,7 @@ func TestRunCmd(t *testing.T) {
 func TestRunCmd_Err(t *testing.T) {
 	v := viper.New()
 
-	ret := runCmd(v, false, func(v *viper.Viper) (int, error) {
+	ret := runCmd(v, false, false, func(v *viper.Viper) (int, error) {
 		return exitcode.ErrGeneric, errors.New("fail")
 	})
 
@@ -88,7 +88,7 @@ func TestRunCmd_ErrOfflineEnqueue(t *testing.T) {
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("plugin", "vim")
 
-	ret := runCmd(v, true, func(v *viper.Viper) (int, error) {
+	ret := runCmd(v, true, false, func(v *viper.Viper) (int, error) {
 		return exitcode.ErrGeneric, errors.New("fail")
 	})
 

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -23,6 +23,7 @@ import (
 
 func TestRunCmd_SendDiagnostics_Error(t *testing.T) {
 	// this is exclusively run in subprocess
+	// TODO: figure out why this test is passing (it should be failing)
 	if os.Getenv("TEST_RUN") == "1" {
 		version.OS = "some os"
 		version.Arch = "some architecture"
@@ -45,7 +46,7 @@ func TestRunCmd_SendDiagnostics_Error(t *testing.T) {
 		v.Set("offline-queue-file", offlineQueueFile.Name())
 		v.Set("plugin", "vim")
 
-		cmd.RunCmd(v, true, func(v *viper.Viper) (int, error) {
+		cmd.RunCmd(v, true, false, func(v *viper.Viper) (int, error) {
 			return 42, errors.New("fail")
 		})
 
@@ -128,7 +129,7 @@ func TestRunCmd_SendDiagnostics_Panic(t *testing.T) {
 		v.Set("offline-queue-file", offlineQueueFile.Name())
 		v.Set("plugin", "vim")
 
-		cmd.RunCmd(v, true, func(v *viper.Viper) (int, error) {
+		cmd.RunCmd(v, true, false, func(v *viper.Viper) (int, error) {
 			panic("fail")
 		})
 
@@ -208,7 +209,7 @@ func TestRunCmdWithOfflineSync(t *testing.T) {
 		v.SetDefault("sync-offline-activity", 24)
 		v.Set("plugin", "vim")
 
-		cmd.RunCmdWithOfflineSync(v, false, func(v *viper.Viper) (int, error) {
+		cmd.RunCmdWithOfflineSync(v, false, false, func(v *viper.Viper) (int, error) {
 			return 0, nil
 		})
 

--- a/pkg/api/diagnostic.go
+++ b/pkg/api/diagnostic.go
@@ -13,24 +13,26 @@ import (
 )
 
 type diagnosticsBody struct {
-	Platform     string `json:"platform"`
 	Architecture string `json:"architecture"`
-	Plugin       string `json:"plugin"`
 	CliVersion   string `json:"cli_version"`
+	IsPanic      bool   `json:"is_panic,omitempty"`
 	Logs         string `json:"logs,omitempty"`
+	Platform     string `json:"platform"`
+	Plugin       string `json:"plugin"`
 	Stack        string `json:"stacktrace,omitempty"`
 }
 
 // SendDiagnostics sends diagnostics to the WakaTime api.
-func (c *Client) SendDiagnostics(plugin string, diagnostics ...diagnostic.Diagnostic) error {
+func (c *Client) SendDiagnostics(plugin string, panic bool, diagnostics ...diagnostic.Diagnostic) error {
 	url := c.baseURL + "/plugins/errors"
 
 	log.Debugf("sending diagnostic data to api at %s", url)
 
 	body := diagnosticsBody{
-		Platform:     version.OS,
 		Architecture: version.Arch,
 		CliVersion:   version.Version,
+		IsPanic:      panic,
+		Platform:     version.OS,
 		Plugin:       plugin,
 	}
 

--- a/pkg/api/diagnostic_test.go
+++ b/pkg/api/diagnostic_test.go
@@ -52,7 +52,7 @@ func TestClient_SendDiagnostics(t *testing.T) {
 	}
 
 	c := api.NewClient(url)
-	err := c.SendDiagnostics("vim", diagnostics...)
+	err := c.SendDiagnostics("vim", false, diagnostics...)
 	require.NoError(t, err)
 
 	assert.Eventually(t, func() bool { return numCalls == 1 }, time.Second, 50*time.Millisecond)


### PR DESCRIPTION
Also can be enabled in `~/.wakatime.cfg` with `settings.send_diagnostics_on_errors`.