### PR TITLE
Fix race condition in test

### DIFF
--- a/cmd/heartbeat/heartbeat_test.go
+++ b/cmd/heartbeat/heartbeat_test.go
@@ -137,10 +137,10 @@ func TestSendHeartbeats_RateLimited(t *testing.T) {
 		numCalls++
 	})
 
-	tmpFile, err := os.CreateTemp(t.TempDir(), "wakatime")
+	tmpFile, err := os.CreateTemp(t.TempDir(), "wakatime-internal-config")
 	require.NoError(t, err)
 
-	offlineQueueFile, err := os.CreateTemp(t.TempDir(), "")
+	offlineQueueFile, err := os.CreateTemp(t.TempDir(), "offline-queue-file")
 	require.NoError(t, err)
 
 	v := viper.New()

--- a/cmd/params/params_test.go
+++ b/cmd/params/params_test.go
@@ -2629,12 +2629,10 @@ func TestLoadHeartbeatParams_ExtraHeartbeats_StdinReadOnlyOnce(t *testing.T) {
 	data, err := os.ReadFile("testdata/extra_heartbeats.json")
 	require.NoError(t, err)
 
-	go func() {
-		_, err := w.Write(data)
-		require.NoError(t, err)
+	_, err = w.Write(data)
+	require.NoError(t, err)
 
-		w.Close()
-	}()
+	w.Close()
 
 	v := viper.New()
 	v.Set("entity", "/path/to/file")
@@ -2656,12 +2654,10 @@ func TestLoadHeartbeatParams_ExtraHeartbeats_StdinReadOnlyOnce(t *testing.T) {
 	data, err = os.ReadFile("testdata/extra_heartbeats_with_string_values.json")
 	require.NoError(t, err)
 
-	go func() {
-		_, err := w.Write(data)
-		require.NoError(t, err)
+	_, err = w.Write(data)
+	require.NoError(t, err)
 
-		w.Close()
-	}()
+	w.Close()
 
 	os.Stdin = r
 


### PR DESCRIPTION
Fixes test error:

```
Run make test
  make test
  shell: /usr/bin/bash -e {0}
  env:
    GO_VERSION_FILE: go.mod
    CHECK_LATEST: true
    TEST_VERSION: <local-build>
go test -race -covermode=atomic -coverprofile=coverage.out ./...
	github.com/wakatime/wakatime-cli		coverage: 0.0% of statements
	github.com/wakatime/wakatime-cli/cmd/api		coverage: 0.0% of statements
ok  	github.com/wakatime/wakatime-cli/cmd	1.607s	coverage: 3[2](https://github.com/wakatime/wakatime-cli/actions/runs/10142317404/job/28041372963#step:5:2).0% of statements
ok  	github.com/wakatime/wakatime-cli/cmd/configread	1.016s	coverage: 68.4% of statements
ok  	github.com/wakatime/wakatime-cli/cmd/configwrite	1.015s	coverage: [3](https://github.com/wakatime/wakatime-cli/actions/runs/10142317404/job/28041372963#step:5:3)2.5% of statements
	github.com/wakatime/wakatime-cli/cmd/offline		coverage: 0.0% of statements
ok  	github.com/wakatime/wakatime-cli/cmd/fileexperts	1.399s	coverage: [4](https://github.com/wakatime/wakatime-cli/actions/runs/10142317404/job/28041372963#step:5:4)0.3% of statements
ok  	github.com/wakatime/wakatime-cli/cmd/heartbeat	1.8[5](https://github.com/wakatime/wakatime-cli/actions/runs/10142317404/job/28041372963#step:5:5)5s	coverage: 64.0% of statements
ok  	github.com/wakatime/wakatime-cli/cmd/logfile	1.019s	coverage: 40.5% of statements
ok  	github.com/wakatime/wakatime-cli/cmd/offlinecount	1.019s	coverage: 18.9% of statements
ok  	github.com/wakatime/wakatime-cli/cmd/offlineprint	1.020s	coverage: 28.[6](https://github.com/wakatime/wakatime-cli/actions/runs/10142317404/job/28041372963#step:5:6)% of statements
ok  	github.com/wakatime/wakatime-cli/cmd/offlinesync	1.461s	coverage: 46.9% of statements
{"caller":"cmd/params/params.go:[7](https://github.com/wakatime/wakatime-cli/actions/runs/10142317404/job/28041372963#step:5:7)76","func":"params.parseExtraHeartbeats","level":"debug","message":"skipping extra heartbeats, as no data was provided","now":"2024-07-29T10:10:54Z","os/arch":"unset/unset","version":"unset"}
{"caller":"cmd/params/params.go:4[8](https://github.com/wakatime/wakatime-cli/actions/runs/10142317404/job/28041372963#step:5:9)6","func":"params.loadFilterParams","level":"warning","message":"failed to compile exclude regex pattern \"(?i)[\"","now":"2024-07-2[9](https://github.com/wakatime/wakatime-cli/actions/runs/10142317404/job/28041372963#step:5:10)T10:10:54Z","os/arch":"unset/unset","version":"unset"}
{"caller":"cmd/params/params.go:506","func":"params.loadFilterParams","level":"warning","message":"failed to compile include regex pattern \"(?i)[\"","now":"2024-07-29T[10](https://github.com/wakatime/wakatime-cli/actions/runs/10142317404/job/28041372963#step:5:11):10:54Z","os/arch":"unset/unset","version":"unset"}
{"caller":"cmd/params/params.go:650","func":"params.LoadOfflineParams","level":"warning","message":"argument --heartbeat-rate-limit-seconds must be zero or a positive integer number, got -1","now":"2024-07-29T10:10:54Z","os/arch":"unset/unset","version":"unset"}
{"caller":"cmd/params/params.go:668","func":"params.LoadOfflineParams","level":"warning","message":"failed to parse heartbeats_last_sent_at: parsing time \"2021-08-30\" as \"2006-01-02T15:04:05Z07:00\": cannot parse \"\" as \"T\"","now":"2024-07-29T10:10:54Z","os/arch":"unset/unset","version":"unset"}
{"caller":"cmd/params/params.go:657","func":"params.LoadOfflineParams","level":"warning","message":"argument --sync-offline-activity must be zero or a positive integer number, got -1","now":"2024-07-29T10:10:54Z","os/arch":"unset/unset","version":"unset"}
{"caller":"cmd/params/params.go:335","func":"params.LoadAPIKey","level":"debug","message":"loaded api key from vault","now":"2024-07-29T10:10:54Z","os/arch":"unset/unset","version":"unset"}
{"caller":"cmd/params/params.go:346","func":"params.LoadAPIKey","level":"debug","message":"loaded api key from env var","now":"2024-07-29T10:10:54Z","os/arch":"unset/unset","version":"unset"}
{"caller":"cmd/params/params.go:230","func":"params.LoadAPIParams","level":"warning","message":"failed to parse backoff_at: parsing time \"2021-08-30\" as \"2006-01-02T15:04:05Z07:00\": cannot parse \"\" as \"T\"","now":"2024-07-29T10:10:54Z","os/arch":"unset/unset","version":"unset"}
==================
WARNING: DATA RACE
Write at 0x00c00004e860 by goroutine 256:
  github.com/wakatime/wakatime-cli/cmd/params_test.TestLoadHeartbeatParams_ExtraHeartbeats_StdinReadOnlyOnce()
      /home/runner/work/wakatime-cli/wakatime-cli/cmd/params/params_test.go:2653 +0x6d6
  testing.tRunner()
      /opt/hostedtoolcache/go/1.22.5/x64/src/testing/testing.go:1689 +0x21e
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.22.5/x64/src/testing/testing.go:1742 +0x44

Previous read at 0x00c00004e860 by goroutine 257:
  github.com/wakatime/wakatime-cli/cmd/params_test.TestLoadHeartbeatParams_ExtraHeartbeats_StdinReadOnlyOnce.func3()
      /home/runner/work/wakatime-cli/wakatime-cli/cmd/params/params_test.go:2636 +0xa4

Goroutine 256 (running) created at:
  testing.(*T).Run()
      /opt/hostedtoolcache/go/1.22.5/x64/src/testing/testing.go:1742 +0x825
  testing.runTests.func1()
      /opt/hostedtoolcache/go/1.22.5/x64/src/testing/testing.go:2161 +0x85
  testing.tRunner()
      /opt/hostedtoolcache/go/1.22.5/x64/src/testing/testing.go:1689 +0x21e
  testing.runTests()
      /opt/hostedtoolcache/go/1.22.5/x64/src/testing/testing.go:2159 +0x8be
  testing.(*M).Run()
      /opt/hostedtoolcache/go/1.22.5/x64/src/testing/testing.go:2027 +0xf17
  main.main()
      _testmain.go:377 +0x2e4

Goroutine 257 (finished) created at:
  github.com/wakatime/wakatime-cli/cmd/params_test.TestLoadHeartbeatParams_ExtraHeartbeats_StdinReadOnlyOnce()
      /home/runner/work/wakatime-cli/wakatime-cli/cmd/params/params_test.go:2632 +0x464
  testing.tRunner()
      /opt/hostedtoolcache/go/1.22.5/x64/src/testing/testing.go:1689 +0x21e
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.22.5/x64/src/testing/testing.go:1742 +0x44
==================
--- FAIL: TestLoadHeartbeatParams_ExtraHeartbeats_StdinReadOnlyOnce (0.00s)
    testing.go:1398: race detected during execution of test
FAIL
coverage: 84.9% of statements
FAIL	github.com/wakatime/wakatime-cli/cmd/params	0.[11](https://github.com/wakatime/wakatime-cli/actions/runs/10142317404/job/28041372963#step:5:12)6s
ok  	github.com/wakatime/wakatime-cli/cmd/today	1.352s	coverage: 46.7% of statements
ok  	github.com/wakatime/wakatime-cli/cmd/todaygoal	1.314s	coverage: 49.1% of statements
	github.com/wakatime/wakatime-cli/pkg/diagnostic		coverage: 0.0% of statements
	github.com/wakatime/wakatime-cli/pkg/exitcode		coverage: 0.0% of statements
ok  	github.com/wakatime/wakatime-cli/pkg/api	2.675s	coverage: 69.0% of statements
ok  	github.com/wakatime/wakatime-cli/pkg/apikey	1.0[12](https://github.com/wakatime/wakatime-cli/actions/runs/10142317404/job/28041372963#step:5:13)s	coverage: 35.7% of statements
ok  	github.com/wakatime/wakatime-cli/pkg/backoff	1.025s	coverage: 45.7% of statements
ok  	github.com/wakatime/wakatime-cli/pkg/deps	1.709s	coverage: 83.6% of statements
ok  	github.com/wakatime/wakatime-cli/pkg/doctype	1.010s	coverage: 77.8% of statements
ok  	github.com/wakatime/wakatime-cli/pkg/file	1.0[13](https://github.com/wakatime/wakatime-cli/actions/runs/10142317404/job/28041372963#step:5:14)s	coverage: 100.0% of statements
ok  	github.com/wakatime/wakatime-cli/pkg/fileexperts	1.0[14](https://github.com/wakatime/wakatime-cli/actions/runs/10142317404/job/28041372963#step:5:15)s	coverage: 47.8% of statements
ok  	github.com/wakatime/wakatime-cli/pkg/filestats	1.020s	coverage: 43.4% of statements
ok  	github.com/wakatime/wakatime-cli/pkg/filter	1.018s	coverage: 56.8% of statements
ok  	github.com/wakatime/wakatime-cli/pkg/goal	1.011s	coverage: 90.0% of statements
	github.com/wakatime/wakatime-cli/pkg/log		coverage: 0.0% of statements
	github.com/wakatime/wakatime-cli/pkg/metrics		coverage: 0.0% of statements
ok  	github.com/wakatime/wakatime-cli/pkg/heartbeat	2.879s	coverage: 96.5% of statements
ok  	github.com/wakatime/wakatime-cli/pkg/ini	1.027s	coverage: 58.9% of statements
ok  	github.com/wakatime/wakatime-cli/pkg/language	2.196s	coverage: 80.9% of statements
ok  	github.com/wakatime/wakatime-cli/pkg/lexer	3.937s	coverage: 49.9% of statements
ok  	github.com/wakatime/wakatime-cli/pkg/offline	1.393s	coverage: 65.3% of statements
ok  	github.com/wakatime/wakatime-cli/pkg/output	1.012s	coverage: 90.0% of statements
ok  	github.com/wakatime/wakatime-cli/pkg/project	1.184s	coverage: 78.7% of statements
ok  	github.com/wakatime/wakatime-cli/pkg/regex	1.0[16](https://github.com/wakatime/wakatime-cli/actions/runs/10142317404/job/28041372963#step:5:17)s	coverage: 48.1% of statements
	github.com/wakatime/wakatime-cli/pkg/system		coverage: 0.0% of statements
?   	github.com/wakatime/wakatime-cli/pkg/version	[no test files]
ok  	github.com/wakatime/wakatime-cli/pkg/remote	1.566s	coverage: 68.2% of statements
?   	github.com/wakatime/wakatime-cli/pkg/wakaerror	[no test files]
ok  	github.com/wakatime/wakatime-cli/pkg/shebang	1.013s	coverage: 85.7% of statements
ok  	github.com/wakatime/wakatime-cli/pkg/summary	1.012s	coverage: 85.7% of statements
ok  	github.com/wakatime/wakatime-cli/pkg/vipertools	1.012s	coverage: 100.0% of statements
ok  	github.com/wakatime/wakatime-cli/pkg/windows	3.036s	coverage: 85.1% of statements
ok  	github.com/wakatime/wakatime-cli/pkg/xml	1.011s	coverage: 77.8% of statements
FAIL
make: *** [Makefile:163: test] Error 1
Error: Process completed with exit code 2.
```