### PR TITLE
Bump Chroma to v2.14.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.5
 require (
 	github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358
 	github.com/alecthomas/assert v1.0.0
-	github.com/alecthomas/chroma/v2 v2.13.0
+	github.com/alecthomas/chroma/v2 v2.14.0
 	github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964
 	github.com/dlclark/regexp2 v1.11.0
 	github.com/gandarez/go-olson-timezone v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -42,10 +42,10 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/alecthomas/assert v1.0.0 h1:3XmGh/PSuLzDbK3W2gUbRXwgW5lqPkuqvRgeQ30FI5o=
 github.com/alecthomas/assert v1.0.0/go.mod h1:va/d2JC+M7F6s+80kl/R3G7FUiW6JzUO+hPhLyJ36ZY=
-github.com/alecthomas/assert/v2 v2.6.0 h1:o3WJwILtexrEUk3cUVal3oiQY2tfgr/FHWiz/v2n4FU=
-github.com/alecthomas/assert/v2 v2.6.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
-github.com/alecthomas/chroma/v2 v2.13.0 h1:VP72+99Fb2zEcYM0MeaWJmV+xQvz5v5cxRHd+ooU1lI=
-github.com/alecthomas/chroma/v2 v2.13.0/go.mod h1:BUGjjsD+ndS6eX37YgTchSEG+Jg9Jv1GiZs9sqPqztk=
+github.com/alecthomas/assert/v2 v2.7.0 h1:QtqSACNS3tF7oasA8CU6A6sXZSBDqnm7RfpLl9bZqbE=
+github.com/alecthomas/assert/v2 v2.7.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
+github.com/alecthomas/chroma/v2 v2.14.0 h1:R3+wzpnUArGcQz7fCETQBzO5n9IMNi13iIs46aU4V9E=
+github.com/alecthomas/chroma/v2 v2.14.0/go.mod h1:QolEbTfmUHIMVpBqxeDnNBj2uoeI4EbYP4i6n68SG4I=
 github.com/alecthomas/colour v0.1.0 h1:nOE9rJm6dsZ66RGWYSFrXw461ZIt9A6+nHgL7FRrDUk=
 github.com/alecthomas/colour v0.1.0/go.mod h1:QO9JBoKquHd+jz9nshCh40fOfO+JzsoXy8qTHF68zU0=
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=

--- a/pkg/heartbeat/language.go
+++ b/pkg/heartbeat/language.go
@@ -563,6 +563,8 @@ const (
 	LanguageGitAttributes
 	// LanguageGitConfig represents the Git Config programming language.
 	LanguageGitConfig
+	// LanguageGleam represents the Gleam programming language.
+	LanguageGleam
 	// LanguageGLSL represents the GLSL programming language.
 	LanguageGLSL
 	// LanguageGlyph represents the Glyph programming language.
@@ -1871,6 +1873,7 @@ const (
 	languageGitStr                         = "Git"
 	languageGitAttributesStr               = "Git Attributes"
 	languageGitConfigStr                   = "Git Config"
+	languageGleamStr                       = "Gleam"
 	languageGLSLStr                        = "GLSL"
 	languageGlyphStr                       = "Glyph"
 	languageGlyphBitmapStr                 = "Glyph Bitmap Distribution Format"
@@ -3002,6 +3005,8 @@ func ParseLanguage(s string) (Language, bool) {
 		return LanguageGitAttributes, true
 	case normalizeString(languageGitConfigStr):
 		return LanguageGitConfig, true
+	case normalizeString(languageGleamStr):
+		return LanguageGleam, true
 	case normalizeString(languageGLSLStr):
 		return LanguageGLSL, true
 	case normalizeString(languageGlyphStr):
@@ -4708,6 +4713,8 @@ func (l Language) String() string {
 		return languageGitAttributesStr
 	case LanguageGitConfig:
 		return languageGitConfigStr
+	case LanguageGleam:
+		return languageGleamStr
 	case LanguageGLSL:
 		return languageGLSLStr
 	case LanguageGlyph:

--- a/pkg/heartbeat/language_test.go
+++ b/pkg/heartbeat/language_test.go
@@ -290,6 +290,7 @@ func languageTests() map[string]heartbeat.Language {
 		"Git":                              heartbeat.LanguageGit,
 		"Git Attributes":                   heartbeat.LanguageGitAttributes,
 		"Git Config":                       heartbeat.LanguageGitConfig,
+		"Gleam":                            heartbeat.LanguageGleam,
 		"GLSL":                             heartbeat.LanguageGLSL,
 		"Glyph":                            heartbeat.LanguageGlyph,
 		"Glyph Bitmap Distribution Format": heartbeat.LanguageGlyphBitmap,


### PR DESCRIPTION
This PR bumps Chroma to v2.14.0 and does:
* Adds `Gleam` lexer as supported by the cli.