### PR TITLE
Prevent panic from os.Stat()

### DIFF
--- a/pkg/heartbeat/heartbeat.go
+++ b/pkg/heartbeat/heartbeat.go
@@ -210,6 +210,11 @@ func PointerTo[t bool | int | string](v t) *t {
 }
 
 func isDir(filepath string) bool {
-	info, _ := os.Stat(filepath)
+	info, err := os.Stat(filepath)
+	if err != nil {
+		log.Warnf("failed to stat filepath %q: %s", filepath, err)
+		return false
+	}
+
 	return info.IsDir()
 }


### PR DESCRIPTION
This PR prevents panic from `os.Stat()` func by checking the error.

Fixes #861 