### PR TITLE
No longer staple because not a dmg

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,15 +1,12 @@
 ---
-name: 🐛 Bug report
+name: Bug report
 about: Report a bug to help us improve WakaTime CLI
-labels: kind/bug
+title: ''
+labels: bug
+assignees: ''
 ---
-<!--
-Please fill out the template below to report a bug.
--->
 
-**Expected behavior (what should have happened)**:
-
-**Actual behavior (what went wrong)**:
+<!-- Describe the bug here. -->
 
 **Environment**:
 
@@ -20,4 +17,10 @@ Please fill out the template below to report a bug.
 
 <!--
 Paste related logs from your ~/.wakatime/wakatime.log file.
+If there's no error message, enable debug mode and reproduce the bug to trigger an error message.
+
+Don't post backoff error messages.
+If your error message contains "won't send heartbeat due to backoff", delete your `~/.wakatime/wakatime-internal.cfg` file to trigger an API connection so we can see the real error message.
+
+More info: https://github.com/wakatime/wakatime-cli/blob/develop/TROUBLESHOOTING.md
 -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,9 +1,0 @@
-blank_issues_enabled: false
-contact_links:
-  - name: ❓ Ask a question
-    url: https://github.com/wakatime/wakatime-cli/discussions/new?category=q-a
-    about: Ask and discuss questions with other WakaTime community members
-
-  - name: 💬 Slack channel
-    url: https://wakaslack.herokuapp.com
-    about: Please ask and answer questions here

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,21 +1,10 @@
 ---
-name: 🚀 Feature request
-about: Suggest an idea for WakaTime
-labels: to discuss
+name: Feature request
+about: Suggest an idea
+title: ''
+labels: feature request
+assignees: ''
+
 ---
-<!--
- Thank you for sending a feature request!
- Please describe what you would like to change/add and why in detail by filling out the template below.
- -->
 
-**Is your feature request related to a problem? Please describe.**
-<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
 
-**Describe the solution you'd like to see**
-<!-- A clear and concise description of what would you like to happen. -->
-
-**Describe alternatives you've considered**
-<!-- A clear and concise description of any alternative solutions or features you've considered. -->
-
-**Additional context**
-<!-- Add any other context or screenshots about the feature request here. -->

--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -577,13 +577,13 @@ jobs:
       -
         name: Notarize amd64
         run: |
-          xcrun notarytool submit ./build/wakatime-cli-darwin-amd64 --keychain-profile "notarytool-profile" --wait
-          xcrun stapler staple ./build/wakatime-cli-darwin-amd64
+          ditto -c -k --keepParent ./build/wakatime-cli-darwin-amd64 ./wakatime-cli-darwin-amd64.zip
+          xcrun notarytool submit ./wakatime-cli-darwin-amd64.zip --keychain-profile "notarytool-profile" --wait
       -
         name: Notarize arm64
         run: |
-          xcrun notarytool submit ./build/wakatime-cli-darwin-arm64 --keychain-profile "notarytool-profile" --wait
-          xcrun stapler staple ./build/wakatime-cli-darwin-arm64
+          ditto -c -k --keepParent ./build/wakatime-cli-darwin-arm64 ./wakatime-cli-darwin-arm64.zip
+          xcrun notarytool submit ./wakatime-cli-darwin-arm64.zip --keychain-profile "notarytool-profile" --wait
       -
         name: Upload artifacts
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
Can only staple dmg and apps, but wakatime-cli is a binary. We weren't stapling before with gon, so removing it here.