### PR TITLE
Fix status bar today when output json missing categories

### DIFF
--- a/pkg/summary/summary.go
+++ b/pkg/summary/summary.go
@@ -179,7 +179,7 @@ func RenderToday(summary *Summary, hideCategories bool, out output.Output) (stri
 		}
 
 		s := simplified{
-			Text:            summary.Data.GrandTotal.Text,
+			Text:            getText(summary, hideCategories),
 			HasTeamFeatures: summary.HasTeamFeatures,
 		}
 
@@ -191,8 +191,12 @@ func RenderToday(summary *Summary, hideCategories bool, out output.Output) (stri
 		return string(data), nil
 	}
 
+	return getText(summary, hideCategories), nil
+}
+
+func getText(summary *Summary, hideCategories bool) string {
 	if len(summary.Data.Categories) < 2 || hideCategories {
-		return summary.Data.GrandTotal.Text, nil
+		return summary.Data.GrandTotal.Text
 	}
 
 	var outputs []string
@@ -200,5 +204,5 @@ func RenderToday(summary *Summary, hideCategories bool, out output.Output) (stri
 		outputs = append(outputs, fmt.Sprintf("%s %s", category.Text, category.Name))
 	}
 
-	return strings.Join(outputs, ", "), nil
+	return strings.Join(outputs, ", ")
 }

--- a/pkg/summary/summary_test.go
+++ b/pkg/summary/summary_test.go
@@ -2,6 +2,7 @@ package summary_test
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/wakatime/wakatime-cli/pkg/output"
@@ -35,7 +36,7 @@ func TestRenderToday(t *testing.T) {
 			rendered, err := summary.RenderToday(testSummary(), false, test.Output)
 			require.NoError(t, err)
 
-			assert.Equal(t, test.Expected, rendered)
+			assert.Equal(t, strings.TrimSpace(test.Expected), strings.TrimSpace(rendered))
 		})
 	}
 }

--- a/pkg/summary/testdata/statusbar_today_simplified.json
+++ b/pkg/summary/testdata/statusbar_today_simplified.json
@@ -1,1 +1,1 @@
-{"text":"2 hrs 17 mins","has_team_features":true}
+{"text":"2 hrs 17 mins Coding, 7 secs Debugging","has_team_features":true}


### PR DESCRIPTION
When `status_bar_hide_categories = false` (the default) we should output today's time broken down by category, unless there's only 1 category. It was correct with `--output text` but broken when `--output json`.
