### PR TITLE
Prevent crash when loading zoneinfo on Windows

### DIFF
--- a/cmd/params/params.go
+++ b/cmd/params/params.go
@@ -225,7 +225,7 @@ func LoadAPIParams(v *viper.Viper) (API, error) {
 
 	backoffAtStr := vipertools.GetString(v, "internal.backoff_at")
 	if backoffAtStr != "" {
-		parsed, err := time.Parse(ini.DateFormat, backoffAtStr)
+		parsed, err := safeTimeParse(ini.DateFormat, backoffAtStr)
 		// nolint:gocritic
 		if err != nil {
 			log.Warnf("failed to parse backoff_at: %s", err)
@@ -666,7 +666,7 @@ func LoadOfflineParams(v *viper.Viper) Offline {
 
 	lastSentAtStr := vipertools.GetString(v, "internal.heartbeats_last_sent_at")
 	if lastSentAtStr != "" {
-		parsed, err := time.Parse(ini.DateFormat, lastSentAtStr)
+		parsed, err := safeTimeParse(ini.DateFormat, lastSentAtStr)
 		// nolint:gocritic
 		if err != nil {
 			log.Warnf("failed to parse heartbeats_last_sent_at: %s", err)
@@ -718,6 +718,16 @@ func LoadStatusBarParams(v *viper.Viper) (StatusBar, error) {
 		HideCategories: hideCategories,
 		Output:         out,
 	}, nil
+}
+
+func safeTimeParse(format string, s string) (parsed time.Time, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("time.Parse panic: %v", r)
+		}
+	}()
+
+	return time.Parse(format, s)
 }
 
 func readAPIKeyFromCommand(cmdStr string) (string, error) {

--- a/cmd/params/params_internal_test.go
+++ b/cmd/params/params_internal_test.go
@@ -3,7 +3,9 @@ package params
 import (
 	"regexp"
 	"testing"
+	"time"
 
+	"github.com/wakatime/wakatime-cli/pkg/ini"
 	"github.com/wakatime/wakatime-cli/pkg/regex"
 
 	"github.com/stretchr/testify/assert"
@@ -56,6 +58,38 @@ func TestParseBoolOrRegexList(t *testing.T) {
 			require.NoError(t, err)
 
 			assert.Equal(t, test.Expected, regex)
+		})
+	}
+}
+
+func TestSafeTimeParse(t *testing.T) {
+	parsed, err := safeTimeParse(ini.DateFormat, "2024-01-13T13:35:58Z")
+	require.NoError(t, err)
+
+	assert.Equal(t, time.Date(2024, 1, 13, 13, 35, 58, 0, time.UTC), parsed)
+}
+
+func TestSafeTimeParse_Err(t *testing.T) {
+	tests := map[string]struct {
+		Input    string
+		Expected string
+	}{
+		"empty string": {
+			Input:    "",
+			Expected: `parsing time "" as "2006-01-02T15:04:05Z07:00": cannot parse "" as "2006"`,
+		},
+		"invalid time": {
+			Input:    "invalid",
+			Expected: `parsing time "invalid" as "2006-01-02T15:04:05Z07:00": cannot parse "invalid" as "2006"`,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			parsed, err := safeTimeParse(ini.DateFormat, test.Input)
+			require.Equal(t, time.Time{}, parsed)
+
+			assert.EqualError(t, err, test.Expected)
 		})
 	}
 }


### PR DESCRIPTION
`Failed to load advapi32.dll: Invalid access to memory location.`

Sometimes loading zoneinfo on Windows causes a panic, not sure why but it's best to log the error and continue sending heartbeats instead of crashing.

<details><summary>Error Stacktrace</summary>

```
goroutine 1 [running]:
runtime/debug.Stack()
C:/hostedtoolcache/windows/go/1.22.5/x64/src/runtime/debug/stack.go:24 +0x5e
github.com/wakatime/wakatime-cli/cmd.runCmd.func1()
D:/a/wakatime-cli/wakatime-cli/cmd/run.go:297 +0x148
panic({0x1321320?, 0xc000041470?})
C:/hostedtoolcache/windows/go/1.22.5/x64/src/runtime/panic.go:770 +0x132
syscall.(*LazyProc).mustFind(...)
C:/hostedtoolcache/windows/go/1.22.5/x64/src/syscall/dll_windows.go:269
syscall.(*LazyProc).Addr(...)
C:/hostedtoolcache/windows/go/1.22.5/x64/src/syscall/dll_windows.go:276
syscall.RegOpenKeyEx(0x80000002, 0x37?, 0x0, 0x9, 0xc00006e000?)
C:/hostedtoolcache/windows/go/1.22.5/x64/src/syscall/zsyscall_windows.go:317 +0xae
internal/syscall/windows/registry.OpenKey(0x80000002, {0x13f8e95?, 0x1b1a900?}, 0x9)
C:/hostedtoolcache/windows/go/1.22.5/x64/src/internal/syscall/windows/registry/key.go:84 +0x66
time.toEnglishName({0xc00017b1d0, 0x12}, {0xc0001db400, 0xf})
C:/hostedtoolcache/windows/go/1.22.5/x64/src/time/zoneinfo_windows.go:59 +0x73
time.abbrev(0xc0004ac374)
C:/hostedtoolcache/windows/go/1.22.5/x64/src/time/zoneinfo_windows.go:96 +0xab
time.initLocalFromTZI(0xc0004ac374)
C:/hostedtoolcache/windows/go/1.22.5/x64/src/time/zoneinfo_windows.go:148 +0xbd
time.initLocal()
C:/hostedtoolcache/windows/go/1.22.5/x64/src/time/zoneinfo_windows.go:236 +0x8f
sync.(*Once).doSlow(0x12df6c0?, 0xc0004ac530?)
C:/hostedtoolcache/windows/go/1.22.5/x64/src/sync/once.go:74 +0xc2
sync.(*Once).Do(...)
C:/hostedtoolcache/windows/go/1.22.5/x64/src/sync/once.go:65
time.(*Location).get(0x1b19720)
C:/hostedtoolcache/windows/go/1.22.5/x64/src/time/zoneinfo.go:96 +0x45
time.(*Location).lookup(0x0?, 0x670688a8)
C:/hostedtoolcache/windows/go/1.22.5/x64/src/time/zoneinfo.go:150 +0x1c
time.parseRFC3339[...]({0xc0000fce21?, 0xc0000fce21?}, 0x1b19720?)
C:/hostedtoolcache/windows/go/1.22.5/x64/src/time/format_rfc3339.go:146 +0x556
time.Parse({0x13de194, 0x19}, {0xc0000fce21, 0x19})
C:/hostedtoolcache/windows/go/1.22.5/x64/src/time/format.go:1010 +0xbb
github.com/wakatime/wakatime-cli/cmd/params.LoadOfflineParams(0xc00006f880)
D:/a/wakatime-cli/wakatime-cli/cmd/params/params.go:669 +0x2b6
github.com/wakatime/wakatime-cli/cmd/heartbeat.LoadParams(_)
D:/a/wakatime-cli/wakatime-cli/cmd/heartbeat/heartbeat.go:184 +0x250
github.com/wakatime/wakatime-cli/cmd/heartbeat.SendHeartbeats(0xc00006f880, {0xc00002eff0, 0x2f})
D:/a/wakatime-cli/wakatime-cli/cmd/heartbeat/heartbeat.go:73 +0x59
github.com/wakatime/wakatime-cli/cmd/heartbeat.Run(0xc00006f880)
```

</details>