### PR TITLE
Fix release script by removing double quotes from input

### DIFF
--- a/bin/prepare_changelog.sh
+++ b/bin/prepare_changelog.sh
@@ -8,8 +8,8 @@ if [[ $# -ne 2 ]]; then
 fi
 
 # Read arguments
-branch=$1
-changelog=$2
+branch=$(echo $1 | tr -d \")
+changelog=$(echo $2 | tr -d \")
 slack=
 
 clean_up() {
@@ -61,7 +61,7 @@ parse_for_release() {
 }
 
 case $branch in
-    develop) 
+    develop)
         parse_for_develop
         clean_up
         slack_output_for_develop


### PR DESCRIPTION
Prepare changelog step failed:

```
Run changelog="## Changelog
  changelog="## Changelog
  
  be4bb75 Disable guessing language from file contents
  8ee0359 Revert "Make lexers auto-register themselves""
  ./bin/prepare_changelog.sh $(echo ${GITHUB_REF#refs/heads/}) "$changelog"
  shell: /usr/bin/bash -e {0}
  env:
    GO_VERSION_FILE: go.mod
    CHECK_LATEST: true
    TEST_VERSION: <local-build>
/home/runner/work/_temp/f7c5699d-bc65-4189-93dc-5e531a74830f.sh: line 4: lexers: command not found
Error: Process completed with exit code 1[2](https://github.com/wakatime/wakatime-cli/actions/runs/6623527591/job/17991021550#step:6:2)[7](https://github.com/wakatime/wakatime-cli/actions/runs/6623527591/job/17991021550#step:6:7).
```