### PR TITLE
Added .fmx and .dfm files to the supported Delphi filenames

### DIFF
--- a/pkg/lexer/delphi.go
+++ b/pkg/lexer/delphi.go
@@ -15,7 +15,7 @@ func (l Delphi) Lexer() chroma.Lexer {
 		&chroma.Config{
 			Name:      l.Name(),
 			Aliases:   []string{"delphi", "pas", "pascal", "objectpascal"},
-			Filenames: []string{"*.pas", "*.dpr"},
+			Filenames: []string{"*.pas", "*.dpr", "*.fmx", "*.dfm"},
 			MimeTypes: []string{"text/x-pascal"},
 		},
 		func() chroma.Rules {


### PR DESCRIPTION
I realized that working on `.fmx` and `.dfm` files show as "Other" instead of "Delphi":

![WakaTime](https://github.com/wakatime/wakatime-cli/assets/5418178/4c60d6ef-9dd0-4bed-a98f-1ddcc08b5c60)

So this PR adds support for `.fmx` and `.dfm` files for the Delphi Programming Language
