### PR TITLE
Disable guessing language from file contents

### DIFF
--- a/cmd/heartbeat/heartbeat.go
+++ b/cmd/heartbeat/heartbeat.go
@@ -241,7 +241,9 @@ func initHandleOptions(params paramscmd.Params) []heartbeat.HandleOption {
 			MapPatterns:   params.API.KeyPatterns,
 		}),
 		filestats.WithDetection(),
-		language.WithDetection(),
+		language.WithDetection(language.Config{
+			GuessLanguage: params.Heartbeat.GuessLanguage,
+		}),
 		deps.WithDetection(deps.Config{
 			FilePatterns: params.Heartbeat.Sanitize.HideFileNames,
 		}),

--- a/cmd/offline/offline.go
+++ b/cmd/offline/offline.go
@@ -142,7 +142,9 @@ func initHandleOptions(params paramscmd.Params) []heartbeat.HandleOption {
 		}),
 		remote.WithDetection(),
 		filestats.WithDetection(),
-		language.WithDetection(),
+		language.WithDetection(language.Config{
+			GuessLanguage: params.Heartbeat.GuessLanguage,
+		}),
 		deps.WithDetection(deps.Config{
 			FilePatterns: params.Heartbeat.Sanitize.HideFileNames,
 		}),

--- a/cmd/params/params.go
+++ b/cmd/params/params.go
@@ -100,6 +100,7 @@ type (
 		Entity            string
 		EntityType        heartbeat.EntityType
 		ExtraHeartbeats   []heartbeat.Heartbeat
+		GuessLanguage     bool
 		IsUnsavedEntity   bool
 		IsWrite           *bool
 		Language          *string
@@ -410,6 +411,7 @@ func LoadHeartbeatParams(v *viper.Viper) (Heartbeat, error) {
 		Entity:            entityExpanded,
 		ExtraHeartbeats:   extraHeartbeats,
 		EntityType:        entityType,
+		GuessLanguage:     vipertools.FirstNonEmptyBool(v, "guess-language", "settings.guess_language"),
 		IsUnsavedEntity:   v.GetBool("is-unsaved-entity"),
 		IsWrite:           isWrite,
 		Language:          language,
@@ -966,14 +968,15 @@ func (p Heartbeat) String() string {
 
 	return fmt.Sprintf(
 		"category: '%s', cursor position: '%s', entity: '%s', entity type: '%s',"+
-			" num extra heartbeats: %d, is unsaved entity: %t, is write: %t,"+
-			" language: '%s', line number: '%s', lines in file: '%s', time: %.5f,"+
-			" filter params: (%s), project params: (%s), sanitize params: (%s)",
+			" num extra heartbeats: %d, guess_language: %t, is unsaved entity: %t,"+
+			" is write: %t, language: '%s', line number: '%s', lines in file: '%s',"+
+			" time: %.5f, filter params: (%s), project params: (%s), sanitize params: (%s)",
 		p.Category,
 		cursorPosition,
 		p.Entity,
 		p.EntityType,
 		len(p.ExtraHeartbeats),
+		p.GuessLanguage,
 		p.IsUnsavedEntity,
 		isWrite,
 		language,

--- a/cmd/params/params_test.go
+++ b/cmd/params/params_test.go
@@ -2310,11 +2310,12 @@ func TestHeartbeat_String(t *testing.T) {
 	assert.Equal(
 		t,
 		"category: 'coding', cursor position: '15', entity: 'path/to/entity.go', entity type: 'file',"+
-			" num extra heartbeats: 3, is unsaved entity: true, is write: true, language: 'Golang', line number: '4',"+
-			" lines in file: '56', time: 1585598059.00000, filter params: (exclude: '[]', exclude unknown project: false,"+
-			" include: '[]', include only with project file: false), project params: (alternate: '', branch alternate: '',"+
-			" map patterns: '[]', override: '', git submodules disabled: '[]', git submodule project map: '[]'),"+
-			" sanitize params: (hide branch names: '[]', hide project folder: false, hide file names: '[]',"+
+			" num extra heartbeats: 3, guess_language: false, is unsaved entity: true, is write: true,"+
+			" language: 'Golang', line number: '4', lines in file: '56', time: 1585598059.00000, filter"+
+			" params: (exclude: '[]', exclude unknown project: false, include: '[]', include only with"+
+			" project file: false), project params: (alternate: '', branch alternate: '', map patterns:"+
+			" '[]', override: '', git submodules disabled: '[]', git submodule project map: '[]'), sanitize"+
+			" params: (hide branch names: '[]', hide project folder: false, hide file names: '[]',"+
 			" hide project names: '[]', project path override: '')",
 		heartbeat.String(),
 	)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -105,6 +105,10 @@ func setFlags(cmd *cobra.Command, v *viper.Viper) {
 		"(deprecated) Absolute path to file for the heartbeat."+
 			" Can also be a url, domain or app when --entity-type is not file.")
 	flags.Bool("file-experts", false, "Prints the top developer within a team for the given entity, then exits.")
+	flags.Bool(
+		"guess-language",
+		false,
+		"Enable detecting language from file contents.")
 	flags.String("hide-branch-names", "", "Obfuscate branch names. Will not send revision control branch names to api.")
 	flags.String("hide-file-names", "", "Obfuscate filenames. Will not send file names to api.")
 	flags.String("hide-filenames", "", "(deprecated) Obfuscate filenames. Will not send file names to api.")

--- a/pkg/language/chroma.go
+++ b/pkg/language/chroma.go
@@ -22,7 +22,7 @@ const maxFileSize = 512000
 // detectChromaCustomized returns the best by filename matching lexer. Best lexer is determined
 // by customized priority.
 // This is a modified implementation of chroma.lexers.internal.api:Match().
-func detectChromaCustomized(filepath string) (heartbeat.Language, float32, bool) {
+func detectChromaCustomized(filepath string, guessLanguage bool) (heartbeat.Language, float32, bool) {
 	_, file := fp.Split(filepath)
 	filename := fp.Base(file)
 	matched := chroma.PrioritisedLexers{}
@@ -69,6 +69,10 @@ func detectChromaCustomized(filepath string) (heartbeat.Language, float32, bool)
 		}
 
 		return language, weight, true
+	}
+
+	if !guessLanguage {
+		return heartbeat.LanguageUnknown, 0, false
 	}
 
 	// Finally, try matching by file content.

--- a/pkg/language/language_test.go
+++ b/pkg/language/language_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestWithDetection(t *testing.T) {
-	opt := language.WithDetection()
+	opt := language.WithDetection(language.Config{})
 
 	h := opt(func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
 		assert.Len(t, hh, 1)
@@ -49,7 +49,7 @@ func TestWithDetection(t *testing.T) {
 }
 
 func TestWithDetection_Override(t *testing.T) {
-	opt := language.WithDetection()
+	opt := language.WithDetection(language.Config{})
 
 	h := opt(func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
 		assert.Len(t, hh, 1)
@@ -86,7 +86,7 @@ func TestWithDetection_Override(t *testing.T) {
 }
 
 func TestWithDetection_NonExistingEntity_Override(t *testing.T) {
-	opt := language.WithDetection()
+	opt := language.WithDetection(language.Config{})
 
 	h := opt(func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
 		assert.Len(t, hh, 1)
@@ -124,7 +124,7 @@ func TestWithDetection_NonExistingEntity_Override(t *testing.T) {
 }
 
 func TestWithDetection_Alternate(t *testing.T) {
-	opt := language.WithDetection()
+	opt := language.WithDetection(language.Config{})
 
 	h := opt(func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
 		assert.Len(t, hh, 1)
@@ -161,96 +161,96 @@ func TestWithDetection_Alternate(t *testing.T) {
 }
 
 func TestDetect_HeaderFile_Corresponding_C_File(t *testing.T) {
-	lang, err := language.Detect("testdata/codefiles/h_with_c_file/empty.h")
+	lang, err := language.Detect("testdata/codefiles/h_with_c_file/empty.h", false)
 	require.NoError(t, err)
 	assert.Equal(t, heartbeat.LanguageC, lang)
 }
 
 func TestDetect_HeaderFile_With_C_Files(t *testing.T) {
-	lang, err := language.Detect("testdata/codefiles/h_with_any_c_file/empty.h")
+	lang, err := language.Detect("testdata/codefiles/h_with_any_c_file/empty.h", false)
 	require.NoError(t, err)
 	assert.Equal(t, heartbeat.LanguageC, lang)
 }
 
 func TestDetect_HeaderFile_With_C_And_CPP_Files(t *testing.T) {
-	lang, err := language.Detect("testdata/codefiles/h_with_any_c_and_cpp_files/cpp.h")
+	lang, err := language.Detect("testdata/codefiles/h_with_any_c_and_cpp_files/cpp.h", false)
 	require.NoError(t, err)
 
 	assert.Equal(t, heartbeat.LanguageCPP, lang)
 }
 
 func TestDetect_HeaderFile_With_C_And_CXX_Files(t *testing.T) {
-	lang, err := language.Detect("testdata/codefiles/h_with_any_c_and_cxx_files/cpp.h")
+	lang, err := language.Detect("testdata/codefiles/h_with_any_c_and_cxx_files/cpp.h", false)
 	require.NoError(t, err)
 
 	assert.Equal(t, heartbeat.LanguageCPP, lang)
 }
 
 func TestDetect_ObjectiveC_Over_Matlab_MatchingHeader(t *testing.T) {
-	lang, err := language.Detect("testdata/codefiles/with_mat_file/objective-c.m")
+	lang, err := language.Detect("testdata/codefiles/with_mat_file/objective-c.m", false)
 	require.NoError(t, err)
 
 	assert.Equal(t, heartbeat.LanguageObjectiveC, lang)
 }
 
 func TestDetect_ObjectiveC_M_FileInFolder(t *testing.T) {
-	lang, err := language.Detect("testdata/codefiles/with_mat_file/objective-c.h")
+	lang, err := language.Detect("testdata/codefiles/with_mat_file/objective-c.h", false)
 	require.NoError(t, err)
 
 	assert.Equal(t, heartbeat.LanguageObjectiveC, lang)
 }
 
 func TestDetect_ObjectiveCPP_MatchingHeader(t *testing.T) {
-	lang, err := language.Detect("testdata/codefiles/with_mat_file/objective-cpp.mm")
+	lang, err := language.Detect("testdata/codefiles/with_mat_file/objective-cpp.mm", false)
 	require.NoError(t, err)
 
 	assert.Equal(t, heartbeat.LanguageObjectiveCPP, lang)
 }
 
 func TestDetect_ObjectiveCPP_MM_FileInFolder(t *testing.T) {
-	lang, err := language.Detect("testdata/codefiles/with_mat_file/objective-cpp.h")
+	lang, err := language.Detect("testdata/codefiles/with_mat_file/objective-cpp.h", false)
 	require.NoError(t, err)
 
 	assert.Equal(t, heartbeat.LanguageObjectiveCPP, lang)
 }
 
 func TestDetect_ObjectiveC(t *testing.T) {
-	lang, err := language.Detect("testdata/codefiles/objective-c.m")
+	lang, err := language.Detect("testdata/codefiles/objective-c.m", false)
 	require.NoError(t, err)
 
 	assert.Equal(t, heartbeat.LanguageObjectiveC, lang)
 }
 
 func TestDetect_Matlab_Over_ObjectiveC_Mat_FileInFolder(t *testing.T) {
-	lang, err := language.Detect("testdata/codefiles/with_mat_file/empty.m")
+	lang, err := language.Detect("testdata/codefiles/with_mat_file/empty.m", false)
 	require.NoError(t, err)
 
 	assert.Equal(t, heartbeat.LanguageMatlab, lang)
 }
 
 func TestDetect_ObjectiveC_Over_Matlab_NonMatchingHeader(t *testing.T) {
-	lang, err := language.Detect("testdata/codefiles/matlab_with_headers/empty.m")
+	lang, err := language.Detect("testdata/codefiles/matlab_with_headers/empty.m", false)
 	require.NoError(t, err)
 
 	assert.Equal(t, heartbeat.LanguageObjectiveC, lang)
 }
 
 func TestDetect_NonHeaderFile_C_FilesInFolder(t *testing.T) {
-	lang, err := language.Detect("testdata/codefiles/py_with_c_files/see.py")
+	lang, err := language.Detect("testdata/codefiles/py_with_c_files/see.py", false)
 	require.NoError(t, err)
 
 	assert.Equal(t, heartbeat.LanguagePython, lang)
 }
 
 func TestDetect_Perl_Over_Prolog(t *testing.T) {
-	lang, err := language.Detect("testdata/codefiles/perl.pl")
+	lang, err := language.Detect("testdata/codefiles/perl.pl", false)
 	require.NoError(t, err)
 
 	assert.Equal(t, heartbeat.LanguagePerl, lang)
 }
 
 func TestDetect_FSharp_Over_Forth(t *testing.T) {
-	lang, err := language.Detect("testdata/codefiles/fsharp.fs")
+	lang, err := language.Detect("testdata/codefiles/fsharp.fs", false)
 	require.NoError(t, err)
 
 	assert.Equal(t, heartbeat.LanguageFSharp, lang)
@@ -261,8 +261,9 @@ func TestDetect_ChromaTopLanguagesRetrofit(t *testing.T) {
 	require.NoError(t, err)
 
 	tests := map[string]struct {
-		Filepaths []string
-		Expected  heartbeat.Language
+		Filepaths     []string
+		GuessLanguage bool
+		Expected      heartbeat.Language
 	}{
 		"apache config": {
 			Filepaths: []string{
@@ -309,9 +310,15 @@ func TestDetect_ChromaTopLanguagesRetrofit(t *testing.T) {
 				"path/to/zshrc",
 				"path/to/.zshrc",
 				"path/to/PKGBUILD",
-				"testdata/bash",
 			},
 			Expected: heartbeat.LanguageBash,
+		},
+		"bash from file contents": {
+			Filepaths: []string{
+				"testdata/bash",
+			},
+			GuessLanguage: true,
+			Expected:      heartbeat.LanguageBash,
 		},
 		"c": {
 			Filepaths: []string{"path/to/file.c"},
@@ -592,9 +599,15 @@ func TestDetect_ChromaTopLanguagesRetrofit(t *testing.T) {
 		"perl not prolog": {
 			Filepaths: []string{
 				"testdata/codefiles/chroma_unsupported_top/perl.pl",
-				"testdata/perl",
 			},
 			Expected: heartbeat.LanguagePerl,
+		},
+		"perl not prolog from file contents": {
+			Filepaths: []string{
+				"testdata/perl",
+			},
+			GuessLanguage: true,
+			Expected:      heartbeat.LanguagePerl,
 		},
 		"php": {
 			Filepaths: []string{
@@ -662,9 +675,15 @@ func TestDetect_ChromaTopLanguagesRetrofit(t *testing.T) {
 				"path/to/BUILD.bazel",
 				"path/to/WORKSPACE",
 				"path/to/file.tac",
-				"testdata/python3",
 			},
 			Expected: heartbeat.LanguagePython,
+		},
+		"python from file contents": {
+			Filepaths: []string{
+				"testdata/python3",
+			},
+			GuessLanguage: true,
+			Expected:      heartbeat.LanguagePython,
 		},
 		"qml": {
 			Filepaths: []string{
@@ -889,7 +908,7 @@ func TestDetect_ChromaTopLanguagesRetrofit(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			for _, filepath := range test.Filepaths {
-				lang, err := language.Detect(filepath)
+				lang, err := language.Detect(filepath, test.GuessLanguage)
 				require.NoError(t, err)
 
 				assert.Equal(t, test.Expected, lang, fmt.Sprintf("Got: %q, want: %q", lang, test.Expected))


### PR DESCRIPTION
Disables language detection from file contents added in #910, unless enabled with `--guess-language` or `settings.guess_language` INI config set to `true`.