### PR TITLE
Try to guess the language by file content

### DIFF
--- a/pkg/language/language.go
+++ b/pkg/language/language.go
@@ -175,7 +175,7 @@ func correspondingFileExists(fp string, extension string) bool {
 	return false
 }
 
-// loadFolderExtensions loads all existing from a folder.
+// loadFolderExtensions loads all existing file extensions from a folder.
 func loadFolderExtensions(dir string) ([]string, error) {
 	files, err := os.ReadDir(dir)
 	if err != nil {

--- a/pkg/language/language_test.go
+++ b/pkg/language/language_test.go
@@ -305,6 +305,7 @@ func TestDetect_ChromaTopLanguagesRetrofit(t *testing.T) {
 				"path/to/zshrc",
 				"path/to/.zshrc",
 				"path/to/PKGBUILD",
+				"testdata/bash",
 			},
 			Expected: heartbeat.LanguageBash,
 		},
@@ -586,8 +587,11 @@ func TestDetect_ChromaTopLanguagesRetrofit(t *testing.T) {
 			Expected:  heartbeat.LanguagePawn,
 		},
 		"perl not prolog": {
-			Filepaths: []string{"testdata/codefiles/chroma_unsupported_top/perl.pl"},
-			Expected:  heartbeat.LanguagePerl,
+			Filepaths: []string{
+				"testdata/codefiles/chroma_unsupported_top/perl.pl",
+				"testdata/perl",
+			},
+			Expected: heartbeat.LanguagePerl,
 		},
 		"php": {
 			Filepaths: []string{
@@ -655,6 +659,7 @@ func TestDetect_ChromaTopLanguagesRetrofit(t *testing.T) {
 				"path/to/BUILD.bazel",
 				"path/to/WORKSPACE",
 				"path/to/file.tac",
+				"testdata/python3",
 			},
 			Expected: heartbeat.LanguagePython,
 		},

--- a/pkg/language/testdata/bash
+++ b/pkg/language/testdata/bash
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Greet user and request their name
+echo "The activity generator"
+read -p "What is your name? " name
+
+# Create an array of activities
+activity[0]="Football"
+activity[1]="Table Tennis"
+activity[2]="8 Ball Pool"
+activity[3]="PS5"
+activity[4]="Blackjack"
+
+array_length=${#activity[@]} # Store the length of the array
+index=$(($RANDOM % $array_length)) # Randomly select an index from 0 to array_length
+
+# Invite the user to join you participate in an activity
+echo "Hi" $name, "would you like to play" ${activity[$index]}"?"
+read -p "Answer: " answer

--- a/pkg/language/testdata/perl
+++ b/pkg/language/testdata/perl
@@ -1,0 +1,18 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+
+use Path::Tiny;
+
+my $dir = path('foo','bar'); # foo/bar
+
+# Iterate over the content of foo/bar
+my $iter = $dir->iterator;
+while (my $file = $iter->()) {
+    
+    # See if it is a directory and skip
+    next if $file->is_dir();
+    
+    # Print out the file name and path
+    print "$file\n";
+}

--- a/pkg/language/testdata/python3
+++ b/pkg/language/testdata/python3
@@ -1,0 +1,4 @@
+#!/usr/bin/python3
+
+if __name__ == "__main__":
+    print("Hello, World!")


### PR DESCRIPTION
This PR adds a fallback that will try to guess the language by the content of a file. It also fixes `fileHead` function to read the first 512 bytes and do not fill the entire array with null characters making false-positives in some circunstances.

Fixes #821 