### PR TITLE
Remove unused error response from WithSSLCertPool

### DIFF
--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -54,12 +54,7 @@ func newClient(params paramscmd.API, opts ...api.Option) (*api.Client, error) {
 
 		opts = append(opts, withSSLCert)
 	} else if !params.DisableSSLVerify {
-		withSSLCert, err := api.WithSSLCertPool(api.CACerts())
-		if err != nil {
-			return nil, fmt.Errorf("failed to set up ssl cert pool option on api client: %s", err)
-		}
-
-		opts = append(opts, withSSLCert)
+		opts = append(opts, api.WithSSLCertPool(api.CACerts()))
 	}
 
 	if params.ProxyURL != "" {

--- a/pkg/api/option.go
+++ b/pkg/api/option.go
@@ -37,7 +37,7 @@ func WithAuth(auth BasicAuth) (Option, error) {
 // WithDisableSSLVerify disables verification of insecure certificates.
 func WithDisableSSLVerify() Option {
 	return func(c *Client) {
-		var transport = LazyCreateNewTransport(c)
+		transport := LazyCreateNewTransport(c)
 
 		tlsConfig := transport.TLSClientConfig
 		tlsConfig.InsecureSkipVerify = true
@@ -110,7 +110,7 @@ func WithProxy(proxyURL string) (Option, error) {
 	}
 
 	return func(c *Client) {
-		var transport = LazyCreateNewTransport(c)
+		transport := LazyCreateNewTransport(c)
 		transport.Proxy = http.ProxyURL(u)
 		c.client.Transport = transport
 	}, nil
@@ -126,19 +126,21 @@ func WithSSLCertFile(filepath string) (Option, error) {
 	caCertPool := x509.NewCertPool()
 	caCertPool.AppendCertsFromPEM(caCert)
 
-	return WithSSLCertPool(caCertPool)
+	return WithSSLCertPool(caCertPool), nil
 }
 
 // WithSSLCertPool overrides the default CA cert pool to trust specified cert pool.
-func WithSSLCertPool(caCertPool *x509.CertPool) (Option, error) {
+func WithSSLCertPool(caCertPool *x509.CertPool) Option {
 	return func(c *Client) {
-		var transport = LazyCreateNewTransport(c)
+		transport := LazyCreateNewTransport(c)
+
 		tlsConfig := transport.TLSClientConfig
 		tlsConfig.RootCAs = caCertPool
+
 		transport.TLSClientConfig = tlsConfig
 
 		c.client.Transport = transport
-	}, nil
+	}
 }
 
 // WithTimeout configures a timeout for all requests.

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -66,7 +66,7 @@ func TestWithFiltering(t *testing.T) {
 func TestWithLengthValidator(t *testing.T) {
 	opt := filter.WithLengthValidator()
 	h := opt(func(_ []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
-		return []heartbeat.Result{}, errors.New("this will should never be called")
+		return []heartbeat.Result{}, errors.New("this should never be called")
 	})
 
 	result, err := h([]heartbeat.Heartbeat{})


### PR DESCRIPTION
This PR removes unused error response from `WithSSLCertPool` option.