### PR TITLE
Support using git remote as project name

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -49,6 +49,7 @@ projects/foo = your-api-key
 
 [git]
 submodules_disabled = false
+project_from_git_remote = false
 
 [git_submodule_projectmap]
 some/submodule/name = new project name

--- a/cmd/fileexperts/fileexperts.go
+++ b/cmd/fileexperts/fileexperts.go
@@ -116,8 +116,9 @@ func initHandleOptions(params paramscmd.Params) []heartbeat.HandleOption {
 			MapPatterns:   params.API.KeyPatterns,
 		}),
 		project.WithDetection(project.Config{
-			HideProjectNames: params.Heartbeat.Sanitize.HideProjectNames,
-			MapPatterns:      params.Heartbeat.Project.MapPatterns,
+			HideProjectNames:     params.Heartbeat.Sanitize.HideProjectNames,
+			MapPatterns:          params.Heartbeat.Project.MapPatterns,
+			ProjectFromGitRemote: params.Heartbeat.Project.ProjectFromGitRemote,
 			Submodule: project.Submodule{
 				DisabledPatterns: params.Heartbeat.Project.SubmodulesDisabled,
 				MapPatterns:      params.Heartbeat.Project.SubmoduleMapPatterns,

--- a/cmd/heartbeat/heartbeat.go
+++ b/cmd/heartbeat/heartbeat.go
@@ -187,6 +187,7 @@ func buildHeartbeats(params paramscmd.Params) []heartbeat.Heartbeat {
 		params.Heartbeat.LinesInFile,
 		params.Heartbeat.LocalFile,
 		params.Heartbeat.Project.Alternate,
+		params.Heartbeat.Project.ProjectFromGitRemote,
 		params.Heartbeat.Project.Override,
 		params.Heartbeat.Sanitize.ProjectPathOverride,
 		params.Heartbeat.Time,
@@ -211,6 +212,7 @@ func buildHeartbeats(params paramscmd.Params) []heartbeat.Heartbeat {
 				h.Lines,
 				h.LocalFile,
 				h.ProjectAlternate,
+				h.ProjectFromGitRemote,
 				h.ProjectOverride,
 				h.ProjectPathOverride,
 				h.Time,
@@ -242,8 +244,9 @@ func initHandleOptions(params paramscmd.Params) []heartbeat.HandleOption {
 			FilePatterns: params.Heartbeat.Sanitize.HideFileNames,
 		}),
 		project.WithDetection(project.Config{
-			HideProjectNames: params.Heartbeat.Sanitize.HideProjectNames,
-			MapPatterns:      params.Heartbeat.Project.MapPatterns,
+			HideProjectNames:     params.Heartbeat.Sanitize.HideProjectNames,
+			MapPatterns:          params.Heartbeat.Project.MapPatterns,
+			ProjectFromGitRemote: params.Heartbeat.Project.ProjectFromGitRemote,
 			Submodule: project.Submodule{
 				DisabledPatterns: params.Heartbeat.Project.SubmodulesDisabled,
 				MapPatterns:      params.Heartbeat.Project.SubmoduleMapPatterns,

--- a/cmd/offline/offline.go
+++ b/cmd/offline/offline.go
@@ -94,6 +94,7 @@ func buildHeartbeats(params paramscmd.Params) []heartbeat.Heartbeat {
 		params.Heartbeat.LinesInFile,
 		params.Heartbeat.LocalFile,
 		params.Heartbeat.Project.Alternate,
+		params.Heartbeat.Project.ProjectFromGitRemote,
 		params.Heartbeat.Project.Override,
 		params.Heartbeat.Sanitize.ProjectPathOverride,
 		params.Heartbeat.Time,
@@ -118,6 +119,7 @@ func buildHeartbeats(params paramscmd.Params) []heartbeat.Heartbeat {
 				h.Lines,
 				h.LocalFile,
 				h.ProjectAlternate,
+				h.ProjectFromGitRemote,
 				h.ProjectOverride,
 				h.ProjectPathOverride,
 				h.Time,
@@ -145,8 +147,9 @@ func initHandleOptions(params paramscmd.Params) []heartbeat.HandleOption {
 			FilePatterns: params.Heartbeat.Sanitize.HideFileNames,
 		}),
 		project.WithDetection(project.Config{
-			HideProjectNames: params.Heartbeat.Sanitize.HideProjectNames,
-			MapPatterns:      params.Heartbeat.Project.MapPatterns,
+			HideProjectNames:     params.Heartbeat.Sanitize.HideProjectNames,
+			MapPatterns:          params.Heartbeat.Project.MapPatterns,
+			ProjectFromGitRemote: params.Heartbeat.Project.ProjectFromGitRemote,
 			Submodule: project.Submodule{
 				DisabledPatterns: params.Heartbeat.Project.SubmodulesDisabled,
 				MapPatterns:      params.Heartbeat.Project.SubmoduleMapPatterns,

--- a/cmd/params/params.go
+++ b/cmd/params/params.go
@@ -133,6 +133,7 @@ type (
 		BranchAlternate      string
 		MapPatterns          []project.MapPattern
 		Override             string
+		ProjectFromGitRemote bool
 		SubmodulesDisabled   []regex.Regex
 		SubmoduleMapPatterns []project.MapPattern
 	}
@@ -559,6 +560,7 @@ func loadProjectParams(v *viper.Viper) (ProjectParams, error) {
 		BranchAlternate:      vipertools.GetString(v, "alternate-branch"),
 		MapPatterns:          loadProjectMapPatterns(v, "projectmap"),
 		Override:             vipertools.GetString(v, "project"),
+		ProjectFromGitRemote: v.GetBool("git.project_from_git_remote"),
 		SubmodulesDisabled:   submodulesDisabled,
 		SubmoduleMapPatterns: loadProjectMapPatterns(v, "git_submodule_projectmap"),
 	}, nil

--- a/cmd/params/params_test.go
+++ b/cmd/params/params_test.go
@@ -2341,6 +2341,17 @@ func TestProjectParams_String(t *testing.T) {
 	)
 }
 
+func TestLoadParams_ProjectFromGitRemote(t *testing.T) {
+	v := viper.New()
+	v.Set("git.project_from_git_remote", true)
+	v.Set("entity", "/path/to/file")
+
+	params, err := paramscmd.LoadHeartbeatParams(v)
+	require.NoError(t, err)
+
+	assert.True(t, params.Project.ProjectFromGitRemote)
+}
+
 func TestSanitizeParams_String(t *testing.T) {
 	sanitizeparams := paramscmd.SanitizeParams{
 		HideBranchNames:     []regex.Regex{regex.MustCompile("^/hide")},

--- a/pkg/heartbeat/heartbeat.go
+++ b/pkg/heartbeat/heartbeat.go
@@ -37,6 +37,7 @@ type Heartbeat struct {
 	LocalFileNeedsCleanup bool       `json:"-"`
 	Project               *string    `json:"project,omitempty"`
 	ProjectAlternate      string     `json:"-"`
+	ProjectFromGitRemote  bool       `json:"-"`
 	ProjectOverride       string     `json:"-"`
 	ProjectPath           string     `json:"-"`
 	ProjectPathOverride   string     `json:"-"`
@@ -61,29 +62,31 @@ func New(
 	lines *int,
 	localFile string,
 	projectAlternate string,
+	projectFromGitRemote bool,
 	projectOverride string,
 	projectPathOverride string,
 	time float64,
 	userAgent string,
 ) Heartbeat {
 	return Heartbeat{
-		BranchAlternate:     branchAlternate,
-		Category:            category,
-		CursorPosition:      cursorPosition,
-		Entity:              entity,
-		EntityType:          entityType,
-		IsUnsavedEntity:     isUnsavedEntity,
-		IsWrite:             isWrite,
-		Language:            language,
-		LanguageAlternate:   languageAlternate,
-		LineNumber:          lineNumber,
-		Lines:               lines,
-		LocalFile:           localFile,
-		ProjectAlternate:    projectAlternate,
-		ProjectOverride:     projectOverride,
-		ProjectPathOverride: projectPathOverride,
-		Time:                time,
-		UserAgent:           userAgent,
+		BranchAlternate:      branchAlternate,
+		Category:             category,
+		CursorPosition:       cursorPosition,
+		Entity:               entity,
+		EntityType:           entityType,
+		IsUnsavedEntity:      isUnsavedEntity,
+		IsWrite:              isWrite,
+		Language:             language,
+		LanguageAlternate:    languageAlternate,
+		LineNumber:           lineNumber,
+		Lines:                lines,
+		LocalFile:            localFile,
+		ProjectAlternate:     projectAlternate,
+		ProjectFromGitRemote: projectFromGitRemote,
+		ProjectOverride:      projectOverride,
+		ProjectPathOverride:  projectPathOverride,
+		Time:                 time,
+		UserAgent:            userAgent,
 	}
 }
 

--- a/pkg/heartbeat/heartbeat_test.go
+++ b/pkg/heartbeat/heartbeat_test.go
@@ -32,6 +32,7 @@ func TestNew(t *testing.T) {
 		nil,
 		"/path/to/file",
 		"billing",
+		false,
 		"pci",
 		"/custom-path",
 		1592868313.541149,

--- a/pkg/project/git_test.go
+++ b/pkg/project/git_test.go
@@ -134,6 +134,26 @@ func TestGit_Detect_Worktree(t *testing.T) {
 	}, result)
 }
 
+func TestGit_Detect_WorktreeGitRemote(t *testing.T) {
+	fp := setupTestGitWorktree(t)
+
+	g := project.Git{
+		Filepath:             filepath.Join(fp, "api/src/pkg/file.go"),
+		ProjectFromGitRemote: true,
+	}
+
+	result, detected, err := g.Detect()
+	require.NoError(t, err)
+
+	assert.True(t, detected)
+	assert.Contains(t, result.Folder, filepath.Join(fp, "wakatime-cli"))
+	assert.Equal(t, project.Result{
+		Project: "wakatime/wakatime-cli",
+		Branch:  "feature/api",
+		Folder:  result.Folder,
+	}, result)
+}
+
 func TestGit_Detect_Submodule(t *testing.T) {
 	fp := setupTestGitSubmodule(t)
 
@@ -219,6 +239,27 @@ func TestGit_Detect_SubmoduleProjectMap(t *testing.T) {
 	assert.Contains(t, result.Folder, filepath.Join(fp, "wakatime-cli"))
 	assert.Equal(t, project.Result{
 		Project: "my-project-1",
+		Branch:  "master",
+		Folder:  result.Folder,
+	}, result)
+}
+
+func TestGit_Detect_SubmoduleGitRemote(t *testing.T) {
+	fp := setupTestGitSubmodule(t)
+
+	g := project.Git{
+		Filepath:                  filepath.Join(fp, "wakatime-cli/lib/billing/src/lib/lib.cpp"),
+		ProjectFromGitRemote:      true,
+		SubmoduleDisabledPatterns: []regex.Regex{regexp.MustCompile("not_matching")},
+	}
+
+	result, detected, err := g.Detect()
+	require.NoError(t, err)
+
+	assert.True(t, detected)
+	assert.Contains(t, result.Folder, filepath.Join(fp, "wakatime-cli"))
+	assert.Equal(t, project.Result{
+		Project: "wakatime/billing",
 		Branch:  "master",
 		Folder:  result.Folder,
 	}, result)
@@ -462,7 +503,7 @@ func setupTestGitSubmodule(t *testing.T) (fp string) {
 	copyFile(t, "testdata/git_submodule/HEAD", filepath.Join(tmpDir, "wakatime-cli/.git/HEAD"))
 
 	// Setup git submodule
-	copyFile(t, "testdata/git_basic/config", filepath.Join(tmpDir, "wakatime-cli/.git/modules/lib/billing/config"))
+	copyFile(t, "testdata/git_submodule/config", filepath.Join(tmpDir, "wakatime-cli/.git/modules/lib/billing/config"))
 	copyFile(t, "testdata/git_submodule/HEAD2", filepath.Join(tmpDir, "wakatime-cli/.git/modules/lib/billing/HEAD"))
 	copyFile(t, "testdata/git_basic/config", filepath.Join(tmpDir, "billing/.git/config"))
 	copyFile(t, "testdata/git_submodule/HEAD2", filepath.Join(tmpDir, "billing/.git/HEAD"))

--- a/pkg/project/project_test.go
+++ b/pkg/project/project_test.go
@@ -523,6 +523,7 @@ func TestDetectWithRevControl_GitDetected(t *testing.T) {
 	result := project.DetectWithRevControl(
 		[]regex.Regex{},
 		[]project.MapPattern{},
+		false,
 		project.DetecterArg{
 			Filepath:  filepath.Join(fp, "wakatime-cli/src/pkg/file.go"),
 			ShouldRun: true,
@@ -532,6 +533,27 @@ func TestDetectWithRevControl_GitDetected(t *testing.T) {
 	assert.Contains(t, result.Folder, filepath.Join(fp, "wakatime-cli"))
 	assert.Equal(t, project.Result{
 		Project: "wakatime-cli",
+		Folder:  result.Folder,
+		Branch:  "master",
+	}, result)
+}
+
+func TestDetectWithRevControl_GitRemoteDetected(t *testing.T) {
+	fp := setupTestGitBasic(t)
+
+	result := project.DetectWithRevControl(
+		[]regex.Regex{},
+		[]project.MapPattern{},
+		true,
+		project.DetecterArg{
+			Filepath:  filepath.Join(fp, "wakatime-cli/src/pkg/file.go"),
+			ShouldRun: true,
+		},
+	)
+
+	assert.Contains(t, result.Folder, filepath.Join(fp, "wakatime-cli"))
+	assert.Equal(t, project.Result{
+		Project: "wakatime/wakatime-cli",
 		Folder:  result.Folder,
 		Branch:  "master",
 	}, result)

--- a/pkg/project/testdata/git_submodule/config
+++ b/pkg/project/testdata/git_submodule/config
@@ -4,13 +4,10 @@
 	bare = false
 	logallrefupdates = true
 	ignorecase = true
-	precomposeunicode = true
+	worktree = ../../../billing
 [remote "origin"]
-	url = git@github.com:wakatime/wakatime-cli.git
+	url = git@github.com:wakatime/billing.git
 	fetch = +refs/heads/*:refs/remotes/origin/*
-[branch "develop"]
+[branch "main"]
 	remote = origin
-	merge = refs/heads/develop
-[user]
-	email = wakatime-cli@wakatime.com
-	name = WakaTime
+	merge = refs/heads/main


### PR DESCRIPTION
Fixes https://github.com/wakatime/jetbrains-wakatime/issues/249

Adds a new `~/.wakatime.cfg` key:

```ini
[git]
project_from_git_remote = false
```

Defaults to `false`, but if set to `true` will use the Git remote instead of local folder as project name.

For ex: `wakatime-cli` becomes `wakatime/wakatime-cli`