### PR TITLE
Fix panicking when getting timezone

### DIFF
--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -35,7 +35,7 @@ func newClient(params paramscmd.API, opts ...api.Option) (*api.Client, error) {
 	opts = append(opts, api.WithTimeout(params.Timeout))
 	opts = append(opts, api.WithHostname(strings.TrimSpace(params.Hostname)))
 
-	tz, err := tz.Name()
+	tz, err := timezone()
 	if err != nil {
 		log.Debugf("failed to detect local timezone: %s", err)
 	} else {
@@ -83,4 +83,16 @@ func newClient(params paramscmd.API, opts ...api.Option) (*api.Client, error) {
 	opts = append(opts, api.WithUserAgent(params.Plugin))
 
 	return api.NewClient(params.URL, opts...), nil
+}
+
+func timezone() (name string, err error) {
+	defer func() {
+		if e := recover(); e != nil {
+			err = fmt.Errorf("panicked when detecting timezone: %s", e)
+		}
+	}()
+
+	name, err = tz.Name()
+
+	return name, err
 }


### PR DESCRIPTION
This PR address an issue that happens only on Windows machines where it panics trying to load `advapi32.dll` to load registry. It early recover from panic avoiding breaking the cli and logs it.

```
Failed to load advapi32.dll: The paging file is too small for this operation to complete.

goroutine 1 [running]:
runtime/debug.Stack()
 C:/hostedtoolcache/windows/go/1.21.5/x64/src/runtime/debug/stack.go:24 +0x5e
github.com/wakatime/wakatime-cli/cmd.runCmd.func1()
 D:/a/wakatime-cli/wakatime-cli/cmd/run.go:313 +0x13c
panic({0xaa7260?, 0xc0004af020?})
 C:/hostedtoolcache/windows/go/1.21.5/x64/src/runtime/panic.go:914 +0x21f
syscall.(*LazyProc).mustFind(...)
 C:/hostedtoolcache/windows/go/1.21.5/x64/src/syscall/dll_windows.go:269
syscall.(*LazyProc).Addr(...)
 C:/hostedtoolcache/windows/go/1.21.5/x64/src/syscall/dll_windows.go:276
syscall.RegOpenKeyEx(0xb7981d?, 0x34?, 0x0, 0x1, 0x4281b3?)
 C:/hostedtoolcache/windows/go/1.21.5/x64/src/syscall/zsyscall_windows.go:317 +0xb4
golang.org/x/sys/windows/registry.OpenKey(0x19d25ee0108?, {0xb7981d?, 0x1266200?}, 0x4ee700?)
 C:/Users/runneradmin/go/pkg/mod/golang.org/x/sys@v0.15.0/windows/registry/key.go:84 +0x66
github.com/gandarez/go-olson-timezone.Name()
 C:/Users/runneradmin/go/pkg/mod/github.com/gandarez/go-olson-timezone@v0.1.0/timezone_windows.go:25 +0x65
github.com/wakatime/wakatime-cli/cmd/api.newClient({{0x0, 0x0, 0x0}, 0x0, 0x0, {0xc0004fa750, 0xe}, {0xc00002e3f0, 0x29}, {0x0, ...}, ...}, ...)
 D:/a/wakatime-cli/wakatime-cli/cmd/api/api.go:38 +0x1f2
github.com/wakatime/wakatime-cli/cmd/api.NewClient({{0x0, 0x0, 0x0}, 0x0, 0x0, {0xc0004fa750, 0xe}, {0xc00002e3f0, 0x29}, {0x0, ...}, ...})
 D:/a/wakatime-cli/wakatime-cli/cmd/api/api.go:24 +0xe8
github.com/wakatime/wakatime-cli/cmd/today.Today(0xc0004aed20?)
 D:/a/wakatime-cli/wakatime-cli/cmd/today/today.go:48 +0x1d8
github.com/wakatime/wakatime-cli/cmd/today.Run(0xe14380?)
 D:/a/wakatime-cli/wakatime-cli/cmd/today/today.go:18 +0x1c
github.com/wakatime/wakatime-cli/cmd.runCmd(0xc000502380, 0x0, 0x0, 0xd37c28)
 D:/a/wakatime-cli/wakatime-cli/cmd/run.go:331 +0x124
github.com/wakatime/wakatime-cli/cmd.RunCmd(0xc0004ebda0?, 0xee?, 0x2e?, 0x0?, 0xd37be0)
 D:/a/wakatime-cli/wakatime-cli/cmd/run.go:270 +0x18
github.com/wakatime/wakatime-cli/cmd.Run(0x0?, 0x0?)
 D:/a/wakatime-cli/wakatime-cli/cmd/run.go:119 +0x5c5
github.com/wakatime/wakatime-cli/cmd.NewRootCMD.func1(0xc0000b2c00?, {0xb42231?, 0x4?, 0xb42235?})
 D:/a/wakatime-cli/wakatime-cli/cmd/root.go:29 +0x17
github.com/spf13/cobra.(*Command).execute(0xc000584000, {0xc000122010, 0x5, 0x7})
 C:/Users/runneradmin/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:944 +0x863
github.com/spf13/cobra.(*Command).ExecuteC(0xc000584000)
 C:/Users/runneradmin/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:1068 +0x3a5
github.com/spf13/cobra.(*Command).Execute(...)
 C:/Users/runneradmin/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:992
github.com/wakatime/wakatime-cli/cmd.Execute()
 D:/a/wakatime-cli/wakatime-cli/cmd/root.go:271 +0x18
main.main()
 D:/a/wakatime-cli/wakatime-cli/main.go:6 +0xf
```