### PR TITLE
Support nested heartbeat response status in 2xx range

### DIFF
--- a/pkg/api/heartbeat.go
+++ b/pkg/api/heartbeat.go
@@ -135,7 +135,7 @@ func parseHeartbeatResponse(data []json.RawMessage) (heartbeat.Result, error) {
 		return heartbeat.Result{}, fmt.Errorf("failed to parse json status: %s", err)
 	}
 
-	if result.Status >= http.StatusBadRequest {
+	if result.Status < http.StatusOK || result.Status > 299 {
 		resultErrors, err := parseHeartbeatResponseError(data[0])
 		if err != nil {
 			return heartbeat.Result{}, fmt.Errorf("failed to parse result errors: %s", err)

--- a/pkg/offline/offline.go
+++ b/pkg/offline/offline.go
@@ -218,8 +218,7 @@ func handleResults(filepath string, results []heartbeat.Result, hh []heartbeat.H
 			continue
 		}
 
-		if result.Status != http.StatusCreated &&
-			result.Status != http.StatusAccepted {
+		if result.Status < http.StatusOK || result.Status > 299 {
 			withInvalidStatus = append(withInvalidStatus, hh[n])
 		}
 	}


### PR DESCRIPTION
The HTTP response needs 201 or 202 because some proxies or other network configurations always return 200 status even for failed requests that don't reach the WakaTime API. Because the WakaTime API never responds to POST heartbeats with 200 status, we want to treat 200 status as an error and save the heartbeats to the local offline db.

But for the nested JSON array in the response content we can accept any 2xx status code.