### PR TITLE
Validate required fields for fileexperts

### DIFF
--- a/cmd/fileexperts/fileexperts.go
+++ b/cmd/fileexperts/fileexperts.go
@@ -133,6 +133,7 @@ func initHandleOptions(params paramscmd.Params) []heartbeat.HandleOption {
 			HideProjectFolder: params.Heartbeat.Sanitize.HideProjectFolder,
 			ProjectPatterns:   params.Heartbeat.Sanitize.HideProjectNames,
 		}),
+		fileexperts.WithValidation(),
 		filter.WithLengthValidator(),
 	}
 }

--- a/pkg/fileexperts/validation.go
+++ b/pkg/fileexperts/validation.go
@@ -1,0 +1,41 @@
+package fileexperts
+
+import (
+	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
+	"github.com/wakatime/wakatime-cli/pkg/log"
+)
+
+// WithValidation initializes and returns a heartbeat handle option, which
+// can be used in a heartbeat processing pipeline to validate the heartbeat
+// before sending it to the API.
+func WithValidation() heartbeat.HandleOption {
+	return func(next heartbeat.Handle) heartbeat.Handle {
+		return func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+			log.Debugln("execute fileexperts validation")
+
+			var filtered []heartbeat.Heartbeat
+
+			for _, h := range hh {
+				if !Validate(h) {
+					log.Debugf("missing required fields for fileexperts")
+					continue
+				}
+
+				filtered = append(filtered, h)
+			}
+
+			return next(filtered)
+		}
+	}
+}
+
+// Validate validates if required fields are not empty.
+func Validate(h heartbeat.Heartbeat) bool {
+	if h.Entity == "" ||
+		h.Project == nil || *h.Project == "" ||
+		h.ProjectRootCount == nil || *h.ProjectRootCount == 0 {
+		return false
+	}
+
+	return true
+}

--- a/pkg/fileexperts/validation_test.go
+++ b/pkg/fileexperts/validation_test.go
@@ -1,0 +1,97 @@
+package fileexperts_test
+
+import (
+	"testing"
+
+	"github.com/wakatime/wakatime-cli/pkg/fileexperts"
+	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithValidation(t *testing.T) {
+	opt := fileexperts.WithValidation()
+	h := opt(func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+		assert.Equal(t, []heartbeat.Heartbeat{
+			{
+				Entity:           "/path/to/file",
+				Project:          heartbeat.PointerTo("wakatime"),
+				ProjectRootCount: heartbeat.PointerTo(3),
+			},
+		}, hh)
+
+		return []heartbeat.Result{
+			{
+				Status: 201,
+			},
+		}, nil
+	})
+
+	result, err := h([]heartbeat.Heartbeat{
+		{
+			Entity:           "/path/to/file",
+			Project:          heartbeat.PointerTo("wakatime"),
+			ProjectRootCount: heartbeat.PointerTo(3),
+		},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, []heartbeat.Result{
+		{
+			Status: 201,
+		},
+	}, result)
+}
+
+func TestValidate_EmptyEntity(t *testing.T) {
+	h := heartbeat.Heartbeat{}
+
+	result := fileexperts.Validate(h)
+
+	assert.False(t, result)
+}
+
+func TestValidate_NilProject(t *testing.T) {
+	h := heartbeat.Heartbeat{
+		Entity: "/path/to/file",
+	}
+
+	result := fileexperts.Validate(h)
+
+	assert.False(t, result)
+}
+
+func TestValidate_EmptyProject(t *testing.T) {
+	h := heartbeat.Heartbeat{
+		Entity:  "/path/to/file",
+		Project: heartbeat.PointerTo(""),
+	}
+
+	result := fileexperts.Validate(h)
+
+	assert.False(t, result)
+}
+
+func TestValidate_NilProjectRootCount(t *testing.T) {
+	h := heartbeat.Heartbeat{
+		Entity:  "/path/to/file",
+		Project: heartbeat.PointerTo("waktime"),
+	}
+
+	result := fileexperts.Validate(h)
+
+	assert.False(t, result)
+}
+
+func TestValidate_ZeroProjectRootCount(t *testing.T) {
+	h := heartbeat.Heartbeat{
+		Entity:           "/path/to/file",
+		Project:          heartbeat.PointerTo("waktime"),
+		ProjectRootCount: heartbeat.PointerTo(0),
+	}
+
+	result := fileexperts.Validate(h)
+
+	assert.False(t, result)
+}


### PR DESCRIPTION
This PR validates required fields to avoid bad request before calling file experts endpoint.

Fix #919 