### PR TITLE
Recover from panic when closing db

### DIFF
--- a/pkg/offline/offline.go
+++ b/pkg/offline/offline.go
@@ -411,6 +411,13 @@ func openDB(filepath string) (db *bolt.DB, _ func(), err error) {
 	}
 
 	return db, func() {
+		// recover from panic when closing db
+		defer func() {
+			if r := recover(); r != nil {
+				log.Warnf("panicked: failed to close db file: %v", r)
+			}
+		}()
+
 		if err := db.Close(); err != nil {
 			log.Debugf("failed to close db file: %s", err)
 		}


### PR DESCRIPTION
This PR adds an extra layer of validation to bbolt when closing it. There are some users getting panic to close it making the whole heartbeat to be gone.

logs
```
runtime error: invalid memory address or nil pointer dereference

goroutine 1 [running]:
runtime/debug.Stack()
 C:/hostedtoolcache/windows/go/1.22.0/x64/src/runtime/debug/stack.go:24 +0x5e
github.com/wakatime/wakatime-cli/cmd.runCmd.func1()
 D:/a/wakatime-cli/wakatime-cli/cmd/run.go:313 +0x13c
panic({0xccd4e0?, 0x1494030?})
 C:/hostedtoolcache/windows/go/1.22.0/x64/src/runtime/panic.go:770 +0x132
syscall.CloseHandle(0x280)
 C:/hostedtoolcache/windows/go/1.22.0/x64/src/syscall/zsyscall_windows.go:484 +0x9b
internal/poll.(*FD).destroy(0xc00043ac88)
 C:/hostedtoolcache/windows/go/1.22.0/x64/src/internal/poll/fd_windows.go:372 +0x74
internal/poll.(*FD).decref(0xc000151d48?)
 C:/hostedtoolcache/windows/go/1.22.0/x64/src/internal/poll/fd_mutex.go:213 +0x53
internal/poll.(*FD).Close(0xc00043ac88)
 C:/hostedtoolcache/windows/go/1.22.0/x64/src/internal/poll/fd_windows.go:390 +0x69
os.(*file).close(0xc00043ac88)
 C:/hostedtoolcache/windows/go/1.22.0/x64/src/os/file_windows.go:134 +0xa5
os.(*File).Close(...)
 C:/hostedtoolcache/windows/go/1.22.0/x64/src/os/file_posix.go:23
go.etcd.io/bbolt.(*DB).close(0xc000151d48)
 C:/Users/runneradmin/go/pkg/mod/go.etcd.io/bbolt@v1.3.8/db.go:688 +0x245
go.etcd.io/bbolt.(*DB).Close(0xc000151d48)
 C:/Users/runneradmin/go/pkg/mod/go.etcd.io/bbolt@v1.3.8/db.go:656 +0x145
github.com/wakatime/wakatime-cli/pkg/offline.openDB.func2()
 D:/a/wakatime-cli/wakatime-cli/pkg/offline/offline.go:414 +0x1e
github.com/wakatime/wakatime-cli/pkg/offline.popHeartbeats({0xc0000a3280?, 0x23eb76e19a8?}, 0x19)
 D:/a/wakatime-cli/wakatime-cli/pkg/offline/offline.go:266 +0x3b0
github.com/wakatime/wakatime-cli/pkg/offline.Sync.func1(0xc00027f740)
 D:/a/wakatime-cli/wakatime-cli/pkg/offline/offline.go:145 +0xc5
github.com/wakatime/wakatime-cli/cmd/offlinesync.SyncOfflineActivity.WithSync.func1.1({0xc00027f740?, 0x0?, 0xc0001e6420?})
 D:/a/wakatime-cli/wakatime-cli/pkg/offline/offline.go:109 +0xd3
github.com/wakatime/wakatime-cli/cmd/offlinesync.SyncOfflineActivity.NewHandle.func3({0x0, 0x0, 0x0})
 D:/a/wakatime-cli/wakatime-cli/pkg/heartbeat/heartbeat.go:169 +0xc8
github.com/wakatime/wakatime-cli/cmd/offlinesync.SyncOfflineActivity(0xc000084a80, {0xc0000a3280, 0x1c})
 D:/a/wakatime-cli/wakatime-cli/cmd/offlinesync/offlinesync.go:72 +0x3ea
github.com/wakatime/wakatime-cli/cmd/offlinesync.Run(0xc000084a80)
 D:/a/wakatime-cli/wakatime-cli/cmd/offlinesync/offlinesync.go:28 +0x39
github.com/wakatime/wakatime-cli/cmd.runCmd(0xc000084a80, 0x0, 0x0, 0xf70a80)
 D:/a/wakatime-cli/wakatime-cli/cmd/run.go:331 +0x124
github.com/wakatime/wakatime-cli/cmd.RunCmdWithOfflineSync(0xc000084a80, 0x0, 0x0, 0x0?, 0xf70a40)
 D:/a/wakatime-cli/wakatime-cli/cmd/run.go:288 +0x65
github.com/wakatime/wakatime-cli/cmd.Run(0xc000002308, 0xc000084a80)
 D:/a/wakatime-cli/wakatime-cli/cmd/run.go:137 +0x759
github.com/wakatime/wakatime-cli/cmd.NewRootCMD.func1(0xc0000bf500?, {0xd7ab0c?, 0x4?, 0xd7ab10?})
 D:/a/wakatime-cli/wakatime-cli/cmd/root.go:29 +0x17
github.com/spf13/cobra.(*Command).execute(0xc000002308, {0xc00011e010, 0x13, 0x1f})
 C:/Users/runneradmin/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:944 +0x867
github.com/spf13/cobra.(*Command).ExecuteC(0xc000002308)
 C:/Users/runneradmin/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:1068 +0x3a5
github.com/spf13/cobra.(*Command).Execute(...)
 C:/Users/runneradmin/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:992
github.com/wakatime/wakatime-cli/cmd.Execute()
 D:/a/wakatime-cli/wakatime-cli/cmd/root.go:273 +0x18
main.main()
 D:/a/wakatime-cli/wakatime-cli/main.go:6 +0xf
```