### PR TITLE
Add Apple Team ID for release notarization

### DIFF
--- a/gon.hcl
+++ b/gon.hcl
@@ -4,6 +4,7 @@ bundle_id = "com.wakatime.wakatime-cli"
 apple_id {
   username = "alan@wakatime.com"
   password = "@env:AC_PASSWORD"
+  provider = "538RQNWSWT"
 }
 
 sign {


### PR DESCRIPTION
Fixes error:

`Error: Team ID must be at least 3 characters`