### PR TITLE
Update version.go

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -3,13 +3,13 @@ package version
 // nolint:gochecknoglobals
 var (
 	// Arch specifies the CPU architecture of the wakatime-cli build.
-	Arch = "unset"
+	Arch = "unknown"
 	// BuildDate states the date of the wakatime-cli build.
-	BuildDate = "unset"
+	BuildDate = "unknown"
 	// Commit states the commit of the wakatime-cli build.
-	Commit = "unset"
+	Commit = "unknown"
 	// OS specifies the target operating system of the wakatime-cli build.
-	OS = "unset"
+	OS = "unknown"
 	// Version states the version of the wakatime-cli build.
-	Version = "unset"
+	Version = "unknown"
 )


### PR DESCRIPTION
Hi, @alanhamlett 
By initializing the variables to "unknown", we make it clear that the values are not set by default, will prevent any confusion that could arise from using the previous "unset" value. 