### PR TITLE
Improve command params

### DIFF
--- a/cmd/configread/configread.go
+++ b/cmd/configread/configread.go
@@ -36,7 +36,7 @@ func Run(v *viper.Viper) (int, error) {
 func Read(v *viper.Viper) (string, error) {
 	params, err := LoadParams(v)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to load command parameters: %w", err)
 	}
 
 	value := strings.TrimSpace(vipertools.GetString(v, params.ViperKey()))

--- a/cmd/configread/configread_test.go
+++ b/cmd/configread/configread_test.go
@@ -77,17 +77,20 @@ func TestReadErr(t *testing.T) {
 			ErrorMsg: fmt.Sprintf("given section and key \"%s.%s\" returned an empty string", "settings", "api_key"),
 		},
 		"section_missing": {
-			Key:      "api_key",
-			Value:    "b9485572-74bf-419a-916b-22056ca3a24c",
-			ErrorMsg: "failed reading wakatime config file. neither section nor key can be empty",
+			Key:   "api_key",
+			Value: "b9485572-74bf-419a-916b-22056ca3a24c",
+			ErrorMsg: "failed to load command parameters:" +
+				" failed reading wakatime config file. neither section nor key can be empty",
 		},
 		"key_missing": {
-			Section:  "settings",
-			Value:    "b9485572-74bf-419a-916b-22056ca3a24c",
-			ErrorMsg: "failed reading wakatime config file. neither section nor key can be empty",
+			Section: "settings",
+			Value:   "b9485572-74bf-419a-916b-22056ca3a24c",
+			ErrorMsg: "failed to load command parameters:" +
+				" failed reading wakatime config file. neither section nor key can be empty",
 		},
 		"all_missing": {
-			ErrorMsg: "failed reading wakatime config file. neither section nor key can be empty",
+			ErrorMsg: "failed to load command parameters:" +
+				" failed reading wakatime config file. neither section nor key can be empty",
 		},
 	}
 

--- a/cmd/configwrite/configwrite.go
+++ b/cmd/configwrite/configwrite.go
@@ -42,7 +42,7 @@ func Run(v *viper.Viper) (int, error) {
 func Write(v *viper.Viper, w ini.Writer) error {
 	params, err := LoadParams(v)
 	if err != nil {
-		return fmt.Errorf("failed loading params: %w", err)
+		return fmt.Errorf("failed to load command parameters: %w", err)
 	}
 
 	return w.Write(params.Section, params.KeyValue)

--- a/cmd/configwrite/configwrite_test.go
+++ b/cmd/configwrite/configwrite_test.go
@@ -122,7 +122,7 @@ func TestWriteErr(t *testing.T) {
 
 			assert.Equal(
 				t,
-				"failed loading params: neither section nor key/value can be empty",
+				"failed to load command parameters: neither section nor key/value can be empty",
 				err.Error(),
 				fmt.Sprintf("error %q differs from the string set", err),
 			)

--- a/cmd/heartbeat/heartbeat.go
+++ b/cmd/heartbeat/heartbeat.go
@@ -35,12 +35,17 @@ func Run(v *viper.Viper) (int, error) {
 
 	err = SendHeartbeats(v, queueFilepath)
 	if err != nil {
-		var errBackoff api.ErrBackoff
+		var errauth api.ErrAuth
 
-		if errors.As(err, &errBackoff) {
-			log.Debugf("sending heartbeat(s) failed: %s", errBackoff.Message())
+		// api.ErrAuth represents an error when parsing api key.
+		// Save heartbeats to offline db even when api key invalid.
+		// It avoids losing heartbeats when api key is invalid.
+		if errors.As(err, &errauth) {
+			if err := offlinecmd.SaveHeartbeats(v, nil, queueFilepath); err != nil {
+				log.Errorf("failed to save heartbeats to offline queue: %s", err)
+			}
 
-			return errBackoff.ExitCode(), nil
+			return errauth.ExitCode(), fmt.Errorf("sending heartbeat(s) failed: %s", errauth.Message())
 		}
 
 		if errwaka, ok := err.(wakaerror.Error); ok {
@@ -62,13 +67,12 @@ func Run(v *viper.Viper) (int, error) {
 // heartbeats from the offline queue, if available and offline sync is not
 // explicitly disabled.
 func SendHeartbeats(v *viper.Viper, queueFilepath string) error {
-	params, err := paramscmd.Load(v)
+	params, err := LoadParams(v)
 	if err != nil {
 		return fmt.Errorf("failed to load command parameters: %w", err)
 	}
 
 	setLogFields(params)
-
 	log.Debugf("params: %s", params)
 
 	heartbeats := buildHeartbeats(params)
@@ -138,6 +142,30 @@ func SendHeartbeats(v *viper.Viper, queueFilepath string) error {
 	}
 
 	return nil
+}
+
+// LoadParams loads params from viper.Viper instance. Returns ErrAuth
+// if failed to retrieve api key.
+func LoadParams(v *viper.Viper) (paramscmd.Params, error) {
+	if v == nil {
+		return paramscmd.Params{}, errors.New("viper instance unset")
+	}
+
+	apiParams, err := paramscmd.LoadAPIParams(v)
+	if err != nil {
+		return paramscmd.Params{}, fmt.Errorf("failed to load API parameters: %w", err)
+	}
+
+	heartbeatParams, err := paramscmd.LoadHeartbeatParams(v)
+	if err != nil {
+		return paramscmd.Params{}, fmt.Errorf("failed to load heartbeat params: %s", err)
+	}
+
+	return paramscmd.Params{
+		API:       apiParams,
+		Heartbeat: heartbeatParams,
+		Offline:   paramscmd.LoadOfflineParams(v),
+	}, nil
 }
 
 func buildHeartbeats(params paramscmd.Params) []heartbeat.Heartbeat {

--- a/cmd/offline/offline.go
+++ b/cmd/offline/offline.go
@@ -63,24 +63,16 @@ func loadParams(v *viper.Viper) (paramscmd.Params, error) {
 		log.Warnf("failed to load API parameters: %s", err)
 	}
 
-	paramOffline, err := paramscmd.LoadOfflineParams(v)
-	if err != nil {
-		log.Warnf("failed to load offline parameters: %s", err)
-	}
-
-	params := paramscmd.Params{
-		API:     paramAPI,
-		Offline: paramOffline,
-	}
-
 	paramHeartbeat, err := paramscmd.LoadHeartbeatParams(v)
 	if err != nil {
 		return paramscmd.Params{}, fmt.Errorf("failed to load heartbeat parameters: %s", err)
 	}
 
-	params.Heartbeat = paramHeartbeat
-
-	return params, nil
+	return paramscmd.Params{
+		API:       paramAPI,
+		Heartbeat: paramHeartbeat,
+		Offline:   paramscmd.LoadOfflineParams(v),
+	}, nil
 }
 
 func buildHeartbeats(params paramscmd.Params) []heartbeat.Heartbeat {

--- a/cmd/offlinecount/offlinecount.go
+++ b/cmd/offlinecount/offlinecount.go
@@ -20,10 +20,7 @@ func Run(v *viper.Viper) (int, error) {
 		)
 	}
 
-	p, err := params.LoadOfflineParams(v)
-	if err != nil {
-		return exitcode.ErrGeneric, fmt.Errorf("failed to load offline parameters: %w", err)
-	}
+	p := params.LoadOfflineParams(v)
 
 	if p.QueueFile != "" {
 		queueFilepath = p.QueueFile

--- a/cmd/offlineprint/offlineprint.go
+++ b/cmd/offlineprint/offlineprint.go
@@ -23,10 +23,7 @@ func Run(v *viper.Viper) (int, error) {
 		)
 	}
 
-	p, err := params.LoadOfflineParams(v)
-	if err != nil {
-		return exitcode.ErrGeneric, fmt.Errorf("failed to load offline parameters: %w", err)
-	}
+	p := params.LoadOfflineParams(v)
 
 	if p.QueueFile != "" {
 		queueFilepath = p.QueueFile

--- a/cmd/offlinesync/offlinesync.go
+++ b/cmd/offlinesync/offlinesync.go
@@ -45,10 +45,7 @@ func Run(v *viper.Viper) (int, error) {
 // SyncOfflineActivity syncs offline activity by sending heartbeats
 // from the offline queue to the WakaTime API.
 func SyncOfflineActivity(v *viper.Viper, queueFilepath string) error {
-	paramOffline, err := params.LoadOfflineParams(v)
-	if err != nil {
-		return fmt.Errorf("failed to load offline parameters: %w", err)
-	}
+	paramOffline := params.LoadOfflineParams(v)
 
 	paramAPI, err := params.LoadAPIParams(v)
 	if err != nil {

--- a/cmd/params/params.go
+++ b/cmd/params/params.go
@@ -153,41 +153,6 @@ type (
 	}
 )
 
-// Load loads params from viper.Viper instance. Returns ErrAuth
-// if failed to retrieve api key.
-func Load(v *viper.Viper) (Params, error) {
-	if v == nil {
-		return Params{}, errors.New("viper instance unset")
-	}
-
-	heartbeatParams, err := LoadHeartbeatParams(v)
-	if err != nil {
-		return Params{}, fmt.Errorf("failed to load heartbeat params: %s", err)
-	}
-
-	apiParams, err := LoadAPIParams(v)
-	if err != nil {
-		log.Warnf("failed to load api params: %s", err)
-	}
-
-	offlineParams, err := LoadOfflineParams(v)
-	if err != nil {
-		log.Warnf("failed to load offline params: %s", err)
-	}
-
-	statusBarParams, err := LoadStatusBarParams(v)
-	if err != nil {
-		log.Warnf("failed to load status bar params: %s", err)
-	}
-
-	return Params{
-		API:       apiParams,
-		Heartbeat: heartbeatParams,
-		Offline:   offlineParams,
-		StatusBar: statusBarParams,
-	}, nil
-}
-
 // LoadAPIParams loads API params from viper.Viper instance. Returns ErrAuth
 // if failed to retrieve api key.
 func LoadAPIParams(v *viper.Viper) (API, error) {
@@ -201,7 +166,7 @@ func LoadAPIParams(v *viper.Viper) (API, error) {
 	if !ok {
 		apiKey, err = readAPIKeyFromCommand(vipertools.GetString(v, "settings.api_key_vault_cmd"))
 		if err != nil {
-			return API{}, api.ErrAuth{Err: fmt.Errorf("failed to load api key from vault: %s", err)}
+			return API{}, api.ErrAuth{Err: fmt.Errorf("failed to read api key from vault: %s", err)}
 		}
 
 		if apiKey == "" {
@@ -260,7 +225,7 @@ func LoadAPIParams(v *viper.Viper) (API, error) {
 
 	apiURL, err := url.Parse(apiURLStr)
 	if err != nil {
-		return API{}, fmt.Errorf("invalid api url: %s", err)
+		return API{}, api.ErrAuth{Err: fmt.Errorf("invalid api url: %s", err)}
 	}
 
 	var backoffAt time.Time
@@ -293,7 +258,7 @@ func LoadAPIParams(v *viper.Viper) (API, error) {
 	if !ok {
 		hostname, err = os.Hostname()
 		if err != nil {
-			return API{}, fmt.Errorf("failed to retrieve hostname from system: %s", err)
+			log.Warnf("failed to retrieve hostname from system: %s", err)
 		}
 	}
 
@@ -305,7 +270,7 @@ func LoadAPIParams(v *viper.Viper) (API, error) {
 	}
 
 	if proxyURL != "" && !rgx.MatchString(proxyURL) {
-		return API{}, fmt.Errorf(errMsgTemplate, proxyURL)
+		return API{}, api.ErrAuth{Err: fmt.Errorf(errMsgTemplate, proxyURL)}
 	}
 
 	proxyEnv := httpproxy.FromEnvironment()
@@ -326,8 +291,7 @@ func LoadAPIParams(v *viper.Viper) (API, error) {
 	if ok {
 		sslCertFilepath, err = homedir.Expand(sslCertFilepath)
 		if err != nil {
-			return API{},
-				fmt.Errorf("failed expanding ssl certs file: %s", err)
+			return API{}, api.ErrAuth{Err: fmt.Errorf("failed expanding ssl certs file: %s", err)}
 		}
 	}
 
@@ -627,7 +591,7 @@ func loadProjectMapPatterns(v *viper.Viper, prefix string) []project.MapPattern 
 }
 
 // LoadOfflineParams loads offline params from viper.Viper instance.
-func LoadOfflineParams(v *viper.Viper) (Offline, error) {
+func LoadOfflineParams(v *viper.Viper) Offline {
 	disabled := vipertools.FirstNonEmptyBool(v, "disable-offline", "disableoffline")
 	if b := v.GetBool("settings.offline"); v.IsSet("settings.offline") {
 		disabled = !b
@@ -635,7 +599,9 @@ func LoadOfflineParams(v *viper.Viper) (Offline, error) {
 
 	syncMax := v.GetInt("sync-offline-activity")
 	if syncMax < 0 {
-		return Offline{}, errors.New("argument --sync-offline-activity must be zero or a positive integer number")
+		log.Warnf("argument --sync-offline-activity must be zero or a positive integer number, got %d", syncMax)
+
+		syncMax = 0
 	}
 
 	return Offline{
@@ -643,7 +609,7 @@ func LoadOfflineParams(v *viper.Viper) (Offline, error) {
 		QueueFile: vipertools.GetString(v, "offline-queue-file"),
 		PrintMax:  v.GetInt("print-offline-heartbeats"),
 		SyncMax:   syncMax,
-	}, nil
+	}
 }
 
 // LoadStatusBarParams loads status bar params from viper.Viper instance.
@@ -706,7 +672,7 @@ func readAPIKeyFromCommand(cmdStr string) (string, error) {
 
 	out, err := cmd.Output()
 	if err != nil {
-		return "", fmt.Errorf("failed to read api key from vault: %s", err)
+		return "", err
 	}
 
 	return strings.TrimSpace(string(out)), nil

--- a/cmd/params/params_internal_test.go
+++ b/cmd/params/params_internal_test.go
@@ -4,9 +4,10 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/wakatime/wakatime-cli/pkg/regex"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/wakatime/wakatime-cli/pkg/regex"
 )
 
 func TestParseEditorFromPlugin(t *testing.T) {

--- a/cmd/params/testdata/.wakatime-vault-error.cfg
+++ b/cmd/params/testdata/.wakatime-vault-error.cfg
@@ -1,0 +1,2 @@
+[settings]
+api_key_vault_cmd = printf error >&2

--- a/cmd/params/testdata/.wakatime-vault.cfg
+++ b/cmd/params/testdata/.wakatime-vault.cfg
@@ -1,3 +1,2 @@
 [settings]
-api_key = 
 api_key_vault_cmd = echo 00000000-0000-4000-8000-000000000000

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -56,7 +56,9 @@ func Run(cmd *cobra.Command, v *viper.Viper) {
 		log.Errorf("failed to parse config files: %s", err)
 
 		if v.IsSet("entity") {
-			saveHeartbeatsAndExit(v)
+			saveHeartbeats(v)
+
+			os.Exit(exitcode.ErrConfigFileParse)
 		}
 	}
 
@@ -262,7 +264,7 @@ func runCmd(v *viper.Viper, verbose bool, sendDiagsOnErrors bool, cmd cmdFn) int
 	// catch panics
 	defer func() {
 		if err := recover(); err != nil {
-			log.Errorf("panicked: %v", err)
+			log.Errorf("panicked: %v. Stack: %s", err, string(debug.Stack()))
 
 			resetLogs()
 
@@ -306,7 +308,7 @@ func runCmd(v *viper.Viper, verbose bool, sendDiagsOnErrors bool, cmd cmdFn) int
 	return exitCode
 }
 
-func saveHeartbeatsAndExit(v *viper.Viper) {
+func saveHeartbeats(v *viper.Viper) {
 	queueFilepath, err := offline.QueueFilepath()
 	if err != nil {
 		log.Warnf("failed to load offline queue filepath: %s", err)
@@ -315,8 +317,6 @@ func saveHeartbeatsAndExit(v *viper.Viper) {
 	if err := cmdoffline.SaveHeartbeats(v, nil, queueFilepath); err != nil {
 		log.Errorf("failed to save heartbeats to offline queue: %s", err)
 	}
-
-	os.Exit(exitcode.ErrConfigFileParse)
 }
 
 func sendDiagnostics(v *viper.Viper, d diagnostics) error {

--- a/cmd/today/today_test.go
+++ b/cmd/today/today_test.go
@@ -119,7 +119,7 @@ func TestToday_ErrAuth(t *testing.T) {
 
 	var errauth api.ErrAuth
 
-	assert.True(t, errors.As(err, &errauth))
+	assert.ErrorAs(t, err, &errauth)
 
 	expectedMsg := fmt.Sprintf(
 		`failed fetching today from api: `+
@@ -127,6 +127,7 @@ func TestToday_ErrAuth(t *testing.T) {
 		testServerURL,
 	)
 	assert.Equal(t, expectedMsg, err.Error())
+
 	assert.Eventually(t, func() bool { return numCalls == 1 }, time.Second, 50*time.Millisecond)
 }
 
@@ -169,7 +170,8 @@ func TestToday_ErrAuth_UnsetAPIKey(t *testing.T) {
 
 	var errauth api.ErrAuth
 
-	assert.True(t, errors.As(err, &errauth))
+	assert.ErrorAs(t, err, &errauth)
+
 	assert.Equal(t, "failed to load API parameters: api key not found or empty", err.Error())
 }
 

--- a/cmd/todaygoal/todaygoal_test.go
+++ b/cmd/todaygoal/todaygoal_test.go
@@ -127,14 +127,15 @@ func TestGoal_ErrAuth(t *testing.T) {
 
 	var errauth api.ErrAuth
 
-	assert.True(t, errors.As(err, &errauth))
+	assert.ErrorAs(t, err, &errauth)
 
 	expectedMsg := fmt.Sprintf(
 		`failed fetching todays goal from api: `+
 			`authentication failed at "%s/users/current/goals/00000000-0000-4000-8000-000000000000". body: ""`,
 		testServerURL,
 	)
-	assert.Equal(t, expectedMsg, err.Error())
+	assert.EqualError(t, err, expectedMsg)
+
 	assert.Eventually(t, func() bool { return numCalls == 1 }, time.Second, 50*time.Millisecond)
 }
 
@@ -179,7 +180,8 @@ func TestGoal_ErrAuth_UnsetAPIKey(t *testing.T) {
 
 	var errauth api.ErrAuth
 
-	assert.True(t, errors.As(err, &errauth))
+	assert.ErrorAs(t, err, &errauth)
+
 	assert.Equal(
 		t,
 		"failed to load command parameters: failed to load API parameters: api key not found or empty",

--- a/pkg/api/error.go
+++ b/pkg/api/error.go
@@ -48,7 +48,7 @@ func (ErrAuth) ExitCode() int {
 
 // Message method to implement wakaerror.Error interface.
 func (e ErrAuth) Message() string {
-	return fmt.Sprintf("invalid api key... find yours at wakatime.com/api-key. %s", e.Err)
+	return fmt.Sprintf("invalid api key... find yours at wakatime.com/api-key. %s", e.Err.Error())
 }
 
 // ErrBadRequest represents a 400 response from the API.

--- a/pkg/api/fileexperts.go
+++ b/pkg/api/fileexperts.go
@@ -20,10 +20,6 @@ import (
 func (c *Client) FileExperts(heartbeats []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
 	url := c.baseURL + "/users/current/file_experts"
 
-	if heartbeats[0].APIKey == "" {
-		return nil, ErrAuth{Err: fmt.Errorf("missing api key")}
-	}
-
 	// change from heartbeat.Heartbeat to fileexpert.Entity
 	// it's safe to get the first item in the slice.
 	e := fileexperts.Entity{

--- a/pkg/api/fileexperts_test.go
+++ b/pkg/api/fileexperts_test.go
@@ -169,7 +169,7 @@ func TestClient_FileExperts_ErrAuth(t *testing.T) {
 
 	var errauth api.ErrAuth
 
-	assert.True(t, errors.As(err, &errauth))
+	assert.ErrorAs(t, err, &errauth)
 
 	assert.Eventually(t, func() bool { return numCalls == 1 }, time.Second, 50*time.Millisecond)
 }

--- a/pkg/api/goal_test.go
+++ b/pkg/api/goal_test.go
@@ -119,7 +119,8 @@ func TestClient_Goal_ErrAuth(t *testing.T) {
 
 	var errauth api.ErrAuth
 
-	assert.True(t, errors.As(err, &errauth))
+	assert.ErrorAs(t, err, &errauth)
+
 	assert.Eventually(t, func() bool { return numCalls == 1 }, time.Second, 50*time.Millisecond)
 }
 

--- a/pkg/api/heartbeat.go
+++ b/pkg/api/heartbeat.go
@@ -44,10 +44,6 @@ func (c *Client) SendHeartbeats(heartbeats []heartbeat.Heartbeat) ([]heartbeat.R
 }
 
 func (c *Client) sendHeartbeats(url string, heartbeats []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
-	if heartbeats[0].APIKey == "" {
-		return nil, ErrAuth{Err: fmt.Errorf("missing api key")}
-	}
-
 	data, err := json.Marshal(heartbeats)
 	if err != nil {
 		return nil, fmt.Errorf("failed to json encode body: %s", err)

--- a/pkg/api/heartbeat_test.go
+++ b/pkg/api/heartbeat_test.go
@@ -170,7 +170,7 @@ func TestClient_SendHeartbeats_ErrAuth(t *testing.T) {
 
 	var errauth api.ErrAuth
 
-	assert.True(t, errors.As(err, &errauth))
+	assert.ErrorAs(t, err, &errauth)
 
 	assert.Eventually(t, func() bool { return numCalls == 1 }, time.Second, 50*time.Millisecond)
 }

--- a/pkg/api/statusbar_test.go
+++ b/pkg/api/statusbar_test.go
@@ -116,7 +116,8 @@ func TestClient_StatusBar_ErrAuth(t *testing.T) {
 
 	var errauth api.ErrAuth
 
-	assert.True(t, errors.As(err, &errauth))
+	assert.ErrorAs(t, err, &errauth)
+
 	assert.Eventually(t, func() bool { return numCalls == 1 }, time.Second, 50*time.Millisecond)
 }
 


### PR DESCRIPTION
This PR does the following:
* Removes `Load` function from params to enable commands to load grouped parameters individually and have better control over errors.
* Standardize loading error message across all requests.
* Improve loading params for `fileexperts` command.
* Improve loading params for `heartbeat` command.
* Replace all occurences of `assert.True(t, errors.As(err, &errapi))` with `assert.ErrorAs(t, err, &errapi)`.
* At heartbeat command check if error is `api.ErrAuth` to correctly save heartbeats to offline db.
* Simplify how heartbeat command handle errors by using its internal `wakaerror.Error`.
* At `params.LoadOfflineParams()` if argument `sync-offline-activity` is less than zero won't be considered an error and instead will log as warn and set `Offline.SyncMax` to zero.
* Add unit test to validate if read from vault errored.
* Improve tests for api key parsing.
* Add `TestSendHeartbeats_ErrAuth_InvalidAPIKEY` as integration test to validate if an invalid api key will make heartbeats to be saved to offline db.
* It might fix #849 