### PR TITLE
Enable metrics without debug being enabled

### DIFF
--- a/cmd/logfile/logfile.go
+++ b/cmd/logfile/logfile.go
@@ -46,11 +46,6 @@ func LoadParams(v *viper.Viper) (Params, error) {
 		),
 	}
 
-	// if debug is disabled, disable metrics as well.
-	if !params.Verbose {
-		params.Metrics = false
-	}
-
 	logFile, ok := vipertools.FirstNonEmptyString(v, "log-file", "logfile", "settings.log_file")
 	if ok {
 		p, err := homedir.Expand(logFile)

--- a/cmd/logfile/logfile_test.go
+++ b/cmd/logfile/logfile_test.go
@@ -86,20 +86,26 @@ func TestLoadParams(t *testing.T) {
 				File: filepath.Join(home, ".wakatime", "wakatime.log"),
 			},
 		},
-		"metrics set and verbose false": {
-			ViperMetrics: true,
-			Expected: logfile.Params{
-				File:    filepath.Join(home, ".wakatime", "wakatime.log"),
-				Metrics: false,
-			},
-		},
-		"metrics set and verbose true": {
-			ViperDebug:   true,
+		"metrics set": {
 			ViperMetrics: true,
 			Expected: logfile.Params{
 				File:    filepath.Join(home, ".wakatime", "wakatime.log"),
 				Metrics: true,
-				Verbose: true,
+			},
+		},
+		"metrics from config": {
+			ViperMetricsConfig: true,
+			Expected: logfile.Params{
+				File:    filepath.Join(home, ".wakatime", "wakatime.log"),
+				Metrics: true,
+			},
+		},
+		"metrics flag takes precedence": {
+			ViperMetrics:       true,
+			ViperMetricsConfig: false,
+			Expected: logfile.Params{
+				File:    filepath.Join(home, ".wakatime", "wakatime.log"),
+				Metrics: true,
 			},
 		},
 		"log to stdout": {


### PR DESCRIPTION
This PR makes `--metrics` flag not related to `--debug`.