### PR TITLE
Catch panic from bbolt open connection

### DIFF
--- a/cmd/run_internal_test.go
+++ b/cmd/run_internal_test.go
@@ -53,7 +53,7 @@ func TestRunCmd_ErrOfflineEnqueue(t *testing.T) {
 	router.HandleFunc("/plugins/errors", func(w http.ResponseWriter, req *http.Request) {
 		// check request
 		assert.Equal(t, http.MethodPost, req.Method)
-		assert.Nil(t, req.Header["Authorization"])
+		assert.Equal(t, []string{"Basic MDAwMDAwMDAtMDAwMC00MDAwLTgwMDAtMDAwMDAwMDAwMDAw"}, req.Header["Authorization"])
 		assert.Equal(t, []string{"application/json"}, req.Header["Content-Type"])
 
 		expectedBodyTpl, err := os.ReadFile("testdata/diagnostics_request_template.json")
@@ -63,12 +63,14 @@ func TestRunCmd_ErrOfflineEnqueue(t *testing.T) {
 		require.NoError(t, err)
 
 		var diagnostics struct {
-			Platform     string `json:"platform"`
-			Architecture string `json:"architecture"`
-			CliVersion   string `json:"cli_version"`
-			Editor       string `json:"editor"`
-			Logs         string `json:"logs"`
-			Stack        string `json:"stacktrace"`
+			Architecture  string `json:"architecture"`
+			CliVersion    string `json:"cli_version"`
+			Editor        string `json:"editor"`
+			Logs          string `json:"logs"`
+			OriginalError string `json:"error_message"`
+			Platform      string `json:"platform"`
+			Plugin        string `json:"plugin"`
+			Stack         string `json:"stacktrace"`
 		}
 
 		err = json.Unmarshal(body, &diagnostics)
@@ -76,6 +78,7 @@ func TestRunCmd_ErrOfflineEnqueue(t *testing.T) {
 
 		expectedBodyStr := fmt.Sprintf(
 			string(expectedBodyTpl),
+			jsonEscape(t, diagnostics.OriginalError),
 			jsonEscape(t, diagnostics.Logs),
 			jsonEscape(t, diagnostics.Stack),
 		)

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -1,8 +1,12 @@
 package api_test
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func setupTestServer() (string, *http.ServeMux, func()) {
@@ -10,4 +14,13 @@ func setupTestServer() (string, *http.ServeMux, func()) {
 	srv := httptest.NewServer(router)
 
 	return srv.URL, router, func() { srv.Close() }
+}
+
+func jsonEscape(t *testing.T, i string) string {
+	b, err := json.Marshal(i)
+	require.NoError(t, err)
+
+	s := string(b)
+
+	return s[1 : len(s)-1]
 }

--- a/pkg/api/error.go
+++ b/pkg/api/error.go
@@ -29,6 +29,16 @@ func (e Err) Message() string {
 	return fmt.Sprintf("api error: %s", e.Err)
 }
 
+// SendDiagsOnErrors method to implement wakaerror.SendDiagsOnErrors interface.
+func (Err) SendDiagsOnErrors() bool {
+	return false
+}
+
+// ShouldLogError method to implement wakaerror.ShouldLogError interface.
+func (Err) ShouldLogError() bool {
+	return true
+}
+
 // ErrAuth represents an authentication error.
 type ErrAuth struct {
 	Err error
@@ -49,6 +59,16 @@ func (ErrAuth) ExitCode() int {
 // Message method to implement wakaerror.Error interface.
 func (e ErrAuth) Message() string {
 	return fmt.Sprintf("invalid api key... find yours at wakatime.com/api-key. %s", e.Err.Error())
+}
+
+// SendDiagsOnErrors method to implement wakaerror.SendDiagsOnErrors interface.
+func (ErrAuth) SendDiagsOnErrors() bool {
+	return false
+}
+
+// ShouldLogError method to implement wakaerror.ShouldLogError interface.
+func (ErrAuth) ShouldLogError() bool {
+	return true
 }
 
 // ErrBadRequest represents a 400 response from the API.
@@ -73,6 +93,16 @@ func (e ErrBadRequest) Message() string {
 	return fmt.Sprintf("bad request: %s", e.Err)
 }
 
+// SendDiagsOnErrors method to implement wakaerror.SendDiagsOnErrors interface.
+func (ErrBadRequest) SendDiagsOnErrors() bool {
+	return false
+}
+
+// ShouldLogError method to implement wakaerror.ShouldLogError interface.
+func (ErrBadRequest) ShouldLogError() bool {
+	return true
+}
+
 // ErrBackoff means we send later because currently rate limited.
 type ErrBackoff struct {
 	Err error
@@ -93,4 +123,14 @@ func (ErrBackoff) ExitCode() int {
 // Message method to implement wakaerror.Error interface.
 func (e ErrBackoff) Message() string {
 	return fmt.Sprintf("rate limited: %s", e.Err)
+}
+
+// SendDiagsOnErrors method to implement wakaerror.SendDiagsOnErrors interface.
+func (ErrBackoff) SendDiagsOnErrors() bool {
+	return false
+}
+
+// ShouldLogError method to implement wakaerror.ShouldLogError interface.
+func (ErrBackoff) ShouldLogError() bool {
+	return false
 }

--- a/pkg/api/testdata/diagnostics_request.json
+++ b/pkg/api/testdata/diagnostics_request.json
@@ -1,9 +1,0 @@
-{
-	"architecture": "amd64",
-	"cli_version": "<local-build>",
-	"error_message": "some error",
-	"logs": "some logs",
-	"platform": "linux",
-	"plugin": "vim",
-	"stacktrace": "some stack"
-}

--- a/pkg/api/testdata/diagnostics_request_template.json
+++ b/pkg/api/testdata/diagnostics_request_template.json
@@ -1,0 +1,9 @@
+{
+	"architecture": "some architecture",
+	"cli_version": "some version",
+	"error_message": "%s",
+	"logs": "%s",
+	"platform": "some os",
+	"plugin": "vim",
+	"stacktrace": "%s"
+}

--- a/pkg/offline/error.go
+++ b/pkg/offline/error.go
@@ -1,0 +1,41 @@
+package offline
+
+import (
+	"fmt"
+
+	"github.com/wakatime/wakatime-cli/pkg/exitcode"
+	"github.com/wakatime/wakatime-cli/pkg/wakaerror"
+)
+
+// ErrOpenDB is an error returned when the database cannot be opened.
+type ErrOpenDB struct {
+	Err error
+}
+
+var _ wakaerror.Error = ErrOpenDB{}
+
+// Error method to implement error interface.
+func (e ErrOpenDB) Error() string {
+	return e.Err.Error()
+}
+
+// Message method to implement wakaerror.Error interface.
+func (e ErrOpenDB) Message() string {
+	return fmt.Sprintf("failed to open db file: %s", e.Err)
+}
+
+// ExitCode method to implement wakaerror.Error interface.
+func (ErrOpenDB) ExitCode() int {
+	// Despite the error, we don't want to exit with an error code.
+	return exitcode.Success
+}
+
+// SendDiagsOnErrors method to implement wakaerror.SendDiagsOnErrors interface.
+func (ErrOpenDB) SendDiagsOnErrors() bool {
+	return true
+}
+
+// ShouldLogError method to implement wakaerror.ShouldLogError interface.
+func (ErrOpenDB) ShouldLogError() bool {
+	return true
+}

--- a/pkg/wakaerror/wakaerror.go
+++ b/pkg/wakaerror/wakaerror.go
@@ -2,7 +2,13 @@ package wakaerror
 
 // Error is a custom error interface.
 type Error interface {
+	// ExitCode returns the exit code for the error.
 	ExitCode() int
+	// Message returns the error message.
 	Message() string
+	// SendDiagsOnErrors returns true when diagnostics should be sent on error.
+	SendDiagsOnErrors() bool
+	// ShouldLogError returns true when error should be logged.
+	ShouldLogError() bool
 	error
 }


### PR DESCRIPTION
This PR catches any panic from `bolt.Open` and log it as error or warning depending the context where it's called. This is a way to avoid breaking the cli when there's a corrupted bolt file. It also fixes few typos.

Closes #848 