### PR TITLE
Support loading api key from env var

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -131,6 +131,12 @@ projects/foo = your-api-key
 ^/home/user/projects/bar(\d+)/ = your-api-key
 ```
 
+### Api Key Environment Variable
+
+If a `WAKATIME_API_KEY` env var exists, wakatime-cli will use it’s value as the api key.
+This means you don’t need a `~/.wakatime.cfg` file, or you can omit or leave empty the `api_key` setting in your config file if using the env var.
+However, if an api key exists in your `~/.wakatime.cfg` file then it takes precedence over the env var.
+
 ### Git Section
 
 | option                         | description | type | default value |

--- a/cmd/logfile/logfile.go
+++ b/cmd/logfile/logfile.go
@@ -46,8 +46,8 @@ func LoadParams(v *viper.Viper) (Params, error) {
 		),
 	}
 
-	logFile, ok := vipertools.FirstNonEmptyString(v, "log-file", "logfile", "settings.log_file")
-	if ok {
+	logFile := vipertools.FirstNonEmptyString(v, "log-file", "logfile", "settings.log_file")
+	if logFile != "" {
 		p, err := homedir.Expand(logFile)
 		if err != nil {
 			return Params{}, fmt.Errorf("failed expanding log file: %s", err)

--- a/pkg/vipertools/vipertools.go
+++ b/pkg/vipertools/vipertools.go
@@ -40,20 +40,19 @@ func FirstNonEmptyInt(v *viper.Viper, keys ...string) (int, bool) {
 }
 
 // FirstNonEmptyString accepts multiple keys and returns the first non empty string value
-// from viper.Viper via these keys. Non-empty meaning "" value will not be accepted.
-// Will return false as second parameter, if non-empty string value could not be retrieved.
-func FirstNonEmptyString(v *viper.Viper, keys ...string) (string, bool) {
+// from viper.Viper via these keys. Returns empty string by default if a value couldn't be found.
+func FirstNonEmptyString(v *viper.Viper, keys ...string) string {
 	if v == nil {
-		return "", false
+		return ""
 	}
 
 	for _, key := range keys {
 		if value := GetString(v, key); value != "" {
-			return value, true
+			return value
 		}
 	}
 
-	return "", false
+	return ""
 }
 
 // GetString gets a parameter/setting by key and strips any quotes.

--- a/pkg/vipertools/vipertools_test.go
+++ b/pkg/vipertools/vipertools_test.go
@@ -81,25 +81,24 @@ func TestFirstNonEmptyString(t *testing.T) {
 	v.Set("second", "secret")
 	v.Set("third", "ignored")
 
-	value, ok := vipertools.FirstNonEmptyString(v, "first", "second", "third")
-	require.True(t, ok)
+	value := vipertools.FirstNonEmptyString(v, "first", "second", "third")
 	assert.Equal(t, "secret", value)
 }
 
 func TestFirstNonEmptyString_NilPointer(t *testing.T) {
-	_, ok := vipertools.FirstNonEmptyString(nil, "first")
-	assert.False(t, ok)
+	value := vipertools.FirstNonEmptyString(nil, "first")
+	assert.Empty(t, value)
 }
 
 func TestFirstNonEmptyString_EmptyKeys(t *testing.T) {
 	v := viper.New()
-	_, ok := vipertools.FirstNonEmptyString(v)
-	assert.False(t, ok)
+	value := vipertools.FirstNonEmptyString(v)
+	assert.Empty(t, value)
 }
 
 func TestFirstNonEmptyString_NotFound(t *testing.T) {
-	_, ok := vipertools.FirstNonEmptyString(viper.New(), "key")
-	assert.False(t, ok)
+	value := vipertools.FirstNonEmptyString(viper.New(), "key")
+	assert.Empty(t, value)
 }
 
 func TestGetString(t *testing.T) {


### PR DESCRIPTION
When env var `WAKATIME_API_KEY` present, use it's value as the api key. This means you don't need a `~/.wakatime.cfg` file, but if the `~/.wakatime.cfg` file exists and has an `api_key` then it takes precedence over the env var.

Fixes #761.