### PR TITLE
Build for Android arm using CGO and NDK

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -262,12 +262,19 @@ jobs:
           check-latest: ${{ env.CHECK_LATEST }}
           cache: false
       -
-        name: Build binaries
+        name: Build binary for arm
         env:
           VERSION: ${{ needs.version.outputs.semver_tag }}
         shell: bash
         # 2 is the number of virtual cpus for Linux. macOS is 3.
-        run: make -j2 build-all-android
+        run: make -j2 build-android-arm CC="{{ $ANDROID_NDK_LATEST_HOME }}/toolchains/llvm/prebuilt/linux-x86_64/bin/armv7a-linux-androideabi21-clang"
+      -
+        name: Build binary for arm64
+        env:
+          VERSION: ${{ needs.version.outputs.semver_tag }}
+        shell: bash
+        # 2 is the number of virtual cpus for Linux. macOS is 3.
+        run: make -j2 build-android-arm64
       -
         name: Upload artifacts
         uses: actions/upload-artifact@v2

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 # globals
 BINARY_NAME?=wakatime-cli
 BUILD_DIR?="./build"
+CGO_ENABLED?=0
 COMMIT?=$(shell git rev-parse --short HEAD)
 DATE?=$(shell date -u '+%Y-%m-%dT%H:%M:%S %Z')
 REPO=github.com/wakatime/wakatime-cli
@@ -41,8 +42,11 @@ build-all: build-all-android build-darwin build-freebsd build-linux build-netbsd
 
 build-all-android: build-android-arm build-android-arm64
 
+# to build for android arm, you need to have the android ndk installed, enable CGO and
+# set CC to the path of the android ndk toolchain
+# example: CC=/path/to/Android/sdk/ndk/26.0.10792818/toolchains/llvm/prebuilt/darwin-x86_64/bin/armv7a-linux-androideabi34-clang
 build-android-arm:
-	GOOS=android GOARCH=arm make build
+	GOOS=android GOARCH=arm CGO_ENABLED=1 make build
 
 build-android-arm64:
 	GOOS=android GOARCH=arm64 make build
@@ -121,13 +125,13 @@ build-windows-arm64:
 
 .PHONY: build
 build:
-	CGO_ENABLED="0" GOOS=$(GOOS) GOARCH=$(GOARCH) $(GOBUILD) -v \
+	CGO_ENABLED=$(CGO_ENABLED) GOOS=$(GOOS) GOARCH=$(GOARCH) $(GOBUILD) -v \
 		-ldflags "${LD_FLAGS} -X ${REPO}/pkg/version.OS=$(GOOS) -X ${REPO}/pkg/version.Arch=$(GOARCH)" \
 		-o ${BUILD_DIR}/$(BINARY_NAME)-$(GOOS)-$(GOARCH)
 
 .PHONY: build-windows
 build-windows:
-	CGO_ENABLED="0" GOOS=$(GOOS) GOARCH=$(GOARCH) $(GOBUILD) -v \
+	CGO_ENABLED=$(CGO_ENABLED) GOOS=$(GOOS) GOARCH=$(GOARCH) $(GOBUILD) -v \
 		-ldflags "${LD_FLAGS} -X ${REPO}/pkg/version.OS=$(GOOS) -X ${REPO}/pkg/version.Arch=$(GOARCH)" \
 		-o ${BUILD_DIR}/$(BINARY_NAME)-$(GOOS)-$(GOARCH).exe
 

--- a/bin/prepare_assets.sh
+++ b/bin/prepare_assets.sh
@@ -13,6 +13,8 @@ if [ "$(which zip)" = "" ]; then
 fi
 
 # add execution permission
+chmod 750 ./build/wakatime-cli-android-arm
+chmod 750 ./build/wakatime-cli-android-arm64
 chmod 750 ./build/wakatime-cli-freebsd-386
 chmod 750 ./build/wakatime-cli-freebsd-amd64
 chmod 750 ./build/wakatime-cli-freebsd-arm
@@ -33,6 +35,8 @@ chmod 750 ./build/wakatime-cli-windows-amd64.exe
 chmod 750 ./build/wakatime-cli-windows-arm64.exe
 
 # create archives
+zip -j ./release/wakatime-cli-android-arm.zip ./build/wakatime-cli-android-arm
+zip -j ./release/wakatime-cli-android-arm64.zip ./build/wakatime-cli-android-arm64
 zip -j ./release/wakatime-cli-freebsd-386.zip ./build/wakatime-cli-freebsd-386
 zip -j ./release/wakatime-cli-freebsd-amd64.zip ./build/wakatime-cli-freebsd-amd64
 zip -j ./release/wakatime-cli-freebsd-arm.zip ./build/wakatime-cli-freebsd-arm


### PR DESCRIPTION
To have Android built for ARM architecture is required to enable cross-compilation with CGO and NDK.