### PR TITLE
Upgrade goInfo to v0.1.0-wakatime.9 for Windows platform detection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -57,4 +57,4 @@ require (
 
 replace github.com/alecthomas/chroma/v2 => github.com/gandarez/chroma/v2 v2.9.1-wakatime.1
 
-replace github.com/matishsiao/goInfo => github.com/wakatime/goInfo v0.1.0-wakatime.8
+replace github.com/matishsiao/goInfo => github.com/wakatime/goInfo v0.1.0-wakatime.9

--- a/go.sum
+++ b/go.sum
@@ -270,6 +270,8 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/wakatime/goInfo v0.1.0-wakatime.8 h1:MgyeRnCkynEmUxLKXnYUAP5Dd+vhKxhqg6Nx1PdAZy4=
 github.com/wakatime/goInfo v0.1.0-wakatime.8/go.mod h1:aEt7p9Rvh67BYApmZwNDPpgircTO2kgdmDUoF/1QmwA=
+github.com/wakatime/goInfo v0.1.0-wakatime.9 h1:QkFBcdCcUwFb2CxacFdt4I4aVPcJRY7nXh0sq1gqu3o=
+github.com/wakatime/goInfo v0.1.0-wakatime.9/go.mod h1:aEt7p9Rvh67BYApmZwNDPpgircTO2kgdmDUoF/1QmwA=
 github.com/yookoala/realpath v1.0.0 h1:7OA9pj4FZd+oZDsyvXWQvjn5oBdcHRTV44PpdMSuImQ=
 github.com/yookoala/realpath v1.0.0/go.mod h1:gJJMA9wuX7AcqLy1+ffPatSCySA1FQ2S8Ya9AIoYBpE=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
Before:

`wakatime/v1.98.3 (windows-10.0.22631.4037-unknown) go1.22.5 vscode/1.92.2 vscode-wakatime/24.6.1`

After:

`wakatime/v1.98.3 (windows-10.0.22631.4037-x86_64) go1.22.5 vscode/1.92.2 vscode-wakatime/24.6.1`