### PR TITLE
Save heartbeats to offline db even when api key invalid

### DIFF
--- a/cmd/fileexperts/fileexperts_test.go
+++ b/cmd/fileexperts/fileexperts_test.go
@@ -241,7 +241,7 @@ func TestFileExperts_ErrAuth_UnsetAPIKey(t *testing.T) {
 	assert.True(t, errors.As(err, &errauth))
 	assert.Equal(
 		t,
-		"failed to load command parameters: failed to load api params: api key not found or empty",
+		"missing api key",
 		err.Error(),
 	)
 }

--- a/cmd/params/params.go
+++ b/cmd/params/params.go
@@ -167,17 +167,17 @@ func Load(v *viper.Viper) (Params, error) {
 
 	apiParams, err := LoadAPIParams(v)
 	if err != nil {
-		return Params{}, fmt.Errorf("failed to load api params: %w", err)
+		log.Warnf("failed to load api params: %s", err)
 	}
 
 	offlineParams, err := LoadOfflineParams(v)
 	if err != nil {
-		return Params{}, fmt.Errorf("failed to load offline params: %w", err)
+		log.Warnf("failed to load offline params: %s", err)
 	}
 
 	statusBarParams, err := LoadStatusBarParams(v)
 	if err != nil {
-		return Params{}, fmt.Errorf("failed to load status bar params: %w", err)
+		log.Warnf("failed to load status bar params: %s", err)
 	}
 
 	return Params{

--- a/pkg/api/fileexperts.go
+++ b/pkg/api/fileexperts.go
@@ -20,6 +20,10 @@ import (
 func (c *Client) FileExperts(heartbeats []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
 	url := c.baseURL + "/users/current/file_experts"
 
+	if heartbeats[0].APIKey == "" {
+		return nil, ErrAuth{Err: fmt.Errorf("missing api key")}
+	}
+
 	// change from heartbeat.Heartbeat to fileexpert.Entity
 	// it's safe to get the first item in the slice.
 	e := fileexperts.Entity{

--- a/pkg/api/fileexperts_test.go
+++ b/pkg/api/fileexperts_test.go
@@ -58,6 +58,7 @@ func TestClient_FileExperts(t *testing.T) {
 			c := api.NewClient(url)
 			results, err := c.FileExperts([]heartbeat.Heartbeat{
 				{
+					APIKey:           "00000000-0000-4000-8000-000000000000",
 					Entity:           "/tmp/main.go",
 					Project:          heartbeat.PointerTo("wakatime-cli"),
 					ProjectRootCount: heartbeat.PointerTo(6),
@@ -131,6 +132,7 @@ func TestClient_FileExperts_Err(t *testing.T) {
 	c := api.NewClient(url)
 	_, err := c.FileExperts([]heartbeat.Heartbeat{
 		{
+			APIKey:           "00000000-0000-4000-8000-000000000000",
 			Entity:           "/tmp/main.go",
 			Project:          heartbeat.PointerTo("wakatime-cli"),
 			ProjectRootCount: heartbeat.PointerTo(6),
@@ -158,6 +160,7 @@ func TestClient_FileExperts_ErrAuth(t *testing.T) {
 	c := api.NewClient(url)
 	_, err := c.FileExperts([]heartbeat.Heartbeat{
 		{
+			APIKey:           "00000000-0000-4000-8000-000000000000",
 			Entity:           "/tmp/main.go",
 			Project:          heartbeat.PointerTo("wakatime-cli"),
 			ProjectRootCount: heartbeat.PointerTo(6),
@@ -185,6 +188,7 @@ func TestClient_FileExperts_ErrBadRequest(t *testing.T) {
 	c := api.NewClient(url)
 	_, err := c.FileExperts([]heartbeat.Heartbeat{
 		{
+			APIKey:           "00000000-0000-4000-8000-000000000000",
 			Entity:           "/tmp/main.go",
 			Project:          heartbeat.PointerTo("wakatime-cli"),
 			ProjectRootCount: heartbeat.PointerTo(6),
@@ -202,6 +206,7 @@ func TestClient_FileExperts_InvalidUrl(t *testing.T) {
 	c := api.NewClient("invalid-url")
 	_, err := c.FileExperts([]heartbeat.Heartbeat{
 		{
+			APIKey:           "00000000-0000-4000-8000-000000000000",
 			Entity:           "/tmp/main.go",
 			Project:          heartbeat.PointerTo("wakatime-cli"),
 			ProjectRootCount: heartbeat.PointerTo(6),

--- a/pkg/api/heartbeat.go
+++ b/pkg/api/heartbeat.go
@@ -44,6 +44,10 @@ func (c *Client) SendHeartbeats(heartbeats []heartbeat.Heartbeat) ([]heartbeat.R
 }
 
 func (c *Client) sendHeartbeats(url string, heartbeats []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+	if heartbeats[0].APIKey == "" {
+		return nil, ErrAuth{Err: fmt.Errorf("missing api key")}
+	}
+
 	data, err := json.Marshal(heartbeats)
 	if err != nil {
 		return nil, fmt.Errorf("failed to json encode body: %s", err)


### PR DESCRIPTION
We should always save heartbeats to the offline db if possible, so we don't accidentally lose coding activity.