### PR TITLE
Skip extra heartbeats when no data provided

### DIFF
--- a/cmd/params/params.go
+++ b/cmd/params/params.go
@@ -727,6 +727,12 @@ func readExtraHeartbeats() ([]heartbeat.Heartbeat, error) {
 }
 
 func parseExtraHeartbeats(data string) ([]heartbeat.Heartbeat, error) {
+	if data == "" {
+		log.Debugln("skipping extra heartbeats, as no data was provided")
+
+		return nil, nil
+	}
+
 	var extraHeartbeats []ExtraHeartbeat
 
 	err := json.Unmarshal([]byte(data), &extraHeartbeats)

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -34,8 +34,12 @@ func TestRunCmd_Err(t *testing.T) {
 		offlineQueueFile, err := os.CreateTemp(tmpDir, "")
 		require.NoError(t, err)
 
+		defer offlineQueueFile.Close()
+
 		logFile, err := os.CreateTemp(tmpDir, "")
 		require.NoError(t, err)
+
+		defer logFile.Close()
 
 		v := viper.New()
 		v.Set("api-url", os.Getenv("TEST_SERVER_URL"))
@@ -103,8 +107,12 @@ func TestRunCmd_Verbose_Err(t *testing.T) {
 		offlineQueueFile, err := os.CreateTemp(tmpDir, "")
 		require.NoError(t, err)
 
+		defer offlineQueueFile.Close()
+
 		logFile, err := os.CreateTemp(tmpDir, "")
 		require.NoError(t, err)
+
+		defer logFile.Close()
 
 		v := viper.New()
 		v.Set("api-url", os.Getenv("TEST_SERVER_URL"))
@@ -172,8 +180,12 @@ func TestRunCmd_SendDiagnostics_Err(t *testing.T) {
 		offlineQueueFile, err := os.CreateTemp(tmpDir, "")
 		require.NoError(t, err)
 
+		defer offlineQueueFile.Close()
+
 		logFile, err := os.CreateTemp(tmpDir, "")
 		require.NoError(t, err)
+
+		defer logFile.Close()
 
 		v := viper.New()
 		v.Set("api-url", os.Getenv("TEST_SERVER_URL"))
@@ -277,8 +289,12 @@ func TestRunCmd_SendDiagnostics_Panic(t *testing.T) {
 		offlineQueueFile, err := os.CreateTemp(tmpDir, "")
 		require.NoError(t, err)
 
+		defer offlineQueueFile.Close()
+
 		logFile, err := os.CreateTemp(tmpDir, "")
 		require.NoError(t, err)
+
+		defer logFile.Close()
 
 		v := viper.New()
 		v.Set("api-url", os.Getenv("TEST_SERVER_URL"))
@@ -384,8 +400,12 @@ func TestRunCmd_SendDiagnostics_NoLogs_Panic(t *testing.T) {
 		offlineQueueFile, err := os.CreateTemp(tmpDir, "")
 		require.NoError(t, err)
 
+		defer offlineQueueFile.Close()
+
 		logFile, err := os.CreateTemp(tmpDir, "")
 		require.NoError(t, err)
+
+		defer logFile.Close()
 
 		v := viper.New()
 		v.Set("api-url", os.Getenv("TEST_SERVER_URL"))
@@ -489,8 +509,12 @@ func TestRunCmd_SendDiagnostics_WakaError(t *testing.T) {
 		offlineQueueFile, err := os.CreateTemp(tmpDir, "")
 		require.NoError(t, err)
 
+		defer offlineQueueFile.Close()
+
 		logFile, err := os.CreateTemp(tmpDir, "")
 		require.NoError(t, err)
+
+		defer logFile.Close()
 
 		v := viper.New()
 		v.Set("api-url", os.Getenv("TEST_SERVER_URL"))


### PR DESCRIPTION
This PR fixes reading extra heartbeat when the flag is set to `true` but no data was provided.

current log
```
failed to read extra heartbeats: failed parsing: failed to json decode from data \"\": unexpected end of JSON input
```