### PR TITLE
Move log file to .wakatime folder

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -19,5 +19,5 @@ Please fill out the template below to report a bug.
 **Logs**:
 
 <!--
-Paste related logs from your ~/.wakatime.log file.
+Paste related logs from your ~/.wakatime/wakatime.log file.
 -->

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -4,7 +4,7 @@ First, read [How to debug WakaTime plugins][faq debug plugins].
 
 Set `debug=true` in your `~/.wakatime.cfg` file to enable verbose logging.
 
-The common wakatime-cli program logs to your user `$HOME` directory `~/.wakatime.log`.
+The common wakatime-cli program logs to your user `$HOME` directory `~/.wakatime/wakatime.log`.
 
 Each plugin also has its own log file:
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -81,7 +81,7 @@ some/submodule/name = new project name
 | ssl_certs_file                 | Path to a CA certs file. By default, uses bundled Letsencrypt CA cert along with system ca certs. | _filepath_ | |
 | timeout                        | Connection timeout in seconds when communicating with the api. | _int_ | `120` |
 | hostname                       | Optional name of local machine. By default, auto-detects the local machine’s hostname. | _string_ | |
-| log_file                       | Optional log file path. | _filepath_ | `~/.wakatime.log` |
+| log_file                       | Optional log file path. | _filepath_ | `~/.wakatime/wakatime.log` |
 
 ### Project Map Section
 

--- a/cmd/logfile/logfile.go
+++ b/cmd/logfile/logfile.go
@@ -11,7 +11,10 @@ import (
 	"github.com/spf13/viper"
 )
 
-const defaultFile = ".wakatime.log"
+const (
+	defaultFile   = "wakatime.log"
+	defaultFolder = ".wakatime"
+)
 
 // Params contains log file parameters.
 type Params struct {
@@ -49,12 +52,17 @@ func LoadParams(v *viper.Viper) (Params, error) {
 		return params, nil
 	}
 
-	home, err := ini.WakaHomeDir()
+	home, hometype, err := ini.WakaHomeDir()
 	if err != nil {
 		return Params{}, fmt.Errorf("failed getting user's home directory: %s", err)
 	}
 
-	params.File = filepath.Join(home, defaultFile)
+	switch hometype {
+	case ini.WakaHomeTypeEnvVar:
+		params.File = filepath.Join(home, defaultFile)
+	default:
+		params.File = filepath.Join(home, defaultFolder, defaultFile)
+	}
 
 	return params, nil
 }

--- a/cmd/logfile/logfile_test.go
+++ b/cmd/logfile/logfile_test.go
@@ -13,14 +13,14 @@ import (
 )
 
 func TestLoadParams(t *testing.T) {
-	tmpFile, err := os.CreateTemp(t.TempDir(), "wakatime.log")
+	tmpFile, err := os.CreateTemp(t.TempDir(), "")
 	require.NoError(t, err)
 
 	defer tmpFile.Close()
 
 	dir, _ := filepath.Split(tmpFile.Name())
 
-	logFile, err := os.Create(filepath.Join(dir, ".wakatime.log"))
+	logFile, err := os.Create(filepath.Join(dir, "wakatime.log"))
 	require.NoError(t, err)
 
 	defer logFile.Close()
@@ -41,14 +41,14 @@ func TestLoadParams(t *testing.T) {
 		"log file and verbose set": {
 			ViperDebug: true,
 			Expected: logfile.Params{
-				File:    filepath.Join(home, ".wakatime.log"),
+				File:    filepath.Join(home, ".wakatime", "wakatime.log"),
 				Verbose: true,
 			},
 		},
 		"log file and verbose from config": {
 			ViperDebugConfig: true,
 			Expected: logfile.Params{
-				File:    filepath.Join(home, ".wakatime.log"),
+				File:    filepath.Join(home, ".wakatime", "wakatime.log"),
 				Verbose: true,
 			},
 		},
@@ -76,18 +76,18 @@ func TestLoadParams(t *testing.T) {
 		"log file from WAKATIME_HOME": {
 			EnvVar: dir,
 			Expected: logfile.Params{
-				File: filepath.Join(dir, ".wakatime.log"),
+				File: filepath.Join(dir, "wakatime.log"),
 			},
 		},
 		"log file from home dir": {
 			Expected: logfile.Params{
-				File: filepath.Join(home, ".wakatime.log"),
+				File: filepath.Join(home, ".wakatime", "wakatime.log"),
 			},
 		},
 		"log to stdout": {
 			ViperToStdout: true,
 			Expected: logfile.Params{
-				File:     filepath.Join(home, ".wakatime.log"),
+				File:     filepath.Join(home, ".wakatime", "wakatime.log"),
 				ToStdout: true,
 			},
 		},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -154,8 +154,8 @@ func setFlags(cmd *cobra.Command, v *viper.Viper) {
 			" remote file, this local file will be used for stats and just"+
 			" the value of --entity is sent with the heartbeat.",
 	)
-	flags.String("log-file", "", "Optional log file. Defaults to '~/.wakatime.log'.")
-	flags.String("logfile", "", "(deprecated) Optional log file. Defaults to '~/.wakatime.log'.")
+	flags.String("log-file", "", "Optional log file. Defaults to '~/.wakatime/wakatime.log'.")
+	flags.String("logfile", "", "(deprecated) Optional log file. Defaults to '~/.wakatime/wakatime.log'.")
 	flags.Bool("log-to-stdout", false, "If enabled, logs will go to stdout. Will overwrite logfile configs.")
 	flags.Bool(
 		"no-ssl-verify",

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"runtime/debug"
 	"strings"
 
@@ -216,6 +217,14 @@ func SetupLogging(v *viper.Viper) (*logfile.Params, error) {
 	logFile := os.Stdout
 
 	if !logfileParams.ToStdout {
+		dir := filepath.Dir(logfileParams.File)
+		if _, err := os.Stat(dir); os.IsNotExist(err) {
+			err := os.MkdirAll(dir, 0750)
+			if err != nil {
+				return nil, fmt.Errorf("error creating log file directory: %s", err)
+			}
+		}
+
 		logFile, err = os.OpenFile(logfileParams.File, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
 		if err != nil {
 			return nil, fmt.Errorf("error opening log file: %s", err)

--- a/pkg/offline/offline.go
+++ b/pkg/offline/offline.go
@@ -89,7 +89,7 @@ func WithQueue(filepath string) heartbeat.HandleOption {
 // the user's $HOME folder cannot be detected, it defaults to the
 // current directory.
 func QueueFilepath() (string, error) {
-	home, err := ini.WakaHomeDir()
+	home, _, err := ini.WakaHomeDir()
 	if err != nil {
 		return dbFilename, fmt.Errorf("failed getting user's home directory, defaulting to current directory: %s", err)
 	}


### PR DESCRIPTION
This PR moves `.wakatime.log` file to `.wakatime/wakatime.log` path when **WAKATIME_HOME** env var is not set.

ref https://github.com/wakatime/wakatime-cli/issues/558#issuecomment-1502495426