### PR TITLE
Add support for Mojo programming language

### DIFF
--- a/pkg/heartbeat/language.go
+++ b/pkg/heartbeat/language.go
@@ -891,6 +891,8 @@ const (
 	LanguageModula2
 	// LanguageMoinWiki represents the MoinWiki programming language.
 	LanguageMoinWiki
+	// LanguageMojo represents the Mojo programming language.
+	LanguageMojo
 	// LanguageMonkey represents the Monkey programming language.
 	LanguageMonkey
 	// LanguageMonkeyC represents the MonkeyC programming language.
@@ -2004,6 +2006,7 @@ const (
 	languageModelicaStr                    = "Modelica"
 	languageModula2Str                     = "Modula-2"
 	languageMoinWikiStr                    = "MoinMoin/Trac Wiki markup"
+	languageMojoStr                        = "Mojo"
 	languageMonkeyStr                      = "Monkey"
 	languageMonkeyCStr                     = "MonkeyC"
 	languageMonteStr                       = "Monte"
@@ -3280,6 +3283,8 @@ func ParseLanguage(s string) (Language, bool) {
 		return LanguageModula2, true
 	case normalizeString(languageMoinWikiStr):
 		return LanguageMoinWiki, true
+	case normalizeString(languageMojoStr):
+		return LanguageMojo, true
 	case normalizeString(languageMonkeyStr):
 		return LanguageMonkey, true
 	case normalizeString(languageMonkeyCStr):
@@ -4956,6 +4961,8 @@ func (l Language) String() string {
 		return languageModula2Str
 	case LanguageMoinWiki:
 		return languageMoinWikiStr
+	case LanguageMojo:
+		return languageMojoStr
 	case LanguageMonkey:
 		return languageMonkeyStr
 	case LanguageMonkeyC:

--- a/pkg/heartbeat/language_test.go
+++ b/pkg/heartbeat/language_test.go
@@ -453,6 +453,7 @@ func languageTests() map[string]heartbeat.Language {
 		"Modelica":                         heartbeat.LanguageModelica,
 		"Modula-2":                         heartbeat.LanguageModula2,
 		"MoinMoin/Trac Wiki markup":        heartbeat.LanguageMoinWiki,
+		"Mojo":                             heartbeat.LanguageMojo,
 		"Monkey":                           heartbeat.LanguageMonkey,
 		"MonkeyC":                          heartbeat.LanguageMonkeyC,
 		"Monte":                            heartbeat.LanguageMonte,

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -169,6 +169,7 @@ func RegisterAll() error {
 		MiniScript{},
 		Modelica{},
 		Modula2{},
+		Mojo{},
 		Monkey{},
 		Monte{},
 		MoonScript{},

--- a/pkg/lexer/mojo.go
+++ b/pkg/lexer/mojo.go
@@ -1,0 +1,32 @@
+package lexer
+
+import (
+	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
+
+	"github.com/alecthomas/chroma/v2"
+)
+
+// Mojo lexer.
+type Mojo struct{}
+
+// Lexer returns the lexer.
+func (l Mojo) Lexer() chroma.Lexer {
+	return chroma.MustNewLexer(
+		&chroma.Config{
+			Name:      l.Name(),
+			Aliases:   []string{"mojo"},
+			Filenames: []string{"*.🔥", "*.mojo"},
+			MimeTypes: []string{"text/x-mojo"},
+		},
+		func() chroma.Rules {
+			return chroma.Rules{
+				"root": {},
+			}
+		},
+	)
+}
+
+// Name returns the name of the lexer.
+func (Mojo) Name() string {
+	return heartbeat.LanguageMojo.StringChroma()
+}


### PR DESCRIPTION
This PR adds support for both `.🔥` and `.mojo` file extensions.

ref https://github.com/wakatime/vscode-wakatime/issues/365