### PR TITLE
Collect cpu and memory metrics

### DIFF
--- a/cmd/logfile/logfile.go
+++ b/cmd/logfile/logfile.go
@@ -19,6 +19,7 @@ const (
 // Params contains log file parameters.
 type Params struct {
 	File              string
+	Metrics           bool
 	SendDiagsOnErrors bool
 	ToStdout          bool
 	Verbose           bool
@@ -27,6 +28,11 @@ type Params struct {
 // LoadParams loads needed data from the configuration file.
 func LoadParams(v *viper.Viper) (Params, error) {
 	params := Params{
+		Metrics: vipertools.FirstNonEmptyBool(
+			v,
+			"metrics",
+			"settings.metrics",
+		),
 		SendDiagsOnErrors: vipertools.FirstNonEmptyBool(
 			v,
 			"send-diagnostics-on-errors",
@@ -38,6 +44,11 @@ func LoadParams(v *viper.Viper) (Params, error) {
 			"verbose",
 			"settings.debug",
 		),
+	}
+
+	// if debug is disabled, disable metrics as well.
+	if !params.Verbose {
+		params.Metrics = false
 	}
 
 	logFile, ok := vipertools.FirstNonEmptyString(v, "log-file", "logfile", "settings.log_file")

--- a/cmd/logfile/logfile_test.go
+++ b/cmd/logfile/logfile_test.go
@@ -29,23 +29,25 @@ func TestLoadParams(t *testing.T) {
 	require.NoError(t, err)
 
 	tests := map[string]struct {
-		ViperLogFile       string
-		ViperLogFileConfig string
-		ViperLogFileOld    string
-		ViperToStdout      bool
 		EnvVar             string
 		ViperDebug         bool
 		ViperDebugConfig   bool
+		ViperLogFile       string
+		ViperLogFileConfig string
+		ViperLogFileOld    string
+		ViperMetrics       bool
+		ViperMetricsConfig bool
+		ViperToStdout      bool
 		Expected           logfile.Params
 	}{
-		"log file and verbose set": {
+		"verbose set": {
 			ViperDebug: true,
 			Expected: logfile.Params{
 				File:    filepath.Join(home, ".wakatime", "wakatime.log"),
 				Verbose: true,
 			},
 		},
-		"log file and verbose from config": {
+		"verbose from config": {
 			ViperDebugConfig: true,
 			Expected: logfile.Params{
 				File:    filepath.Join(home, ".wakatime", "wakatime.log"),
@@ -84,6 +86,22 @@ func TestLoadParams(t *testing.T) {
 				File: filepath.Join(home, ".wakatime", "wakatime.log"),
 			},
 		},
+		"metrics set and verbose false": {
+			ViperMetrics: true,
+			Expected: logfile.Params{
+				File:    filepath.Join(home, ".wakatime", "wakatime.log"),
+				Metrics: false,
+			},
+		},
+		"metrics set and verbose true": {
+			ViperDebug:   true,
+			ViperMetrics: true,
+			Expected: logfile.Params{
+				File:    filepath.Join(home, ".wakatime", "wakatime.log"),
+				Metrics: true,
+				Verbose: true,
+			},
+		},
 		"log to stdout": {
 			ViperToStdout: true,
 			Expected: logfile.Params{
@@ -99,6 +117,8 @@ func TestLoadParams(t *testing.T) {
 			v.Set("log-file", test.ViperLogFile)
 			v.Set("logfile", test.ViperLogFileOld)
 			v.Set("log-to-stdout", test.ViperToStdout)
+			v.Set("metrics", test.ViperMetrics)
+			v.Set("settings.metrics", test.ViperMetricsConfig)
 			v.Set("settings.log_file", test.ViperLogFileConfig)
 			v.Set("settings.debug", test.ViperDebug)
 			v.Set("verbose", test.ViperDebugConfig)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -160,6 +160,12 @@ func setFlags(cmd *cobra.Command, v *viper.Viper) {
 	flags.String("logfile", "", "(deprecated) Optional log file. Defaults to '~/.wakatime/wakatime.log'.")
 	flags.Bool("log-to-stdout", false, "If enabled, logs will go to stdout. Will overwrite logfile configs.")
 	flags.Bool(
+		"metrics",
+		false,
+		"When set and --verbose or debug enabled, collects metrics usage in '~/.wakatime/metrics' folder."+
+			" Defaults to false.",
+	)
+	flags.Bool(
 		"no-ssl-verify",
 		false,
 		"Disables SSL certificate verification for HTTPS requests. By default,"+

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -27,6 +27,7 @@ import (
 	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 	"github.com/wakatime/wakatime-cli/pkg/ini"
 	"github.com/wakatime/wakatime-cli/pkg/log"
+	"github.com/wakatime/wakatime-cli/pkg/metrics"
 	"github.com/wakatime/wakatime-cli/pkg/offline"
 	"github.com/wakatime/wakatime-cli/pkg/vipertools"
 	"github.com/wakatime/wakatime-cli/pkg/wakaerror"
@@ -68,10 +69,22 @@ func Run(cmd *cobra.Command, v *viper.Viper) {
 		log.Fatalf("failed to setup logging: %s", err)
 	}
 
+	shutdown := func() {}
+
+	// start profiling if enabled
+	if logFileParams.Metrics {
+		shutdown, err = metrics.StartProfiling()
+		if err != nil {
+			log.Errorf("failed to start profiling: %s", err)
+		}
+	}
+
 	if v.GetBool("user-agent") {
 		log.Debugln("command: user-agent")
 
 		fmt.Println(heartbeat.UserAgent(vipertools.GetString(v, "plugin")))
+
+		shutdown()
 
 		os.Exit(exitcode.Success)
 	}
@@ -79,61 +92,61 @@ func Run(cmd *cobra.Command, v *viper.Viper) {
 	if v.GetBool("version") {
 		log.Debugln("command: version")
 
-		RunCmd(v, logFileParams.Verbose, logFileParams.SendDiagsOnErrors, runVersion)
+		RunCmd(v, logFileParams.Verbose, logFileParams.SendDiagsOnErrors, runVersion, shutdown)
 	}
 
 	if v.IsSet("config-read") {
 		log.Debugln("command: config-read")
 
-		RunCmd(v, logFileParams.Verbose, logFileParams.SendDiagsOnErrors, configread.Run)
+		RunCmd(v, logFileParams.Verbose, logFileParams.SendDiagsOnErrors, configread.Run, shutdown)
 	}
 
 	if v.IsSet("config-write") {
 		log.Debugln("command: config-write")
 
-		RunCmd(v, logFileParams.Verbose, logFileParams.SendDiagsOnErrors, configwrite.Run)
+		RunCmd(v, logFileParams.Verbose, logFileParams.SendDiagsOnErrors, configwrite.Run, shutdown)
 	}
 
 	if v.GetBool("today") {
 		log.Debugln("command: today")
 
-		RunCmd(v, logFileParams.Verbose, logFileParams.SendDiagsOnErrors, today.Run)
+		RunCmd(v, logFileParams.Verbose, logFileParams.SendDiagsOnErrors, today.Run, shutdown)
 	}
 
 	if v.IsSet("today-goal") {
 		log.Debugln("command: today-goal")
 
-		RunCmd(v, logFileParams.Verbose, logFileParams.SendDiagsOnErrors, todaygoal.Run)
+		RunCmd(v, logFileParams.Verbose, logFileParams.SendDiagsOnErrors, todaygoal.Run, shutdown)
 	}
 
 	if v.GetBool("file-experts") {
 		log.Debugln("command: file-experts")
 
-		RunCmd(v, logFileParams.Verbose, logFileParams.SendDiagsOnErrors, fileexperts.Run)
+		RunCmd(v, logFileParams.Verbose, logFileParams.SendDiagsOnErrors, fileexperts.Run, shutdown)
 	}
 
 	if v.IsSet("entity") {
 		log.Debugln("command: heartbeat")
 
-		RunCmdWithOfflineSync(v, logFileParams.Verbose, logFileParams.SendDiagsOnErrors, cmdheartbeat.Run)
+		RunCmdWithOfflineSync(v, logFileParams.Verbose, logFileParams.SendDiagsOnErrors, cmdheartbeat.Run, shutdown)
 	}
 
 	if v.IsSet("sync-offline-activity") {
 		log.Debugln("command: sync-offline-activity")
 
-		RunCmd(v, logFileParams.Verbose, logFileParams.SendDiagsOnErrors, offlinesync.Run)
+		RunCmd(v, logFileParams.Verbose, logFileParams.SendDiagsOnErrors, offlinesync.Run, shutdown)
 	}
 
 	if v.GetBool("offline-count") {
 		log.Debugln("command: offline-count")
 
-		RunCmd(v, logFileParams.Verbose, logFileParams.SendDiagsOnErrors, offlinecount.Run)
+		RunCmd(v, logFileParams.Verbose, logFileParams.SendDiagsOnErrors, offlinecount.Run, shutdown)
 	}
 
 	if v.IsSet("print-offline-heartbeats") {
 		log.Debugln("command: print-offline-heartbeats")
 
-		RunCmd(v, logFileParams.Verbose, logFileParams.SendDiagsOnErrors, offlineprint.Run)
+		RunCmd(v, logFileParams.Verbose, logFileParams.SendDiagsOnErrors, offlineprint.Run, shutdown)
 	}
 
 	log.Warnf("one of the following parameters has to be provided: %s", strings.Join([]string{
@@ -238,13 +251,19 @@ func SetupLogging(v *viper.Viper) (*logfile.Params, error) {
 	return &logfileParams, nil
 }
 
-// cmdFn represents a command function.
-type cmdFn func(v *viper.Viper) (int, error)
+type (
+	// cmdFn represents a command function.
+	cmdFn func(v *viper.Viper) (int, error)
+	// shutdownFn represents a shutdown function. It will be called before exiting.
+	shutdownFn func()
+)
 
 // RunCmd runs a command function and exits with the exit code returned by
 // the command function. Will send diagnostic on any errors or panics.
-func RunCmd(v *viper.Viper, verbose bool, sendDiagsOnErrors bool, cmd cmdFn) {
+func RunCmd(v *viper.Viper, verbose bool, sendDiagsOnErrors bool, cmd cmdFn, shutdown shutdownFn) {
 	exitCode := runCmd(v, verbose, sendDiagsOnErrors, cmd)
+
+	shutdown()
 
 	os.Exit(exitCode)
 }
@@ -252,13 +271,17 @@ func RunCmd(v *viper.Viper, verbose bool, sendDiagsOnErrors bool, cmd cmdFn) {
 // RunCmdWithOfflineSync runs a command function and exits with the exit code
 // returned by the command function. If command run was successful, it will execute
 // offline sync command afterwards. Will send diagnostic on any errors or panics.
-func RunCmdWithOfflineSync(v *viper.Viper, verbose bool, sendDiagsOnErrors bool, cmd cmdFn) {
+func RunCmdWithOfflineSync(v *viper.Viper, verbose bool, sendDiagsOnErrors bool, cmd cmdFn, shutdown shutdownFn) {
 	exitCode := runCmd(v, verbose, sendDiagsOnErrors, cmd)
 	if exitCode != exitcode.Success {
+		shutdown()
+
 		os.Exit(exitCode)
 	}
 
 	exitCode = runCmd(v, verbose, sendDiagsOnErrors, offlinesync.Run)
+
+	shutdown()
 
 	os.Exit(exitCode)
 }
@@ -267,7 +290,7 @@ func RunCmdWithOfflineSync(v *viper.Viper, verbose bool, sendDiagsOnErrors bool,
 // It will send diagnostic on any errors or panics.
 // On panic, it will send diagnostic and exit with ErrGeneric exit code.
 // On error, it will only send diagnostic if sendDiagsOnErrors and verbose is true.
-func runCmd(v *viper.Viper, verbose bool, sendDiagsOnErrors bool, cmd cmdFn) int {
+func runCmd(v *viper.Viper, verbose bool, sendDiagsOnErrors bool, cmd cmdFn) (exitCode int) {
 	logs := bytes.NewBuffer(nil)
 	resetLogs := captureLogs(logs)
 
@@ -292,12 +315,14 @@ func runCmd(v *viper.Viper, verbose bool, sendDiagsOnErrors bool, cmd cmdFn) int
 				log.Warnf("failed to send diagnostics: %s", err)
 			}
 
-			os.Exit(exitcode.ErrGeneric)
+			exitCode = exitcode.ErrGeneric
 		}
 	}()
 
+	var err error
+
 	// run command
-	exitCode, err := cmd(v)
+	exitCode, err = cmd(v)
 	// nolint:nestif
 	if err != nil {
 		if errwaka, ok := err.(wakaerror.Error); ok {

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,7 @@
+comment: # this is a top-level key
+  layout: "diff, flags, files"
+  behavior: new
+  require_changes: false # if true: only post the comment if coverage changes
+  require_base: false # [true :: must have a base report to post]
+  require_head: true  # [true :: must have a head report to post]
+  hide_project_coverage: false # [true :: only show coverage on the git diff]

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,59 @@
+package metrics
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime/pprof"
+	"strconv"
+	"time"
+
+	"github.com/wakatime/wakatime-cli/pkg/ini"
+	"github.com/wakatime/wakatime-cli/pkg/log"
+)
+
+// StartProfiling starts profiling cpu and memory. It returns a function that
+// should be called to stop profiling and close the files.
+func StartProfiling() (func(), error) {
+	folder, err := ini.WakaResourcesDir()
+	if err != nil {
+		return nil, fmt.Errorf("failed getting user's home directory: %s", err)
+	}
+
+	metricsFolder := filepath.Join(folder, "metrics")
+	if err := os.MkdirAll(metricsFolder, 0750); err != nil {
+		return nil, fmt.Errorf("failed to create metrics folder: %s", err)
+	}
+
+	now := strconv.FormatInt(time.Now().UTC().UnixNano(), 10)
+
+	cpuf, err := os.Create(filepath.Join(metricsFolder, fmt.Sprintf("cpu_%s.profile", now))) // nolint:gosec
+	if err != nil {
+		return nil, fmt.Errorf("failed to create cpu profile file: %s", err)
+	}
+
+	if err := pprof.StartCPUProfile(cpuf); err != nil {
+		log.Errorf("failed to start cpu profile: %s", err)
+	}
+
+	memf, err := os.Create(filepath.Join(metricsFolder, fmt.Sprintf("mem_%s.profile", now))) // nolint:gosec
+	if err != nil {
+		return nil, fmt.Errorf("failed to create mem profile file: %s", err)
+	}
+
+	if err := pprof.WriteHeapProfile(memf); err != nil {
+		log.Errorf("failed to write heap profile: %s", err)
+	}
+
+	return func() {
+		pprof.StopCPUProfile()
+
+		if err := cpuf.Close(); err != nil {
+			log.Errorf("failed to close cpu profile file: %s", err)
+		}
+
+		if err := memf.Close(); err != nil {
+			log.Errorf("failed to close mem profile file: %s", err)
+		}
+	}, nil
+}


### PR DESCRIPTION
This PR adds new flag `--metrics` when enabled will start profiling cpu and memory to `~/.wakatime/metrics` folder. It uses the standard library to collect both metrics and save them to separate files. These files can be transformed into png images by simply calling `go tool pprof -png <file.profile>`.

Ref #954