### PR TITLE
UrlEncode X-Machine-Name header

### DIFF
--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -33,13 +33,13 @@ func NewClientWithoutAuth(params paramscmd.API) (*api.Client, error) {
 // newClient contains the logic of client initialization, except auth initialization.
 func newClient(params paramscmd.API, opts ...api.Option) (*api.Client, error) {
 	opts = append(opts, api.WithTimeout(params.Timeout))
-	opts = append(opts, api.WithHostname(params.Hostname))
+	opts = append(opts, api.WithHostname(strings.TrimSpace(params.Hostname)))
 
 	tz, err := tz.Name()
 	if err != nil {
 		log.Debugf("failed to detect local timezone: %s", err)
 	} else {
-		opts = append(opts, api.WithTimezone(tz))
+		opts = append(opts, api.WithTimezone(strings.TrimSpace(tz)))
 	}
 
 	if params.DisableSSLVerify {

--- a/pkg/api/option.go
+++ b/pkg/api/option.go
@@ -34,17 +34,6 @@ func WithAuth(auth BasicAuth) (Option, error) {
 	}, nil
 }
 
-// WithHostname sets the X-Machine-Name header to the passed in hostname.
-func WithHostname(hostname string) Option {
-	return func(c *Client) {
-		next := c.doFunc
-		c.doFunc = func(c *Client, req *http.Request) (*http.Response, error) {
-			req.Header.Set("X-Machine-Name", hostname)
-			return next(c, req)
-		}
-	}
-}
-
 // WithDisableSSLVerify disables verification of insecure certificates.
 func WithDisableSSLVerify() Option {
 	return func(c *Client) {
@@ -159,12 +148,27 @@ func WithTimeout(timeout time.Duration) Option {
 	}
 }
 
+// WithHostname sets the X-Machine-Name header to the passed in hostname.
+func WithHostname(hostname string) Option {
+	return func(c *Client) {
+		next := c.doFunc
+		c.doFunc = func(c *Client, req *http.Request) (*http.Response, error) {
+			hostname = url.QueryEscape(strings.TrimSpace(hostname))
+			req.Header.Set("X-Machine-Name", hostname)
+
+			return next(c, req)
+		}
+	}
+}
+
 // WithTimezone sets the TimeZone header to the passed in timezone.
 func WithTimezone(timezone string) Option {
 	return func(c *Client) {
 		next := c.doFunc
 		c.doFunc = func(c *Client, req *http.Request) (*http.Response, error) {
+			timezone = strings.TrimSpace(timezone)
 			req.Header.Set("Timezone", timezone)
+
 			return next(c, req)
 		}
 	}
@@ -178,7 +182,9 @@ func WithUserAgent(plugin string) Option {
 	return func(c *Client) {
 		next := c.doFunc
 		c.doFunc = func(c *Client, req *http.Request) (*http.Response, error) {
+			userAgent = strings.TrimSpace(userAgent)
 			req.Header.Set("User-Agent", userAgent)
+
 			return next(c, req)
 		}
 	}

--- a/pkg/api/option.go
+++ b/pkg/api/option.go
@@ -153,7 +153,7 @@ func WithHostname(hostname string) Option {
 	return func(c *Client) {
 		next := c.doFunc
 		c.doFunc = func(c *Client, req *http.Request) (*http.Response, error) {
-			hostname = url.QueryEscape(strings.TrimSpace(hostname))
+			hostname = url.QueryEscape(hostname)
 			req.Header.Set("X-Machine-Name", hostname)
 
 			return next(c, req)
@@ -166,7 +166,6 @@ func WithTimezone(timezone string) Option {
 	return func(c *Client) {
 		next := c.doFunc
 		c.doFunc = func(c *Client, req *http.Request) (*http.Response, error) {
-			timezone = strings.TrimSpace(timezone)
 			req.Header.Set("Timezone", timezone)
 
 			return next(c, req)

--- a/pkg/api/option.go
+++ b/pkg/api/option.go
@@ -182,7 +182,6 @@ func WithUserAgent(plugin string) Option {
 	return func(c *Client) {
 		next := c.doFunc
 		c.doFunc = func(c *Client, req *http.Request) (*http.Response, error) {
-			userAgent = strings.TrimSpace(userAgent)
 			req.Header.Set("User-Agent", userAgent)
 
 			return next(c, req)

--- a/pkg/api/option_test.go
+++ b/pkg/api/option_test.go
@@ -97,7 +97,7 @@ func TestOption_WithInvalidHostname(t *testing.T) {
 	var numCalls int
 
 	router.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
-		assert.Equal(t, []string{"my%2Bcomputer"}, req.Header["X-Machine-Name"])
+		assert.Equal(t, []string{"my%2Bcomputer%0A"}, req.Header["X-Machine-Name"])
 
 		numCalls++
 	})

--- a/pkg/heartbeat/heartbeat.go
+++ b/pkg/heartbeat/heartbeat.go
@@ -186,12 +186,12 @@ func UserAgent(plugin string) string {
 
 	return fmt.Sprintf(
 		"wakatime/%s (%s-%s-%s) %s %s",
-		version.Version,
-		system.OSName(),
-		info.Core,
-		info.Platform,
-		runtime.Version(),
-		plugin,
+		strings.TrimSpace(version.Version),
+		strings.TrimSpace(system.OSName()),
+		strings.TrimSpace(info.Core),
+		strings.TrimSpace(info.Platform),
+		strings.TrimSpace(runtime.Version()),
+		strings.TrimSpace(plugin),
 	)
 }
 

--- a/pkg/heartbeat/heartbeat.go
+++ b/pkg/heartbeat/heartbeat.go
@@ -186,7 +186,7 @@ func UserAgent(plugin string) string {
 
 	return fmt.Sprintf(
 		"wakatime/%s (%s-%s-%s) %s %s",
-		strings.TrimSpace(version.Version),
+		version.Version,
 		strings.TrimSpace(system.OSName()),
 		strings.TrimSpace(info.Core),
 		strings.TrimSpace(info.Platform),


### PR DESCRIPTION
Fixes https://github.com/wakatime/jetbrains-wakatime/issues/250 by url encoding the `X-Machine-Name` header because it's value comes from user input.

The WakaTime API now urldecodes `X-Machine-Name` header on incoming heartbeats, deployed today.