### PR TITLE
Use custom os.Open fork to prevent locking on Windows

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,8 @@ run:
     - integration
   skip-dirs:
     - "testdata"
+  skip-files:
+    - pkg/file/file_windows.go
 linters:
   enable:
     - bodyclose

--- a/pkg/deps/c.go
+++ b/pkg/deps/c.go
@@ -3,10 +3,10 @@ package deps
 import (
 	"fmt"
 	"io"
-	"os"
 	"regexp"
 	"strings"
 
+	"github.com/wakatime/wakatime-cli/pkg/file"
 	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 	"github.com/wakatime/wakatime-cli/pkg/log"
 
@@ -35,7 +35,7 @@ type ParserC struct {
 
 // Parse parses dependencies from C file content using the C lexer.
 func (p *ParserC) Parse(filepath string) ([]string, error) {
-	reader, err := os.Open(filepath) // nolint:gosec
+	reader, err := file.OpenNoLock(filepath) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
 	}

--- a/pkg/deps/cpp.go
+++ b/pkg/deps/cpp.go
@@ -3,10 +3,10 @@ package deps
 import (
 	"fmt"
 	"io"
-	"os"
 	"regexp"
 	"strings"
 
+	"github.com/wakatime/wakatime-cli/pkg/file"
 	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 	"github.com/wakatime/wakatime-cli/pkg/log"
 
@@ -35,7 +35,7 @@ type ParserCPP struct {
 
 // Parse parses dependencies from C++ file content using the C lexer.
 func (p *ParserCPP) Parse(filepath string) ([]string, error) {
-	reader, err := os.Open(filepath) // nolint:gosec
+	reader, err := file.OpenNoLock(filepath) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
 	}

--- a/pkg/deps/csharp.go
+++ b/pkg/deps/csharp.go
@@ -3,10 +3,10 @@ package deps
 import (
 	"fmt"
 	"io"
-	"os"
 	"regexp"
 	"strings"
 
+	"github.com/wakatime/wakatime-cli/pkg/file"
 	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 	"github.com/wakatime/wakatime-cli/pkg/log"
 
@@ -36,7 +36,7 @@ type ParserCSharp struct {
 
 // Parse parses dependencies from C# file content using the chroma C# lexer.
 func (p *ParserCSharp) Parse(filepath string) ([]string, error) {
-	reader, err := os.Open(filepath) // nolint:gosec
+	reader, err := file.OpenNoLock(filepath) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
 	}

--- a/pkg/deps/elm.go
+++ b/pkg/deps/elm.go
@@ -3,9 +3,9 @@ package deps
 import (
 	"fmt"
 	"io"
-	"os"
 	"strings"
 
+	"github.com/wakatime/wakatime-cli/pkg/file"
 	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 	"github.com/wakatime/wakatime-cli/pkg/log"
 
@@ -32,7 +32,7 @@ type ParserElm struct {
 
 // Parse parses dependencies from Elm file content using the chroma Elm lexer.
 func (p *ParserElm) Parse(filepath string) ([]string, error) {
-	reader, err := os.Open(filepath) // nolint:gosec
+	reader, err := file.OpenNoLock(filepath) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
 	}

--- a/pkg/deps/golang.go
+++ b/pkg/deps/golang.go
@@ -3,10 +3,10 @@ package deps
 import (
 	"fmt"
 	"io"
-	"os"
 	"regexp"
 	"strings"
 
+	"github.com/wakatime/wakatime-cli/pkg/file"
 	"github.com/wakatime/wakatime-cli/pkg/log"
 
 	"github.com/alecthomas/chroma/v2"
@@ -35,7 +35,7 @@ type ParserGo struct {
 
 // Parse parses dependencies from Golang file content using the chroma Golang lexer.
 func (p *ParserGo) Parse(filepath string) ([]string, error) {
-	reader, err := os.Open(filepath) // nolint:gosec
+	reader, err := file.OpenNoLock(filepath) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
 	}

--- a/pkg/deps/haskell.go
+++ b/pkg/deps/haskell.go
@@ -3,9 +3,9 @@ package deps
 import (
 	"fmt"
 	"io"
-	"os"
 	"strings"
 
+	"github.com/wakatime/wakatime-cli/pkg/file"
 	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 	"github.com/wakatime/wakatime-cli/pkg/log"
 
@@ -32,7 +32,7 @@ type ParserHaskell struct {
 
 // Parse parses dependencies from Haskell file content using the chroma Haskell lexer.
 func (p *ParserHaskell) Parse(filepath string) ([]string, error) {
-	reader, err := os.Open(filepath) // nolint:gosec
+	reader, err := file.OpenNoLock(filepath) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
 	}

--- a/pkg/deps/haxe.go
+++ b/pkg/deps/haxe.go
@@ -3,10 +3,10 @@ package deps
 import (
 	"fmt"
 	"io"
-	"os"
 	"regexp"
 	"strings"
 
+	"github.com/wakatime/wakatime-cli/pkg/file"
 	"github.com/wakatime/wakatime-cli/pkg/log"
 
 	"github.com/alecthomas/chroma/v2"
@@ -34,7 +34,7 @@ type ParserHaxe struct {
 
 // Parse parses dependencies from Haxe file content using the chroma Haxe lexer.
 func (p *ParserHaxe) Parse(filepath string) ([]string, error) {
-	reader, err := os.Open(filepath) // nolint:gosec
+	reader, err := file.OpenNoLock(filepath) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
 	}

--- a/pkg/deps/html.go
+++ b/pkg/deps/html.go
@@ -3,10 +3,10 @@ package deps
 import (
 	"fmt"
 	"io"
-	"os"
 	"regexp"
 	"strings"
 
+	"github.com/wakatime/wakatime-cli/pkg/file"
 	"github.com/wakatime/wakatime-cli/pkg/log"
 
 	"github.com/alecthomas/chroma/v2"
@@ -36,7 +36,7 @@ type ParserHTML struct {
 
 // Parse parses dependencies from HTML file content via ReadCloser using the chroma HTML lexer.
 func (p *ParserHTML) Parse(filepath string) ([]string, error) {
-	reader, err := os.Open(filepath) // nolint:gosec
+	reader, err := file.OpenNoLock(filepath) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
 	}

--- a/pkg/deps/java.go
+++ b/pkg/deps/java.go
@@ -3,10 +3,10 @@ package deps
 import (
 	"fmt"
 	"io"
-	"os"
 	"regexp"
 	"strings"
 
+	"github.com/wakatime/wakatime-cli/pkg/file"
 	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 	"github.com/wakatime/wakatime-cli/pkg/log"
 
@@ -38,7 +38,7 @@ type ParserJava struct {
 
 // Parse parses dependencies from Java file content using the chroma Java lexer.
 func (p *ParserJava) Parse(filepath string) ([]string, error) {
-	reader, err := os.Open(filepath) // nolint:gosec
+	reader, err := file.OpenNoLock(filepath) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
 	}

--- a/pkg/deps/javascript.go
+++ b/pkg/deps/javascript.go
@@ -3,10 +3,10 @@ package deps
 import (
 	"fmt"
 	"io"
-	"os"
 	"regexp"
 	"strings"
 
+	"github.com/wakatime/wakatime-cli/pkg/file"
 	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 	"github.com/wakatime/wakatime-cli/pkg/log"
 
@@ -35,7 +35,7 @@ type ParserJavaScript struct {
 
 // Parse parses dependencies from JavaScript file content using the chroma JavaScript lexer.
 func (p *ParserJavaScript) Parse(filepath string) ([]string, error) {
-	reader, err := os.Open(filepath) // nolint:gosec
+	reader, err := file.OpenNoLock(filepath) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
 	}

--- a/pkg/deps/json.go
+++ b/pkg/deps/json.go
@@ -3,10 +3,10 @@ package deps
 import (
 	"fmt"
 	"io"
-	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/wakatime/wakatime-cli/pkg/file"
 	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 	"github.com/wakatime/wakatime-cli/pkg/log"
 
@@ -44,7 +44,7 @@ type ParserJSON struct {
 
 // Parse parses dependencies from JSON file content using the chroma JSON lexer.
 func (p *ParserJSON) Parse(filepath string) ([]string, error) {
-	reader, err := os.Open(filepath) // nolint:gosec
+	reader, err := file.OpenNoLock(filepath) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
 	}

--- a/pkg/deps/kotlin.go
+++ b/pkg/deps/kotlin.go
@@ -3,10 +3,10 @@ package deps
 import (
 	"fmt"
 	"io"
-	"os"
 	"regexp"
 	"strings"
 
+	"github.com/wakatime/wakatime-cli/pkg/file"
 	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 	"github.com/wakatime/wakatime-cli/pkg/log"
 
@@ -35,7 +35,7 @@ type ParserKotlin struct {
 
 // Parse parses dependencies from Kotlin file content using the chroma Kotlin lexer.
 func (p *ParserKotlin) Parse(filepath string) ([]string, error) {
-	reader, err := os.Open(filepath) // nolint:gosec
+	reader, err := file.OpenNoLock(filepath) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
 	}

--- a/pkg/deps/objectivec.go
+++ b/pkg/deps/objectivec.go
@@ -3,9 +3,9 @@ package deps
 import (
 	"fmt"
 	"io"
-	"os"
 	"strings"
 
+	"github.com/wakatime/wakatime-cli/pkg/file"
 	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 	"github.com/wakatime/wakatime-cli/pkg/log"
 
@@ -32,7 +32,7 @@ type ParserObjectiveC struct {
 
 // Parse parses dependencies from Objective-C file content using the chroma Objective-C lexer.
 func (p *ParserObjectiveC) Parse(filepath string) ([]string, error) {
-	reader, err := os.Open(filepath) // nolint:gosec
+	reader, err := file.OpenNoLock(filepath) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
 	}

--- a/pkg/deps/php.go
+++ b/pkg/deps/php.go
@@ -3,10 +3,10 @@ package deps
 import (
 	"fmt"
 	"io"
-	"os"
 	"regexp"
 	"strings"
 
+	"github.com/wakatime/wakatime-cli/pkg/file"
 	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 	"github.com/wakatime/wakatime-cli/pkg/log"
 
@@ -41,7 +41,7 @@ type ParserPHP struct {
 
 // Parse parses dependencies from PHP file content using the chroma PHP lexer.
 func (p *ParserPHP) Parse(filepath string) ([]string, error) {
-	reader, err := os.Open(filepath) // nolint:gosec
+	reader, err := file.OpenNoLock(filepath) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
 	}

--- a/pkg/deps/python.go
+++ b/pkg/deps/python.go
@@ -3,10 +3,10 @@ package deps
 import (
 	"fmt"
 	"io"
-	"os"
 	"regexp"
 	"strings"
 
+	"github.com/wakatime/wakatime-cli/pkg/file"
 	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 	"github.com/wakatime/wakatime-cli/pkg/log"
 
@@ -38,7 +38,7 @@ type ParserPython struct {
 
 // Parse parses dependencies from Python file content using the chroma Python lexer.
 func (p *ParserPython) Parse(filepath string) ([]string, error) {
-	reader, err := os.Open(filepath) // nolint:gosec
+	reader, err := file.OpenNoLock(filepath) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
 	}

--- a/pkg/deps/rust.go
+++ b/pkg/deps/rust.go
@@ -3,9 +3,9 @@ package deps
 import (
 	"fmt"
 	"io"
-	"os"
 	"strings"
 
+	"github.com/wakatime/wakatime-cli/pkg/file"
 	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 	"github.com/wakatime/wakatime-cli/pkg/log"
 
@@ -34,7 +34,7 @@ type ParserRust struct {
 
 // Parse parses dependencies from Rust file content using the chroma Rust lexer.
 func (p *ParserRust) Parse(filepath string) ([]string, error) {
-	reader, err := os.Open(filepath) // nolint:gosec
+	reader, err := file.OpenNoLock(filepath) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
 	}

--- a/pkg/deps/scala.go
+++ b/pkg/deps/scala.go
@@ -3,9 +3,9 @@ package deps
 import (
 	"fmt"
 	"io"
-	"os"
 	"strings"
 
+	"github.com/wakatime/wakatime-cli/pkg/file"
 	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 	"github.com/wakatime/wakatime-cli/pkg/log"
 
@@ -32,7 +32,7 @@ type ParserScala struct {
 
 // Parse parses dependencies from Scala file content using the chroma Scala lexer.
 func (p *ParserScala) Parse(filepath string) ([]string, error) {
-	reader, err := os.Open(filepath) // nolint:gosec
+	reader, err := file.OpenNoLock(filepath) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
 	}

--- a/pkg/deps/swift.go
+++ b/pkg/deps/swift.go
@@ -3,10 +3,10 @@ package deps
 import (
 	"fmt"
 	"io"
-	"os"
 	"regexp"
 	"strings"
 
+	"github.com/wakatime/wakatime-cli/pkg/file"
 	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 	"github.com/wakatime/wakatime-cli/pkg/log"
 
@@ -35,7 +35,7 @@ type ParserSwift struct {
 
 // Parse parses dependencies from Swift file content using the chroma Swift lexer.
 func (p *ParserSwift) Parse(filepath string) ([]string, error) {
-	reader, err := os.Open(filepath) // nolint:gosec
+	reader, err := file.OpenNoLock(filepath) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
 	}

--- a/pkg/deps/vbnet.go
+++ b/pkg/deps/vbnet.go
@@ -3,10 +3,10 @@ package deps
 import (
 	"fmt"
 	"io"
-	"os"
 	"regexp"
 	"strings"
 
+	"github.com/wakatime/wakatime-cli/pkg/file"
 	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 	"github.com/wakatime/wakatime-cli/pkg/log"
 
@@ -36,7 +36,7 @@ type ParserVbNet struct {
 
 // Parse parses dependencies from VB.Net file content using the chroma VB.Net lexer.
 func (p *ParserVbNet) Parse(filepath string) ([]string, error) {
-	reader, err := os.Open(filepath) // nolint:gosec
+	reader, err := file.OpenNoLock(filepath) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
 	}

--- a/pkg/file/file.go
+++ b/pkg/file/file.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+package file
+
+import "os"
+
+// OpenNoLock opens a file for reading in non-exclusive mode. In Unix-like
+// environments it just calls os.Open, but on Windows it forks syscall.Open
+// for control over the sharemode, adding syscall.FILE_SHARE_DELETE.
+func OpenNoLock(path string) (*os.File, error) {
+	return os.Open(path) // nolint:gosec
+}

--- a/pkg/file/file_test.go
+++ b/pkg/file/file_test.go
@@ -1,0 +1,45 @@
+//go:build !windows
+
+package file_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/wakatime/wakatime-cli/pkg/file"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpen(t *testing.T) {
+	tmpFile, err := os.CreateTemp(t.TempDir(), "")
+	require.NoError(t, err)
+
+	err = tmpFile.Close()
+	require.NoError(t, err)
+
+	f, err := os.Open(tmpFile.Name())
+	require.NoError(t, err)
+
+	defer f.Close()
+
+	err = os.Remove(tmpFile.Name())
+	assert.NoError(t, err)
+}
+
+func TestOpenNoLock(t *testing.T) {
+	tmpFile, err := os.CreateTemp(t.TempDir(), "")
+	require.NoError(t, err)
+
+	err = tmpFile.Close()
+	require.NoError(t, err)
+
+	f, err := file.OpenNoLock(tmpFile.Name())
+	require.NoError(t, err)
+
+	defer f.Close()
+
+	err = os.Remove(tmpFile.Name())
+	assert.NoError(t, err)
+}

--- a/pkg/file/file_windows.go
+++ b/pkg/file/file_windows.go
@@ -1,0 +1,244 @@
+//go:build windows
+
+package file
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+// OpenNoLock opens a file for reading in non-exclusive mode. In Unix-like
+// environments it just calls os.Open, but on Windows it forks syscall.Open
+// for control over the sharemode, adding syscall.FILE_SHARE_DELETE.
+func OpenNoLock(path string) (*os.File, error) {
+	return openFile(path, os.O_RDONLY, 0)
+}
+
+func openFile(name string, flag int, perm os.FileMode) (*os.File, error) {
+	f, err := openFileNolog(name, flag, perm)
+	if err != nil {
+		return nil, err
+	}
+
+	return f, nil
+}
+
+// openFileNolog is the Windows implementation of OpenFile.
+func openFileNolog(name string, flag int, perm os.FileMode) (*os.File, error) {
+	if name == "" {
+		return nil, &os.PathError{Op: "open", Path: name, Err: syscall.ENOENT}
+	}
+	path := fixLongPath(name)
+	r, e := syscallOpen(path, flag)
+	if e != nil {
+		// We should return EISDIR when we are trying to open a directory with write access.
+		if e == syscall.ERROR_ACCESS_DENIED && (flag&os.O_WRONLY != 0 || flag&os.O_RDWR != 0) {
+			pathp, e1 := syscall.UTF16PtrFromString(path)
+			if e1 == nil {
+				var fa syscall.Win32FileAttributeData
+				e1 = syscall.GetFileAttributesEx(pathp, syscall.GetFileExInfoStandard, (*byte)(unsafe.Pointer(&fa)))
+				if e1 == nil && fa.FileAttributes&syscall.FILE_ATTRIBUTE_DIRECTORY != 0 {
+					e = syscall.EISDIR
+				}
+			}
+		}
+		return nil, &os.PathError{Op: "open", Path: name, Err: e}
+	}
+	f, e := os.NewFile(uintptr(r), name), nil
+	if e != nil {
+		return nil, &os.PathError{Op: "open", Path: name, Err: e}
+	}
+	return f, nil
+}
+
+func syscallOpen(path string, mode int) (fd syscall.Handle, err error) {
+	if len(path) == 0 {
+		return syscall.InvalidHandle, syscall.ERROR_FILE_NOT_FOUND
+	}
+	pathp, err := syscall.UTF16PtrFromString(path)
+	if err != nil {
+		return syscall.InvalidHandle, err
+	}
+	var access uint32
+	switch mode & (syscall.O_RDONLY | syscall.O_WRONLY | syscall.O_RDWR) {
+	case syscall.O_RDONLY:
+		access = syscall.GENERIC_READ
+	case syscall.O_WRONLY:
+		access = syscall.GENERIC_WRITE
+	case syscall.O_RDWR:
+		access = syscall.GENERIC_READ | syscall.GENERIC_WRITE
+	}
+	if mode&syscall.O_CREAT != 0 {
+		access |= syscall.GENERIC_WRITE
+	}
+	if mode&syscall.O_APPEND != 0 {
+		access &^= syscall.GENERIC_WRITE
+		access |= syscall.FILE_APPEND_DATA
+	}
+	sharemode := uint32(syscall.FILE_SHARE_READ | syscall.FILE_SHARE_WRITE | syscall.FILE_SHARE_DELETE)
+	var sa *syscall.SecurityAttributes
+	if mode&syscall.O_CLOEXEC == 0 {
+		sa = makeInheritSa()
+	}
+	var createmode uint32
+	switch {
+	case mode&(syscall.O_CREAT|syscall.O_EXCL) == (syscall.O_CREAT | syscall.O_EXCL):
+		createmode = syscall.CREATE_NEW
+	case mode&(syscall.O_CREAT|syscall.O_TRUNC) == (syscall.O_CREAT | syscall.O_TRUNC):
+		createmode = syscall.CREATE_ALWAYS
+	case mode&syscall.O_CREAT == syscall.O_CREAT:
+		createmode = syscall.OPEN_ALWAYS
+	case mode&syscall.O_TRUNC == syscall.O_TRUNC:
+		createmode = syscall.TRUNCATE_EXISTING
+	default:
+		createmode = syscall.OPEN_EXISTING
+	}
+	var attrs uint32 = syscall.FILE_ATTRIBUTE_NORMAL
+	if createmode == syscall.OPEN_EXISTING && access == syscall.GENERIC_READ {
+		// Necessary for opening directory handles.
+		attrs |= syscall.FILE_FLAG_BACKUP_SEMANTICS
+	}
+	if mode&syscall.O_SYNC != 0 {
+		const _FILE_FLAG_WRITE_THROUGH = 0x80000000
+		attrs |= _FILE_FLAG_WRITE_THROUGH
+	}
+	return syscall.CreateFile(pathp, access, sharemode, sa, createmode, attrs, 0)
+}
+
+func makeInheritSa() *syscall.SecurityAttributes {
+	var sa syscall.SecurityAttributes
+	sa.Length = uint32(unsafe.Sizeof(sa))
+	sa.InheritHandle = 1
+	return &sa
+}
+
+func isAbs(path string) (b bool) {
+	v := volumeName(path)
+	if v == "" {
+		return false
+	}
+	path = path[len(v):]
+	if path == "" {
+		return false
+	}
+	return os.IsPathSeparator(path[0])
+}
+
+func volumeName(path string) (v string) {
+	if len(path) < 2 {
+		return ""
+	}
+	// with drive letter
+	c := path[0]
+	if path[1] == ':' &&
+		('0' <= c && c <= '9' || 'a' <= c && c <= 'z' ||
+			'A' <= c && c <= 'Z') {
+		return path[:2]
+	}
+	// is it UNC
+	if l := len(path); l >= 5 && os.IsPathSeparator(path[0]) && os.IsPathSeparator(path[1]) &&
+		!os.IsPathSeparator(path[2]) && path[2] != '.' {
+		// first, leading `\\` and next shouldn't be `\`. its server name.
+		for n := 3; n < l-1; n++ {
+			// second, next '\' shouldn't be repeated.
+			if os.IsPathSeparator(path[n]) {
+				n++
+				// third, following something characters. its share name.
+				if !os.IsPathSeparator(path[n]) {
+					if path[n] == '.' {
+						break
+					}
+					for ; n < l; n++ {
+						if os.IsPathSeparator(path[n]) {
+							break
+						}
+					}
+					return path[:n]
+				}
+				break
+			}
+		}
+	}
+	return ""
+}
+
+// fixLongPath returns the extended-length (\\?\-prefixed) form of
+// path when needed, in order to avoid the default 260 character file
+// path limit imposed by Windows. If path is not easily converted to
+// the extended-length form (for example, if path is a relative path
+// or contains .. elements), or is short enough, fixLongPath returns
+// path unmodified.
+//
+// See https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file#maximum-path-length-limitation
+func fixLongPath(path string) string {
+	// Do nothing (and don't allocate) if the path is "short".
+	// Empirically (at least on the Windows Server 2013 builder),
+	// the kernel is arbitrarily okay with < 248 bytes. That
+	// matches what the docs above say:
+	// "When using an API to create a directory, the specified
+	// path cannot be so long that you cannot append an 8.3 file
+	// name (that is, the directory name cannot exceed MAX_PATH
+	// minus 12)." Since MAX_PATH is 260, 260 - 12 = 248.
+	//
+	// The MSDN docs appear to say that a normal path that is 248 bytes long
+	// will work; empirically the path must be less then 248 bytes long.
+	if len(path) < 248 {
+		// Don't fix. (This is how Go 1.7 and earlier worked,
+		// not automatically generating the \\?\ form)
+		return path
+	}
+
+	// The extended form begins with \\?\, as in
+	// \\?\c:\windows\foo.txt or \\?\UNC\server\share\foo.txt.
+	// The extended form disables evaluation of . and .. path
+	// elements and disables the interpretation of / as equivalent
+	// to \. The conversion here rewrites / to \ and elides
+	// . elements as well as trailing or duplicate separators. For
+	// simplicity it avoids the conversion entirely for relative
+	// paths or paths containing .. elements. For now,
+	// \\server\share paths are not converted to
+	// \\?\UNC\server\share paths because the rules for doing so
+	// are less well-specified.
+	if len(path) >= 2 && path[:2] == `\\` {
+		// Don't canonicalize UNC paths.
+		return path
+	}
+	if !isAbs(path) {
+		// Relative path
+		return path
+	}
+
+	const prefix = `\\?`
+
+	pathbuf := make([]byte, len(prefix)+len(path)+len(`\`))
+	copy(pathbuf, prefix)
+	n := len(path)
+	r, w := 0, len(prefix)
+	for r < n {
+		switch {
+		case os.IsPathSeparator(path[r]):
+			// empty block
+			r++
+		case path[r] == '.' && (r+1 == n || os.IsPathSeparator(path[r+1])):
+			// /./
+			r++
+		case r+1 < n && path[r] == '.' && path[r+1] == '.' && (r+2 == n || os.IsPathSeparator(path[r+2])):
+			// /../ is currently unhandled
+			return path
+		default:
+			pathbuf[w] = '\\'
+			w++
+			for ; r < n && !os.IsPathSeparator(path[r]); r++ {
+				pathbuf[w] = path[r]
+				w++
+			}
+		}
+	}
+	// A drive's root directory needs a trailing \
+	if w == len(`\\?\c:`) {
+		pathbuf[w] = '\\'
+		w++
+	}
+	return string(pathbuf[:w])
+}

--- a/pkg/file/file_windows_test.go
+++ b/pkg/file/file_windows_test.go
@@ -1,0 +1,45 @@
+//go:build windows
+
+package file_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/wakatime/wakatime-cli/pkg/file"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpen(t *testing.T) {
+	tmpFile, err := os.CreateTemp(t.TempDir(), "")
+	require.NoError(t, err)
+
+	err = tmpFile.Close()
+	require.NoError(t, err)
+
+	f, err := os.Open(tmpFile.Name())
+	require.NoError(t, err)
+
+	defer f.Close()
+
+	err = os.Remove(tmpFile.Name())
+	assert.Error(t, err)
+}
+
+func TestOpenNoLock(t *testing.T) {
+	tmpFile, err := os.CreateTemp(t.TempDir(), "")
+	require.NoError(t, err)
+
+	err = tmpFile.Close()
+	require.NoError(t, err)
+
+	f, err := file.OpenNoLock(tmpFile.Name())
+	require.NoError(t, err)
+
+	defer f.Close()
+
+	err = os.Remove(tmpFile.Name())
+	assert.NoError(t, err)
+}

--- a/pkg/filestats/filestats.go
+++ b/pkg/filestats/filestats.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/wakatime/wakatime-cli/pkg/file"
 	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 	"github.com/wakatime/wakatime-cli/pkg/log"
 )
@@ -75,7 +76,7 @@ func WithDetection() heartbeat.HandleOption {
 }
 
 func countLineNumbers(filepath string) (int, error) {
-	f, err := os.Open(filepath) // nolint:gosec
+	f, err := file.OpenNoLock(filepath) // nolint:gosec
 	if err != nil {
 		return 0, fmt.Errorf("failed to open file: %s", err)
 	}

--- a/pkg/language/chroma.go
+++ b/pkg/language/chroma.go
@@ -3,11 +3,11 @@ package language
 import (
 	"fmt"
 	"io"
-	"os"
 	fp "path/filepath"
 	"sort"
 	"strings"
 
+	"github.com/wakatime/wakatime-cli/pkg/file"
 	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 	"github.com/wakatime/wakatime-cli/pkg/log"
 
@@ -200,7 +200,7 @@ func selectByCustomizedPriority(filepath string, lexers chroma.PrioritisedLexers
 
 // fileHead returns the first `maxFileSize` bytes of the file's content.
 func fileHead(filepath string) ([]byte, error) {
-	f, err := os.Open(filepath) // nolint:gosec
+	f, err := file.OpenNoLock(filepath) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file: %s", err)
 	}

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/mitchellh/go-homedir"
+	"github.com/wakatime/wakatime-cli/pkg/file"
 	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 	"github.com/wakatime/wakatime-cli/pkg/log"
 
@@ -277,7 +278,7 @@ func (c Client) knownHostKeys() []ssh.PublicKey {
 
 	for _, filename := range filenames {
 		if err := func(fn string) error {
-			file, err := os.Open(fn) // nolint:gosec
+			file, err := file.OpenNoLock(fn) // nolint:gosec
 			if err != nil {
 				return fmt.Errorf("failed to open known_hosts file: %s", err)
 			}


### PR DESCRIPTION
Forks `os.Open` on Windows and adds sharemode `syscall.FILE_SHARE_DELETE`.

Might fix https://github.com/wakatime/visualstudio-wakatime/issues/152