### PR TITLE
Add support for IDA family

### DIFF
--- a/pkg/heartbeat/language.go
+++ b/pkg/heartbeat/language.go
@@ -655,6 +655,8 @@ const (
 	LanguageHyPhy
 	// LanguageIcon represents the Icon programming language.
 	LanguageIcon
+	// LanguageIDA represents the IDA programming language.
+	LanguageIDA
 	// LanguageIDL represents the IDL programming language.
 	LanguageIDL
 	// LanguageIdris represents the Idris programming language.
@@ -1888,6 +1890,7 @@ const (
 	languageHybrisStr                      = "Hybris"
 	languageHyPhyStr                       = "HyPhy"
 	languageIconStr                        = "Icon"
+	languageIDAStr                         = "IDA"
 	languageIDLStr                         = "IDL"
 	languageIdrisStr                       = "Idris"
 	languageIgnoreListStr                  = "Ignore List"
@@ -3047,6 +3050,8 @@ func ParseLanguage(s string) (Language, bool) {
 		return LanguageHyPhy, true
 	case normalizeString(languageIconStr):
 		return LanguageIcon, true
+	case normalizeString(languageIDAStr):
+		return LanguageIDA, true
 	case normalizeString(languageIDLStr):
 		return LanguageIDL, true
 	case normalizeString(languageIdrisStr):
@@ -4725,6 +4730,8 @@ func (l Language) String() string {
 		return languageHyPhyStr
 	case LanguageIcon:
 		return languageIconStr
+	case LanguageIDA:
+		return languageIDAStr
 	case LanguageIDL:
 		return languageIDLStr
 	case LanguageIdris:

--- a/pkg/heartbeat/language_test.go
+++ b/pkg/heartbeat/language_test.go
@@ -335,6 +335,7 @@ func languageTests() map[string]heartbeat.Language {
 		"Hybris":                           heartbeat.LanguageHybris,
 		"HyPhy":                            heartbeat.LanguageHyPhy,
 		"Icon":                             heartbeat.LanguageIcon,
+		"IDA":                              heartbeat.LanguageIDA,
 		"IDL":                              heartbeat.LanguageIDL,
 		"Idris":                            heartbeat.LanguageIdris,
 		"Ignore List":                      heartbeat.LanguageIgnoreList,

--- a/pkg/lexer/ida.go
+++ b/pkg/lexer/ida.go
@@ -1,0 +1,32 @@
+package lexer
+
+import (
+	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
+
+	"github.com/alecthomas/chroma/v2"
+)
+
+// IDA lexer.
+type IDA struct{}
+
+// Lexer returns the lexer.
+func (l IDA) Lexer() chroma.Lexer {
+	return chroma.MustNewLexer(
+		&chroma.Config{
+			Name:      l.Name(),
+			Aliases:   []string{"IDA Pro", "IDA Free"},
+			Filenames: []string{"*.i64", "*.idb"},
+			MimeTypes: []string{"text/x-ida"},
+		},
+		func() chroma.Rules {
+			return chroma.Rules{
+				"root": {},
+			}
+		},
+	)
+}
+
+// Name returns the name of the lexer.
+func (IDA) Name() string {
+	return heartbeat.LanguageIDA.StringChroma()
+}

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -122,6 +122,7 @@ func RegisterAll() error {
 		INI{},
 		IRCLogs{},
 		Icon{},
+		IDA{},
 		Inform6{},
 		Inform6Template{},
 		Inform7{},


### PR DESCRIPTION
This PR adds support for `IDA` family including `Pro` and `Free` versions. Because IDA stores its own configuration file in a binary format and wakatime-cli detects it as `Objective C` a new lexer dedicated to that IDE is necessary.

ref https://github.com/wakatime/wakatime-cli/issues/928