### PR TITLE
Make single point of exit

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,9 +1,12 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
+	"os"
 
 	"github.com/wakatime/wakatime-cli/pkg/api"
+	"github.com/wakatime/wakatime-cli/pkg/exitcode"
 	"github.com/wakatime/wakatime-cli/pkg/offline"
 
 	log "github.com/sirupsen/logrus"
@@ -25,8 +28,20 @@ func NewRootCMD() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "wakatime-cli",
 		Short: "Command line interface used by all WakaTime text editor plugins.",
-		Run: func(cmd *cobra.Command, _ []string) {
-			Run(cmd, v)
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := RunE(cmd, v); err != nil {
+				var errexitcode exitcode.Err
+
+				if errors.As(err, &errexitcode) {
+					os.Exit(errexitcode.Code)
+				}
+
+				os.Exit(exitcode.ErrGeneric)
+			}
+
+			os.Exit(exitcode.Success)
+
+			return nil
 		},
 	}
 

--- a/pkg/exitcode/exitcode.go
+++ b/pkg/exitcode/exitcode.go
@@ -1,5 +1,7 @@
 package exitcode
 
+import "strconv"
+
 const (
 	// Success is used when a heartbeat was sent successfully.
 	Success = 0
@@ -18,3 +20,13 @@ const (
 	// ErrBackoff is used when sending heartbeats postponed because we're currently rate limited.
 	ErrBackoff = 112
 )
+
+// Err represents a type response for exit code errors. A Success response is also wrapped in this type.
+type Err struct {
+	Code int
+}
+
+// Error method to implement error interface.
+func (e Err) Error() string {
+	return strconv.Itoa(e.Code)
+}


### PR DESCRIPTION
This PR removes multiple `os.Exit()` calls in order to have it once. It makes easier to control how it returns the exit code by wrapping them in `exitcode.Err` struct. Any successful response should be returned as nil error. 

It replaces the `Run` func in Cobra by `RunE` to have the response error outside "internal" scope.