### PR TITLE
Improve linting for Actions

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -32,9 +32,12 @@ jobs:
       -
         name: Unit tests
         run: make test
-      -
+      - 
         name: Linter
-        run: make lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest
+          skip-cache: true
       -
         name: Vulnerability scan
         run: make vulncheck
@@ -89,9 +92,12 @@ jobs:
       -
         name: Unit tests
         run: make test
-      -
+      - 
         name: Linter
-        run: make lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest
+          skip-cache: true
 
   test-integration-windows:
     name: Integration Tests Windows
@@ -137,9 +143,12 @@ jobs:
       -
         name: Unit tests
         run: make test
-      -
+      - 
         name: Linter
-        run: make lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest
+          skip-cache: true
 
   test-integration-macos:
     name: Integration Tests macOS

--- a/go.sum
+++ b/go.sum
@@ -76,8 +76,6 @@ github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/gandarez/go-olson-timezone v0.1.0 h1:cDRlHKQE0uC3mJNZyKoQIpAuvQtV8KXwIVj8bDEEyuo=
 github.com/gandarez/go-olson-timezone v0.1.0/go.mod h1:+yV/cYNjgs2JqdGShznAD4R13r8lKMGR2XlWAJqa5Yo=
-github.com/gandarez/go-realpath v0.1.0 h1:jaHsXGZp55mXSGoXj2QWUTMLWqTk3jg6yRS6gXold7Y=
-github.com/gandarez/go-realpath v0.1.0/go.mod h1:B5MPsYoZD8dUhGtNbTlOZGuaRD/jM0CnbBWXXD1rSk8=
 github.com/gandarez/go-realpath v1.0.0 h1:fhQBRDshH/MZNmDLWM9vbBameK2fxyLr+ctqkRwbHEU=
 github.com/gandarez/go-realpath v1.0.0/go.mod h1:B5MPsYoZD8dUhGtNbTlOZGuaRD/jM0CnbBWXXD1rSk8=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=


### PR DESCRIPTION
This PR replaces manually calling `make lint` with `golangci-lint-action` to avoid errors like [this](https://github.com/wakatime/wakatime-cli/actions/runs/5739883323/job/15556493045).