### PR TITLE
Fix retry after being rate limited from working offline

### DIFF
--- a/cmd/heartbeat/heartbeat_test.go
+++ b/cmd/heartbeat/heartbeat_test.go
@@ -880,7 +880,7 @@ func TestSendHeartbeats_ErrBackoff_Verbose(t *testing.T) {
 	output, err := io.ReadAll(logFile)
 	require.NoError(t, err)
 
-	assert.Contains(t, string(output), "will retry at")
+	assert.Contains(t, string(output), "will retry again after")
 }
 
 func TestSendHeartbeats_ObfuscateProject(t *testing.T) {

--- a/pkg/backoff/backoff.go
+++ b/pkg/backoff/backoff.go
@@ -95,8 +95,12 @@ func shouldBackoff(retries int, at time.Time) bool {
 		return false
 	}
 
+	if at.Add(duration).Before(time.Now()) {
+		return false
+	}
+
 	log.Debugf(
-		"exponential backoff tried %d times since %s, will retry at %s",
+		"exponential backoff tried %d times since %s, will retry again after %s",
 		retries,
 		at.Format(ini.DateFormat),
 		time.Now().Add(duration).Format(ini.DateFormat),


### PR DESCRIPTION
Fixes a bug introduced in #970 where we no longer checked if we should retry sending code stats:

https://github.com/wakatime/wakatime-cli/pull/970/files?w=1#diff-79a88defe50a288b2faa59643133a7bad2469192119474478dd4f643cffda01aL110