### PR TITLE
All uploaded binaries should follow a pattern

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -606,7 +606,7 @@ jobs:
         name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: binaries
+          name: binaries-darwin
           path: build/
       -
         name: Remove tag if failure


### PR DESCRIPTION
I just found that signed apple binaries aren't following the upload patten `binaries-*`. 