### PR TITLE
Check split lenght when finding git branch

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -170,7 +170,7 @@ jobs:
         name: Build binary
         env:
           VERSION: ${{ env.TEST_VERSION }}
-        run: make build-darwin-amd64
+        run: make build-darwin-arm64
       -
         name: Integration tests
         run: make test-integration

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/wakatime/wakatime-cli
 
-go 1.22.2
+go 1.22.4
 
 require (
 	github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358

--- a/pkg/project/git.go
+++ b/pkg/project/git.go
@@ -290,6 +290,13 @@ func findGitBranch(fp string) (string, error) {
 	}
 
 	if len(lines) > 0 && strings.HasPrefix(strings.TrimSpace(lines[0]), "ref: ") {
+		parts := strings.SplitN(lines[0], "/", 3)
+		if len(parts) < 3 {
+			log.Warnf("invalid branch from %q: %s", fp, lines[0])
+
+			return "", nil
+		}
+
 		return strings.TrimSpace(strings.SplitN(lines[0], "/", 3)[2]), nil
 	}
 

--- a/pkg/project/git_test.go
+++ b/pkg/project/git_test.go
@@ -115,6 +115,29 @@ func TestGit_Detect_GitConfigFile_File(t *testing.T) {
 	}
 }
 
+func TestGit_Detect_GitConfigFile_File_MalformedHEAD(t *testing.T) {
+	fp := setupTestGitFile(t)
+
+	// overwrite HEAD file with a malformed content
+	err := os.WriteFile(filepath.Join(fp, "wakatime-cli/.git/HEAD"), []byte("ref: refs/malformed"), os.FileMode(int(0700)))
+	require.NoError(t, err)
+
+	g := project.Git{
+		Filepath: filepath.Join(fp, "wakatime-cli/src/pkg/file.go"),
+	}
+
+	result, detected, err := g.Detect()
+	require.NoError(t, err)
+
+	assert.True(t, detected)
+	assert.Contains(t, result.Folder, filepath.Join(fp, "wakatime-cli"))
+	assert.Equal(t, project.Result{
+		Project: "wakatime-cli",
+		Branch:  "",
+		Folder:  result.Folder,
+	}, result)
+}
+
 func TestGit_Detect_Worktree(t *testing.T) {
 	fp := setupTestGitWorktree(t)
 


### PR DESCRIPTION
This PR fixes index out of range for `findGitBranch()`.

```
runtime error: index out of range [2] with length 1

goroutine 1 [running]:
runtime/debug.Stack()
 C:/hostedtoolcache/windows/go/1.22.0/x64/src/runtime/debug/stack.go:24 +0x5e
github.com/wakatime/wakatime-cli/cmd.runCmd.func1()
 D:/a/wakatime-cli/wakatime-cli/cmd/run.go:313 +0x13c
panic({0x11c1040?, 0xc0001781e0?})
 C:/hostedtoolcache/windows/go/1.22.0/x64/src/runtime/panic.go:770 +0x132
github.com/wakatime/wakatime-cli/pkg/project.findGitBranch({0xc000038e00, 0x69})
 D:/a/wakatime-cli/wakatime-cli/pkg/project/git.go:293 +0x190
github.com/wakatime/wakatime-cli/pkg/project.Git.Detect({{0xc000038310, 0x69}, 0x0, {0x0, 0x0, 0x0}, {0x0, 0x0, 0x0}})
 D:/a/wakatime-cli/wakatime-cli/pkg/project/git.go:141 +0xb65
github.com/wakatime/wakatime-cli/pkg/project.DetectWithRevControl({0x0, 0x0, 0x0}, {0x0, 0x0, 0x0}, 0x0, {0xc00021b8c8, 0x2, 0x2})
 D:/a/wakatime-cli/wakatime-cli/pkg/project/project.go:292 +0x3f7
github.com/wakatime/wakatime-cli/cmd/heartbeat.initHandleOptions.WithDetection.func9.1({0xc000442c80, 0x1, 0x1})
 D:/a/wakatime-cli/wakatime-cli/pkg/project/project.go:163 +0x425
github.com/wakatime/wakatime-cli/cmd/heartbeat.initHandleOptions.WithDetection.func8.1({0xc000442c80, 0x1, 0x1})
 D:/a/wakatime-cli/wakatime-cli/pkg/deps/deps.go:77 +0x3bd
github.com/wakatime/wakatime-cli/cmd/heartbeat.initHandleOptions.WithDetection.func7.1({0xc000442c80, 0x1, 0x1})
 D:/a/wakatime-cli/wakatime-cli/pkg/language/language.go:54 +0x36c
github.com/wakatime/wakatime-cli/cmd/heartbeat.initHandleOptions.WithDetection.func6.1({0xc000442c80, 0x1, 0x1})
 D:/a/wakatime-cli/wakatime-cli/pkg/filestats/filestats.go:73 +0x546
github.com/wakatime/wakatime-cli/cmd/heartbeat.initHandleOptions.WithReplacing.func5.1({0xc000442c80, 0x1, 0x1})
 D:/a/wakatime-cli/wakatime-cli/pkg/apikey/apikey.go:44 +0x1cb
github.com/wakatime/wakatime-cli/cmd/heartbeat.initHandleOptions.WithDetection.func4.1({0xc000442b40, 0x1, 0x0?})
 D:/a/wakatime-cli/wakatime-cli/pkg/remote/remote.go:112 +0x93c
github.com/wakatime/wakatime-cli/cmd/heartbeat.initHandleOptions.WithFiltering.func3.1({0xc00062a140, 0x1, 0xc00007e2a0?})
 D:/a/wakatime-cli/wakatime-cli/pkg/filter/filter.go:41 +0x2d0
github.com/wakatime/wakatime-cli/cmd/heartbeat.initHandleOptions.WithEntityModifier.func2.1({0xc00062a140, 0x1, 0x1})
 D:/a/wakatime-cli/wakatime-cli/pkg/heartbeat/entity_modify.go:24 +0x1fd
github.com/wakatime/wakatime-cli/cmd/heartbeat.initHandleOptions.WithFormatting.func1.1({0xc00062a140, 0x1, 0x1})
 D:/a/wakatime-cli/wakatime-cli/pkg/heartbeat/format.go:32 +0x28e
github.com/wakatime/wakatime-cli/cmd/heartbeat.SendHeartbeats.NewHandle.func4({0xc00062a140, 0x1, 0x1})
 D:/a/wakatime-cli/wakatime-cli/pkg/heartbeat/heartbeat.go:169 +0xc8
github.com/wakatime/wakatime-cli/cmd/heartbeat.SendHeartbeats(0xc00006bc00, {0xc000464900, 0x1c})
 D:/a/wakatime-cli/wakatime-cli/cmd/heartbeat/heartbeat.go:129 +0x7c5
github.com/wakatime/wakatime-cli/cmd/heartbeat.Run(0xc00006bc00)
 D:/a/wakatime-cli/wakatime-cli/cmd/heartbeat/heartbeat.go:37 +0xc5
github.com/wakatime/wakatime-cli/cmd.runCmd(0xc00006bc00, 0x0, 0x0, 0x13f0a68)
 D:/a/wakatime-cli/wakatime-cli/cmd/run.go:331 +0x124
github.com/wakatime/wakatime-cli/cmd.RunCmdWithOfflineSync(0xc00006bc00, 0x0, 0x0, 0x0?, 0x13f0a40)
 D:/a/wakatime-cli/wakatime-cli/cmd/run.go:281 +0x25
github.com/wakatime/wakatime-cli/cmd.Run(0xc0000d4308, 0xc00006bc00)
 D:/a/wakatime-cli/wakatime-cli/cmd/run.go:137 +0x759
github.com/wakatime/wakatime-cli/cmd.NewRootCMD.func1(0xc000122200?, {0x11fab0c?, 0x4?, 0x11fab10?})
 D:/a/wakatime-cli/wakatime-cli/cmd/root.go:29 +0x17
github.com/spf13/cobra.(*Command).execute(0xc0000d4308, {0xc000124010, 0x13, 0x1f})
 C:/Users/runneradmin/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:944 +0x867
github.com/spf13/cobra.(*Command).ExecuteC(0xc0000d4308)
 C:/Users/runneradmin/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:1068 +0x3a5
github.com/spf13/cobra.(*Command).Execute(...)
 C:/Users/runneradmin/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:992
github.com/wakatime/wakatime-cli/cmd.Execute()
 D:/a/wakatime-cli/wakatime-cli/cmd/root.go:273 +0x18
main.main()
 D:/a/wakatime-cli/wakatime-cli/main.go:6 +0xf
```