### PR TITLE
Count lines changed for current file

### DIFF
--- a/cmd/heartbeat/heartbeat.go
+++ b/cmd/heartbeat/heartbeat.go
@@ -248,6 +248,7 @@ func initHandleOptions(params paramscmd.Params) []heartbeat.HandleOption {
 			FilePatterns: params.Heartbeat.Sanitize.HideFileNames,
 		}),
 		project.WithDetection(project.Config{
+			CountLinesChanged:    params.Heartbeat.CountLinesChanged,
 			HideProjectNames:     params.Heartbeat.Sanitize.HideProjectNames,
 			MapPatterns:          params.Heartbeat.Project.MapPatterns,
 			ProjectFromGitRemote: params.Heartbeat.Project.ProjectFromGitRemote,

--- a/cmd/params/params_test.go
+++ b/cmd/params/params_test.go
@@ -135,6 +135,39 @@ func TestLoadParams_CursorPosition_Unset(t *testing.T) {
 	assert.Nil(t, params.CursorPosition)
 }
 
+func TestLoadHeartbeat_CountLinesChanged_FlagTakesPrecedence(t *testing.T) {
+	v := viper.New()
+	v.Set("entity", "/path/to/file")
+	v.Set("count-lines-changed", true)
+	v.Set("settings.count_lines_changed", false)
+
+	params, err := paramscmd.LoadHeartbeatParams(v)
+	require.NoError(t, err)
+
+	assert.True(t, params.CountLinesChanged)
+}
+
+func TestLoadHeartbeat_CountLinesChanged_FromConfig(t *testing.T) {
+	v := viper.New()
+	v.Set("entity", "/path/to/file")
+	v.Set("settings.count_lines_changed", true)
+
+	params, err := paramscmd.LoadHeartbeatParams(v)
+	require.NoError(t, err)
+
+	assert.True(t, params.CountLinesChanged)
+}
+
+func TestLoadHeartbeat_CountLinesChanged_Default(t *testing.T) {
+	v := viper.New()
+	v.Set("entity", "/path/to/file")
+
+	params, err := paramscmd.LoadHeartbeatParams(v)
+	require.NoError(t, err)
+
+	assert.False(t, params.CountLinesChanged)
+}
+
 func TestLoadParams_Entity_EntityFlagTakesPrecedence(t *testing.T) {
 	v := viper.New()
 	v.Set("entity", "/path/to/file")
@@ -2327,30 +2360,30 @@ func TestFilterParams_String(t *testing.T) {
 
 func TestHeartbeat_String(t *testing.T) {
 	heartbeat := paramscmd.Heartbeat{
-		Category:        heartbeat.CodingCategory,
-		CursorPosition:  heartbeat.PointerTo(15),
-		Entity:          "path/to/entity.go",
-		EntityType:      heartbeat.FileType,
-		ExtraHeartbeats: make([]heartbeat.Heartbeat, 3),
-		GuessLanguage:   true,
-		IsUnsavedEntity: true,
-		IsWrite:         heartbeat.PointerTo(true),
-		Language:        heartbeat.PointerTo("Golang"),
-		LineNumber:      heartbeat.PointerTo(4),
-		LinesInFile:     heartbeat.PointerTo(56),
-		Time:            1585598059,
+		Category:          heartbeat.CodingCategory,
+		CountLinesChanged: true,
+		CursorPosition:    heartbeat.PointerTo(15),
+		Entity:            "path/to/entity.go",
+		EntityType:        heartbeat.FileType,
+		ExtraHeartbeats:   make([]heartbeat.Heartbeat, 3),
+		GuessLanguage:     true,
+		IsUnsavedEntity:   true,
+		IsWrite:           heartbeat.PointerTo(true),
+		Language:          heartbeat.PointerTo("Golang"),
+		LineNumber:        heartbeat.PointerTo(4),
+		LinesInFile:       heartbeat.PointerTo(56),
+		Time:              1585598059,
 	}
 
 	assert.Equal(
 		t,
-		"category: 'coding', cursor position: '15', entity: 'path/to/entity.go', entity type: 'file',"+
-			" num extra heartbeats: 3, guess language: true, is unsaved entity: true, is write: true,"+
-			" language: 'Golang', line number: '4', lines in file: '56', time: 1585598059.00000, filter"+
-			" params: (exclude: '[]', exclude unknown project: false, include: '[]', include only with"+
-			" project file: false), project params: (alternate: '', branch alternate: '', map patterns:"+
-			" '[]', override: '', git submodules disabled: '[]', git submodule project map: '[]'), sanitize"+
-			" params: (hide branch names: '[]', hide project folder: false, hide file names: '[]',"+
-			" hide project names: '[]', project path override: '')",
+		"category: 'coding', count lines changed: true, cursor position: '15', entity: 'path/to/entity.go',"+
+			" entity type: 'file', num extra heartbeats: 3, guess language: true, is unsaved entity: true, is write: true,"+
+			" language: 'Golang', line number: '4', lines in file: '56', time: 1585598059.00000, filter params:"+
+			" (exclude: '[]', exclude unknown project: false, include: '[]', include only with project file: false),"+
+			" project params: (alternate: '', branch alternate: '', map patterns: '[]', override: '',"+
+			" git submodules disabled: '[]', git submodule project map: '[]'), sanitize params: (hide branch names: '[]',"+
+			" hide project folder: false, hide file names: '[]', hide project names: '[]', project path override: '')",
 		heartbeat.String(),
 	)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"flag"
 	"fmt"
 
 	"github.com/wakatime/wakatime-cli/pkg/api"
@@ -74,6 +75,7 @@ func setFlags(cmd *cobra.Command, v *viper.Viper) {
 		nil,
 		"Writes value to a config key, then exits. Expects two arguments, key and value.",
 	)
+	flag.Bool("count-lines-changed", false, "When set, counts lines added and removed in the current entity.")
 	flags.Int("cursorpos", 0, "Optional cursor position in the current file.")
 	flags.Bool("disable-offline", false, "Disables offline time logging instead of queuing logged time.")
 	flags.Bool("disableoffline", false, "(deprecated) Disables offline time logging instead of queuing logged time.")

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -1,0 +1,121 @@
+package git
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"time"
+
+	"github.com/wakatime/wakatime-cli/pkg/log"
+)
+
+const defaultCountLinesChangedTimeoutSecs = 2
+
+var gitLinesChangedRegex = regexp.MustCompile(`^(?P<added>\d+)\s*(?P<removed>\d+)\s*(?s).*$`)
+
+type (
+	// Git is an interface to git.
+	Git interface {
+		CountLinesChanged() (*int, *int, error)
+	}
+
+	// Client is a git client.
+	Client struct {
+		filepath string
+		GitCmd   func(args ...string) (string, error)
+	}
+)
+
+// New creates a new git client.
+func New(filepath string) *Client {
+	return &Client{
+		filepath: filepath,
+		GitCmd:   gitCmdFn,
+	}
+}
+
+// gitCmdFn runs a git command with the specified env vars and returns its output or errors.
+func gitCmdFn(args ...string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultCountLinesChangedTimeoutSecs*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "git", args...)
+
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("failed to execute git command: %s", stderr.String())
+	}
+
+	return stdout.String(), nil
+}
+
+// CountLinesChanged counts the number of lines added and removed in a file.
+func (c *Client) CountLinesChanged() (*int, *int, error) {
+	if !fileExists(c.filepath) {
+		return nil, nil, nil
+	}
+
+	out, err := c.GitCmd("-C", filepath.Dir(c.filepath), "diff", "--numstat", c.filepath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to count lines changed: %s", err)
+	}
+
+	if out == "" {
+		// Maybe it's staged, try with --cached.
+		out, err = c.GitCmd("-C", filepath.Dir(c.filepath), "diff", "--numstat", "--cached", c.filepath)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to count lines changed: %s", err)
+		}
+	}
+
+	if out == "" {
+		return nil, nil, nil
+	}
+
+	match := gitLinesChangedRegex.FindStringSubmatch(out)
+	paramsMap := make(map[string]string)
+
+	for i, name := range gitLinesChangedRegex.SubexpNames() {
+		if i > 0 && i <= len(match) {
+			paramsMap[name] = match[i]
+		}
+	}
+
+	if len(paramsMap) == 0 {
+		log.Debugf("failed to parse git diff output: %s", out)
+
+		return nil, nil, nil
+	}
+
+	var added, removed *int
+
+	if val, ok := paramsMap["added"]; ok {
+		if v, err := strconv.Atoi(val); err == nil {
+			added = &v
+		}
+	}
+
+	if val, ok := paramsMap["removed"]; ok {
+		if v, err := strconv.Atoi(val); err == nil {
+			removed = &v
+		}
+	}
+
+	return added, removed, nil
+}
+
+// fileExists checks if a file or directory exist.
+func fileExists(fp string) bool {
+	_, err := os.Stat(fp)
+	return err == nil || os.IsExist(err)
+}

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -1,0 +1,124 @@
+package git_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/wakatime/wakatime-cli/pkg/git"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCountLinesChanged(t *testing.T) {
+	gc := git.New("testdata/main.go")
+	gc.GitCmd = func(args ...string) (string, error) {
+		assert.Equal(t, args, []string{"-C", "testdata", "diff", "--numstat", "testdata/main.go"})
+
+		return "4       1       testdata/main.go", nil
+	}
+
+	added, removed, err := gc.CountLinesChanged()
+	require.NoError(t, err)
+
+	require.NotNil(t, added)
+	require.NotNil(t, removed)
+
+	assert.Equal(t, 4, *added)
+	assert.Equal(t, 1, *removed)
+}
+
+func TestCountLinesChanged_Err(t *testing.T) {
+	gc := git.New("testdata/main.go")
+	gc.GitCmd = func(args ...string) (string, error) {
+		assert.Equal(t, args, []string{"-C", "testdata", "diff", "--numstat", "testdata/main.go"})
+
+		return "", errors.New("some error")
+	}
+
+	added, removed, err := gc.CountLinesChanged()
+	assert.EqualError(t, err, "failed to count lines changed: some error")
+
+	assert.Nil(t, added)
+	assert.Nil(t, removed)
+}
+
+func TestCountLinesChanged_Staged(t *testing.T) {
+	gc := git.New("testdata/main.go")
+
+	var numCalls int
+
+	gc.GitCmd = func(args ...string) (string, error) {
+		numCalls++
+
+		switch numCalls {
+		case 1:
+			assert.Equal(t, args, []string{"-C", "testdata", "diff", "--numstat", "testdata/main.go"})
+		case 2:
+			assert.Equal(t, args, []string{"-C", "testdata", "diff", "--numstat", "--cached", "testdata/main.go"})
+
+			return "4       1       testdata/main.go", nil
+		}
+
+		return "", nil
+	}
+
+	added, removed, err := gc.CountLinesChanged()
+	assert.NoError(t, err)
+
+	require.NotNil(t, added)
+	require.NotNil(t, removed)
+
+	assert.Equal(t, 4, *added)
+	assert.Equal(t, 1, *removed)
+}
+
+func TestCountLinesChanged_MissingFile(t *testing.T) {
+	gc := git.New("/tmp/missing-file")
+
+	added, removed, err := gc.CountLinesChanged()
+	assert.NoError(t, err)
+
+	assert.Nil(t, added)
+	assert.Nil(t, removed)
+}
+
+func TestCountLinesChanged_NoOutput(t *testing.T) {
+	gc := git.New("testdata/main.go")
+
+	var numCalls int
+
+	gc.GitCmd = func(args ...string) (string, error) {
+		numCalls++
+
+		switch numCalls {
+		case 1:
+			assert.Equal(t, args, []string{"-C", "testdata", "diff", "--numstat", "testdata/main.go"})
+		case 2:
+			assert.Equal(t, args, []string{"-C", "testdata", "diff", "--numstat", "--cached", "testdata/main.go"})
+		}
+
+		return "", nil
+	}
+
+	added, removed, err := gc.CountLinesChanged()
+	assert.NoError(t, err)
+
+	assert.Nil(t, added)
+	assert.Nil(t, removed)
+}
+
+func TestCountLinesChanged_MalformedOutput(t *testing.T) {
+	gc := git.New("testdata/main.go")
+	gc.GitCmd = func(args ...string) (string, error) {
+		assert.Equal(t, args, []string{"-C", "testdata", "diff", "--numstat", "testdata/main.go"})
+
+		return "malformed output", nil
+	}
+
+	added, removed, err := gc.CountLinesChanged()
+	assert.NoError(t, err)
+
+	assert.Nil(t, added)
+	assert.Nil(t, removed)
+}

--- a/pkg/git/testdata/main.go
+++ b/pkg/git/testdata/main.go
@@ -1,0 +1,9 @@
+package main
+
+import "fmt"
+
+func main() {
+	sum := 1 + 2
+
+	fmt.Printf("sum: %d\n", sum)
+}

--- a/pkg/heartbeat/heartbeat.go
+++ b/pkg/heartbeat/heartbeat.go
@@ -33,6 +33,8 @@ type Heartbeat struct {
 	LanguageAlternate     string     `json:"-"`
 	LineNumber            *int       `json:"lineno,omitempty"`
 	Lines                 *int       `json:"lines,omitempty"`
+	LinesAdded            *int       `json:"lines_added,omitempty"`
+	LinesRemoved          *int       `json:"lines_removed,omitempty"`
 	LocalFile             string     `json:"-"`
 	LocalFileNeedsCleanup bool       `json:"-"`
 	Project               *string    `json:"project,omitempty"`

--- a/pkg/project/subversion_test.go
+++ b/pkg/project/subversion_test.go
@@ -143,10 +143,7 @@ func findSvnBinary() (string, bool) {
 	}
 
 	for _, loc := range locations {
-		cmd := exec.Command(loc, "--version")
-
-		err := cmd.Run()
-		if err != nil {
+		if err := exec.Command(loc, "--version").Run(); err != nil {
 			continue
 		}
 

--- a/pkg/project/testdata/git_real/file.go
+++ b/pkg/project/testdata/git_real/file.go
@@ -1,0 +1,13 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello, World!")
+
+	fmt.Println(sum(1, 2))
+}
+
+func sum(a, b int) int {
+	return a + b
+}

--- a/pkg/project/testdata/git_real/file_changed.go
+++ b/pkg/project/testdata/git_real/file_changed.go
@@ -1,0 +1,9 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello, World!")
+
+	fmt.Println("sum is fun")
+}


### PR DESCRIPTION
This PR adds a feature to count lines changed for a specific file if rev control is Git.

Steps to tests:

1. Build wakatime-cli with `make`
2. Change any file inside a git repository
3. Call `./build/wakatime-cli* --entity "/path/to/changed_file" --log-to-stdout --verbose`
4. It should print an array of heartbeats and the first element must contain `lines_added` and `lines_removed` fields
5. It should sync activity

Closes #609 