### PR TITLE
Replace realpath with newer and simpler library

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -21,10 +21,11 @@ jobs:
         name: Checkout
         uses: actions/checkout@v3
       -
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version-file: ${{ env.GO_VERSION_FILE }}
           check-latest: ${{ env.CHECK_LATEST }}
+          cache: false
       -
         name: Pull dependencies
         run: make install-go-modules
@@ -52,10 +53,11 @@ jobs:
         name: Checkout
         uses: actions/checkout@v3
       -
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version-file: ${{ env.GO_VERSION_FILE }}
           check-latest: ${{ env.CHECK_LATEST }}
+          cache: false
       -
         name: Pull dependencies
         run: make install-go-modules
@@ -76,10 +78,11 @@ jobs:
         name: Checkout
         uses: actions/checkout@v3
       -
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version-file: ${{ env.GO_VERSION_FILE }}
           check-latest: ${{ env.CHECK_LATEST }}
+          cache: false
       -
         name: Pull dependencies
         run: make install-go-modules
@@ -98,10 +101,11 @@ jobs:
         name: Checkout
         uses: actions/checkout@v3
       -
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version-file: ${{ env.GO_VERSION_FILE }}
           check-latest: ${{ env.CHECK_LATEST }}
+          cache: false
       -
         name: Pull dependencies
         run: make install-go-modules
@@ -122,16 +126,20 @@ jobs:
         name: Checkout
         uses: actions/checkout@v3
       -
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version-file: ${{ env.GO_VERSION_FILE }}
           check-latest: ${{ env.CHECK_LATEST }}
+          cache: false
       -
         name: Pull dependencies
         run: make install-go-modules
       -
         name: Unit tests
         run: make test
+      -
+        name: Linter
+        run: make lint
 
   test-integration-macos:
     name: Integration Tests macOS
@@ -141,10 +149,11 @@ jobs:
         name: Checkout
         uses: actions/checkout@v3
       -
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version-file: ${{ env.GO_VERSION_FILE }}
           check-latest: ${{ env.CHECK_LATEST }}
+          cache: false
       -
         name: Pull dependencies
         run: make install-go-modules
@@ -233,10 +242,11 @@ jobs:
         uses: actions/checkout@v3
       -
         name: Setup go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version-file: ${{ env.GO_VERSION_FILE }}
           check-latest: ${{ env.CHECK_LATEST }}
+          cache: false
       -
         name: Build binaries
         env:
@@ -273,10 +283,11 @@ jobs:
         uses: actions/checkout@v3
       -
         name: Setup go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version-file: ${{ env.GO_VERSION_FILE }}
           check-latest: ${{ env.CHECK_LATEST }}
+          cache: false
       -
         name: Build binaries
         env:
@@ -313,10 +324,11 @@ jobs:
         uses: actions/checkout@v3
       -
         name: Setup go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version-file: ${{ env.GO_VERSION_FILE }}
           check-latest: ${{ env.CHECK_LATEST }}
+          cache: false
       -
         name: Build binaries
         env:
@@ -353,10 +365,11 @@ jobs:
         uses: actions/checkout@v3
       -
         name: Setup go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version-file: ${{ env.GO_VERSION_FILE }}
           check-latest: ${{ env.CHECK_LATEST }}
+          cache: false
       -
         name: Build binaries
         env:
@@ -393,10 +406,11 @@ jobs:
         uses: actions/checkout@v3
       -
         name: Setup go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version-file: ${{ env.GO_VERSION_FILE }}
           check-latest: ${{ env.CHECK_LATEST }}
+          cache: false
       -
         name: Build binaries
         env:
@@ -433,10 +447,11 @@ jobs:
         uses: actions/checkout@v3
       -
         name: Setup go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version-file: ${{ env.GO_VERSION_FILE }}
           check-latest: ${{ env.CHECK_LATEST }}
+          cache: false
       -
         name: Build binaries
         env:

--- a/cmd/heartbeat/heartbeat_test.go
+++ b/cmd/heartbeat/heartbeat_test.go
@@ -23,8 +23,8 @@ import (
 	"github.com/wakatime/wakatime-cli/pkg/project"
 	"github.com/wakatime/wakatime-cli/pkg/version"
 	"github.com/wakatime/wakatime-cli/pkg/windows"
-	"github.com/yookoala/realpath"
 
+	"github.com/gandarez/go-realpath"
 	"github.com/matishsiao/goInfo"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964
 	github.com/dlclark/regexp2 v1.8.1
 	github.com/gandarez/go-olson-timezone v0.1.0
+	github.com/gandarez/go-realpath v1.0.0
 	github.com/juju/mutex v0.0.0-20180619145857-d21b13acf4bf
 	github.com/kevinburke/ssh_config v1.2.1-0.20220605204831-a56e914e7283
 	github.com/matishsiao/goInfo v0.0.0-20210923090445-da2e3fa8d45f
@@ -18,8 +19,7 @@ require (
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/jwalterweatherman v1.1.0
 	github.com/spf13/viper v1.15.0
-	github.com/stretchr/testify v1.8.1
-	github.com/yookoala/realpath v1.0.0
+	github.com/stretchr/testify v1.8.4
 	go.etcd.io/bbolt v1.3.7
 	golang.org/x/crypto v0.6.0
 	golang.org/x/net v0.7.0
@@ -45,6 +45,7 @@ require (
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/subosito/gotenv v1.4.2 // indirect
+	github.com/yookoala/realpath v1.0.0 // indirect
 	golang.org/x/sys v0.5.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -76,6 +76,10 @@ github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/gandarez/go-olson-timezone v0.1.0 h1:cDRlHKQE0uC3mJNZyKoQIpAuvQtV8KXwIVj8bDEEyuo=
 github.com/gandarez/go-olson-timezone v0.1.0/go.mod h1:+yV/cYNjgs2JqdGShznAD4R13r8lKMGR2XlWAJqa5Yo=
+github.com/gandarez/go-realpath v0.1.0 h1:jaHsXGZp55mXSGoXj2QWUTMLWqTk3jg6yRS6gXold7Y=
+github.com/gandarez/go-realpath v0.1.0/go.mod h1:B5MPsYoZD8dUhGtNbTlOZGuaRD/jM0CnbBWXXD1rSk8=
+github.com/gandarez/go-realpath v1.0.0 h1:fhQBRDshH/MZNmDLWM9vbBameK2fxyLr+ctqkRwbHEU=
+github.com/gandarez/go-realpath v1.0.0/go.mod h1:B5MPsYoZD8dUhGtNbTlOZGuaRD/jM0CnbBWXXD1rSk8=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -258,8 +262,9 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/subosito/gotenv v1.4.2 h1:X1TuBLAMDFbaTAChgCBLu3DU3UPyELpnF2jjJ2cz/S8=
 github.com/subosito/gotenv v1.4.2/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=
 github.com/wakatime/chroma v0.10.0-wakatime.1 h1:S3XwuOsibZY0hQlUyoJ9mak7K2kbrrfTh1X6XD2DK4c=

--- a/main_test.go
+++ b/main_test.go
@@ -24,8 +24,8 @@ import (
 	"github.com/wakatime/wakatime-cli/pkg/project"
 	"github.com/wakatime/wakatime-cli/pkg/version"
 	"github.com/wakatime/wakatime-cli/pkg/windows"
-	"github.com/yookoala/realpath"
 
+	"github.com/gandarez/go-realpath"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/apikey/apikey_test.go
+++ b/pkg/apikey/apikey_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/wakatime/wakatime-cli/pkg/apikey"
 	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 
+	"github.com/gandarez/go-realpath"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/yookoala/realpath"
 )
 
 func TestWithReplacing(t *testing.T) {

--- a/pkg/heartbeat/format.go
+++ b/pkg/heartbeat/format.go
@@ -7,7 +7,7 @@ import (
 	"github.com/wakatime/wakatime-cli/pkg/log"
 	"github.com/wakatime/wakatime-cli/pkg/windows"
 
-	"github.com/yookoala/realpath"
+	"github.com/gandarez/go-realpath"
 )
 
 // WithFormatting initializes and returns a heartbeat handle option, which

--- a/pkg/heartbeat/format_test.go
+++ b/pkg/heartbeat/format_test.go
@@ -5,11 +5,12 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 	"github.com/wakatime/wakatime-cli/pkg/windows"
-	"github.com/yookoala/realpath"
+
+	"github.com/gandarez/go-realpath"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestWithFormatting(t *testing.T) {

--- a/pkg/project/file_test.go
+++ b/pkg/project/file_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 
 	"github.com/wakatime/wakatime-cli/pkg/project"
-	"github.com/yookoala/realpath"
 
+	"github.com/gandarez/go-realpath"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/project/git_test.go
+++ b/pkg/project/git_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/wakatime/wakatime-cli/pkg/project"
 	"github.com/wakatime/wakatime-cli/pkg/regex"
 	"github.com/wakatime/wakatime-cli/pkg/windows"
-	"github.com/yookoala/realpath"
 
+	"github.com/gandarez/go-realpath"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/project/map_test.go
+++ b/pkg/project/map_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	"github.com/wakatime/wakatime-cli/pkg/project"
-	"github.com/yookoala/realpath"
 
+	"github.com/gandarez/go-realpath"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -15,8 +15,8 @@ import (
 	"github.com/wakatime/wakatime-cli/pkg/log"
 	"github.com/wakatime/wakatime-cli/pkg/regex"
 	"github.com/wakatime/wakatime-cli/pkg/windows"
-	"github.com/yookoala/realpath"
 
+	"github.com/gandarez/go-realpath"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 )

--- a/pkg/project/project_test.go
+++ b/pkg/project/project_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/wakatime/wakatime-cli/pkg/project"
 	"github.com/wakatime/wakatime-cli/pkg/regex"
 	"github.com/wakatime/wakatime-cli/pkg/windows"
-	"github.com/yookoala/realpath"
 
+	"github.com/gandarez/go-realpath"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )


### PR DESCRIPTION
The `realpath` port was initially designed in 2010 and last modified in 2017 which misses some language features added to Golang since them. This PR replaces that library with one written by me and well tested.

https://github.com/gandarez/go-realpath

Fixes #888 