### PR TITLE
Catch panic for Chroma analyze text

### DIFF
--- a/pkg/language/chroma.go
+++ b/pkg/language/chroma.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	fp "path/filepath"
+	"runtime/debug"
 	"sort"
 	"strings"
 
@@ -124,6 +125,12 @@ func detectChromaCustomized(filepath string) (heartbeat.Language, float32, bool)
 // analyse text content and return the "best" lexer.
 // This is a copy of chroma.lexers.internal.api:Analyse().
 func analyse(text string) chroma.Lexer {
+	defer func() {
+		if err := recover(); err != nil {
+			log.Errorf("panicked: %v. Stack: %s", err, string(debug.Stack()))
+		}
+	}()
+
 	var picked chroma.Lexer
 
 	highest := float32(0.0)


### PR DESCRIPTION
Some Chroma lexers are not very well tested and can lead to panics, so this PR catch those panics, log them to the file and return as `unknown` language.