### PR TITLE
Add .ruby-version as Ruby language

### DIFF
--- a/pkg/language/language_test.go
+++ b/pkg/language/language_test.go
@@ -690,6 +690,7 @@ func TestDetect_ChromaTopLanguagesRetrofit(t *testing.T) {
 		},
 		"ruby": {
 			Filepaths: []string{
+				"path/to/.ruby-version",
 				"path/to/file.rb",
 				"path/to/file.rbw",
 				"path/to/Rakefile",

--- a/pkg/lexer/ruby.go
+++ b/pkg/lexer/ruby.go
@@ -1,0 +1,27 @@
+package lexer
+
+import (
+	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
+	"github.com/wakatime/wakatime-cli/pkg/log"
+
+	"github.com/alecthomas/chroma/v2/lexers"
+)
+
+// nolint:gochecknoinits
+func init() {
+	language := heartbeat.LanguageRuby.StringChroma()
+	lexer := lexers.Get(language)
+
+	if lexer == nil {
+		log.Debugf("lexer %q not found", language)
+		return
+	}
+
+	cfg := lexer.Config()
+	if cfg == nil {
+		log.Debugf("lexer %q config not found", language)
+		return
+	}
+
+	cfg.Filenames = append(cfg.Filenames, ".ruby-version")
+}


### PR DESCRIPTION
This PR adds `.ruby-version` file as Ruby instead of being detected as `Other`.