### PR TITLE
Log if proxy defined when unable to send heartbeats

### DIFF
--- a/cmd/heartbeat/heartbeat.go
+++ b/cmd/heartbeat/heartbeat.go
@@ -108,9 +108,10 @@ func SendHeartbeats(v *viper.Viper, queueFilepath string) error {
 	}
 
 	handleOpts = append(handleOpts, backoff.WithBackoff(backoff.Config{
-		V:       v,
-		At:      params.API.BackoffAt,
-		Retries: params.API.BackoffRetries,
+		V:        v,
+		At:       params.API.BackoffAt,
+		Retries:  params.API.BackoffRetries,
+		HasProxy: params.API.ProxyURL != "",
 	}))
 
 	apiClient, err := apicmd.NewClientWithoutAuth(params.API)

--- a/pkg/backoff/backoff.go
+++ b/pkg/backoff/backoff.go
@@ -30,6 +30,8 @@ type Config struct {
 	Retries int
 	// V is an instance of Viper.
 	V *viper.Viper
+	// HasProxy is true when using a proxy
+	HasProxy bool
 }
 
 // WithBackoff initializes and returns a heartbeat handle option, which
@@ -42,7 +44,11 @@ func WithBackoff(config Config) heartbeat.HandleOption {
 
 			should, reset := shouldBackoff(config.Retries, config.At)
 			if should {
-				return nil, api.ErrBackoff{Err: errors.New("won't send heartbeat due to backoff")}
+				if config.HasProxy {
+					return nil, api.ErrBackoff{Err: errors.New("won't send heartbeat due to backoff with proxy")}
+				}
+
+				return nil, api.ErrBackoff{Err: errors.New("won't send heartbeat due to backoff without proxy")}
 			}
 
 			if reset {

--- a/pkg/backoff/backoff_test.go
+++ b/pkg/backoff/backoff_test.go
@@ -59,7 +59,30 @@ func TestWithBackoff_BeforeNextBackoff(t *testing.T) {
 	_, err := handle([]heartbeat.Heartbeat{})
 	require.Error(t, err)
 
-	assert.Equal(t, "won't send heartbeat due to backoff", err.Error())
+	assert.Equal(t, "won't send heartbeat due to backoff without proxy", err.Error())
+}
+
+func TestWithBackoff_BeforeNextBackoffWithProxy(t *testing.T) {
+	backoffAt := time.Now().Add(time.Second * -1)
+
+	opt := backoff.WithBackoff(backoff.Config{
+		At:       backoffAt,
+		Retries:  1,
+		HasProxy: true,
+	})
+
+	handle := opt(func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+		return []heartbeat.Result{
+			{
+				Status: 201,
+			},
+		}, nil
+	})
+
+	_, err := handle([]heartbeat.Heartbeat{})
+	require.Error(t, err)
+
+	assert.Equal(t, "won't send heartbeat due to backoff with proxy", err.Error())
 }
 
 func TestWithBackoff_ApiError(t *testing.T) {


### PR DESCRIPTION
To help debug connection issues from logs without debug mode enabled. (https://github.com/wakatime/vscode-wakatime/issues/271#issuecomment-1774358797)