### PR TITLE
Update swift_test.go

### DIFF
--- a/pkg/deps/swift_test.go
+++ b/pkg/deps/swift_test.go
@@ -12,7 +12,7 @@ import (
 func TestParserSwift_Parse(t *testing.T) //TestParserSwift_Parse tests the Parse function of the ParserSwift struct.
 func TestParserSwift_Parse(t *testing.T) {
 	t.Helper()
-{
+
 	parser := deps.ParserSwift{}
 
 	dependencies, err := parser.Parse("testdata/swift.swift")

--- a/pkg/deps/swift_test.go
+++ b/pkg/deps/swift_test.go
@@ -9,13 +9,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestParserSwift_Parse(t *testing.T) //TestParserSwift_Parse tests the Parse function of the ParserSwift struct.
 func TestParserSwift_Parse(t *testing.T) {
+	t.Helper()
+{
 	parser := deps.ParserSwift{}
 
 	dependencies, err := parser.Parse("testdata/swift.swift")
 	require.NoError(t, err)
 
-	assert.Equal(t, []string{
+	require.ElementsMatch(t, []string{
 		"UIKit",
 		"PromiseKit",
 	}, dependencies)


### PR DESCRIPTION
Using `require.ElementsMatch()` function instead of `assert.Equal()` for comparing slices, will ensure that the order of elements in the slice does not matter.