### PR TITLE
Inject logger using context

### DIFF
--- a/cmd/configread/configread.go
+++ b/cmd/configread/configread.go
@@ -1,6 +1,7 @@
 package configread
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -18,7 +19,7 @@ type Params struct {
 }
 
 // Run prints the value for the given config key.
-func Run(v *viper.Viper) (int, error) {
+func Run(_ context.Context, v *viper.Viper) (int, error) {
 	output, err := Read(v)
 	if err != nil {
 		return exitcode.ErrConfigFileRead, fmt.Errorf(

--- a/cmd/configwrite/configwrite.go
+++ b/cmd/configwrite/configwrite.go
@@ -1,6 +1,7 @@
 package configwrite
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -19,8 +20,8 @@ type Params struct {
 }
 
 // Run loads wakatime config file and call Write().
-func Run(v *viper.Viper) (int, error) {
-	w, err := ini.NewWriter(v, ini.FilePath)
+func Run(ctx context.Context, v *viper.Viper) (int, error) {
+	w, err := ini.NewWriter(ctx, v, ini.FilePath)
 	if err != nil {
 		return exitcode.ErrConfigFileParse, fmt.Errorf(
 			"failed to parse config file: %s",
@@ -28,7 +29,7 @@ func Run(v *viper.Viper) (int, error) {
 		)
 	}
 
-	if err := Write(v, w); err != nil {
+	if err := Write(ctx, v, w); err != nil {
 		return exitcode.ErrGeneric, fmt.Errorf(
 			"failed to write to config file: %s",
 			err,
@@ -39,13 +40,13 @@ func Run(v *viper.Viper) (int, error) {
 }
 
 // Write writes value(s) to given config key(s) and persist on disk.
-func Write(v *viper.Viper, w ini.Writer) error {
+func Write(ctx context.Context, v *viper.Viper, w ini.Writer) error {
 	params, err := LoadParams(v)
 	if err != nil {
 		return fmt.Errorf("failed to load command parameters: %w", err)
 	}
 
-	return w.Write(params.Section, params.KeyValue)
+	return w.Write(ctx, params.Section, params.KeyValue)
 }
 
 // LoadParams loads needed data from the configuration file.

--- a/cmd/logfile/logfile.go
+++ b/cmd/logfile/logfile.go
@@ -1,6 +1,7 @@
 package logfile
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 
@@ -23,7 +24,7 @@ type Params struct {
 }
 
 // LoadParams loads needed data from the configuration file.
-func LoadParams(v *viper.Viper) (Params, error) {
+func LoadParams(ctx context.Context, v *viper.Viper) (Params, error) {
 	params := Params{
 		Metrics: vipertools.FirstNonEmptyBool(
 			v,
@@ -55,7 +56,7 @@ func LoadParams(v *viper.Viper) (Params, error) {
 		return params, nil
 	}
 
-	folder, err := ini.WakaResourcesDir()
+	folder, err := ini.WakaResourcesDir(ctx)
 	if err != nil {
 		return Params{}, fmt.Errorf("failed getting resource directory: %s", err)
 	}

--- a/cmd/logfile/logfile_test.go
+++ b/cmd/logfile/logfile_test.go
@@ -1,6 +1,7 @@
 package logfile_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -27,6 +28,8 @@ func TestLoadParams(t *testing.T) {
 
 	home, err := os.UserHomeDir()
 	require.NoError(t, err)
+
+	ctx := context.Background()
 
 	tests := map[string]struct {
 		EnvVar             string
@@ -134,7 +137,7 @@ func TestLoadParams(t *testing.T) {
 
 			defer os.Unsetenv("WAKATIME_HOME")
 
-			params, err := logfile.LoadParams(v)
+			params, err := logfile.LoadParams(ctx, v)
 			require.NoError(t, err)
 
 			assert.Equal(t, test.Expected, params)

--- a/cmd/offlinecount/offlinecount.go
+++ b/cmd/offlinecount/offlinecount.go
@@ -1,6 +1,7 @@
 package offlinecount
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/wakatime/wakatime-cli/pkg/exitcode"
@@ -10,8 +11,8 @@ import (
 )
 
 // Run executes the offline-count command.
-func Run(v *viper.Viper) (int, error) {
-	queueFilepath, err := offline.QueueFilepath(v)
+func Run(ctx context.Context, v *viper.Viper) (int, error) {
+	queueFilepath, err := offline.QueueFilepath(ctx, v)
 	if err != nil {
 		return exitcode.ErrGeneric, fmt.Errorf(
 			"failed to load offline queue filepath: %s",
@@ -19,7 +20,7 @@ func Run(v *viper.Viper) (int, error) {
 		)
 	}
 
-	count, err := offline.CountHeartbeats(queueFilepath)
+	count, err := offline.CountHeartbeats(ctx, queueFilepath)
 	if err != nil {
 		fmt.Println(err)
 		return exitcode.ErrGeneric, fmt.Errorf("failed to count offline heartbeats: %w", err)

--- a/cmd/offlinecount/offlinecount_test.go
+++ b/cmd/offlinecount/offlinecount_test.go
@@ -2,6 +2,7 @@ package offlinecount_test
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -41,7 +42,7 @@ func TestOfflineCount_Empty(t *testing.T) {
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 
-	code, err := offlinecount.Run(v)
+	code, err := offlinecount.Run(context.Background(), v)
 	assert.Equal(t, exitcode.Success, code)
 	require.NoError(t, err)
 
@@ -103,7 +104,7 @@ func TestOfflineCount(t *testing.T) {
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 
-	code, err := offlinecount.Run(v)
+	code, err := offlinecount.Run(context.Background(), v)
 
 	outC := make(chan string)
 	// copy the output in a separate goroutine so printing can't block indefinitely

--- a/cmd/offlineprint/offlineprint.go
+++ b/cmd/offlineprint/offlineprint.go
@@ -2,6 +2,7 @@ package offlineprint
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -14,8 +15,8 @@ import (
 )
 
 // Run executes the print-offline-heartbeats command.
-func Run(v *viper.Viper) (int, error) {
-	queueFilepath, err := offline.QueueFilepath(v)
+func Run(ctx context.Context, v *viper.Viper) (int, error) {
+	queueFilepath, err := offline.QueueFilepath(ctx, v)
 	if err != nil {
 		return exitcode.ErrGeneric, fmt.Errorf(
 			"failed to load offline queue filepath: %s",
@@ -23,9 +24,9 @@ func Run(v *viper.Viper) (int, error) {
 		)
 	}
 
-	p := params.LoadOfflineParams(v)
+	p := params.LoadOfflineParams(ctx, v)
 
-	hh, err := offline.ReadHeartbeats(queueFilepath, p.PrintMax)
+	hh, err := offline.ReadHeartbeats(ctx, queueFilepath, p.PrintMax)
 	if err != nil {
 		fmt.Println(err)
 		return exitcode.ErrGeneric, fmt.Errorf("failed to read offline heartbeats: %w", err)

--- a/cmd/offlineprint/offlineprint_test.go
+++ b/cmd/offlineprint/offlineprint_test.go
@@ -2,6 +2,7 @@ package offlineprint_test
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -55,7 +56,7 @@ func TestPrintOfflineHeartbeats(t *testing.T) {
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 
-	code, err := offlineprint.Run(v)
+	code, err := offlineprint.Run(context.Background(), v)
 	require.NoError(t, err)
 
 	outC := make(chan string)
@@ -95,7 +96,7 @@ func TestPrintOfflineHeartbeats_Empty(t *testing.T) {
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 
-	code, err := offlineprint.Run(v)
+	code, err := offlineprint.Run(context.Background(), v)
 	require.NoError(t, err)
 
 	outC := make(chan string)

--- a/cmd/offlinesync/offlinesync_internal_test.go
+++ b/cmd/offlinesync/offlinesync_internal_test.go
@@ -1,6 +1,7 @@
 package offlinesync
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -101,7 +102,7 @@ func TestSyncOfflineActivityLegacy(t *testing.T) {
 	v.Set("sync-offline-activity", 100)
 	v.Set("plugin", plugin)
 
-	err = syncOfflineActivityLegacy(v, f.Name())
+	err = syncOfflineActivityLegacy(context.Background(), v, f.Name())
 	require.NoError(t, err)
 
 	assert.NoFileExists(t, f.Name())

--- a/cmd/offlinesync/offlinesync_test.go
+++ b/cmd/offlinesync/offlinesync_test.go
@@ -1,6 +1,7 @@
 package offlinesync_test
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -108,7 +109,7 @@ func TestRunWithRateLimiting(t *testing.T) {
 	v.Set("sync-offline-activity", 100)
 	v.Set("plugin", plugin)
 
-	code, err := offlinesync.RunWithRateLimiting(v)
+	code, err := offlinesync.RunWithRateLimiting(context.Background(), v)
 	require.NoError(t, err)
 
 	assert.Equal(t, exitcode.Success, code)
@@ -200,7 +201,7 @@ func TestRunWithoutRateLimiting(t *testing.T) {
 	v.Set("sync-offline-activity", 100)
 	v.Set("plugin", plugin)
 
-	code, err := offlinesync.RunWithoutRateLimiting(v)
+	code, err := offlinesync.RunWithoutRateLimiting(context.Background(), v)
 	require.NoError(t, err)
 
 	assert.Equal(t, exitcode.Success, code)
@@ -215,7 +216,7 @@ func TestRunWithRateLimiting_RateLimited(t *testing.T) {
 	v.Set("heartbeat-rate-limit-seconds", 500)
 	v.Set("internal.heartbeats_last_sent_at", time.Now().Add(-time.Minute).Format(time.RFC3339))
 
-	code, err := offlinesync.RunWithRateLimiting(v)
+	code, err := offlinesync.RunWithRateLimiting(context.Background(), v)
 	require.NoError(t, err)
 
 	assert.Equal(t, exitcode.Success, code)
@@ -305,7 +306,7 @@ func TestSyncOfflineActivity(t *testing.T) {
 	v.Set("sync-offline-activity", 100)
 	v.Set("plugin", plugin)
 
-	err = offlinesync.SyncOfflineActivity(v, f.Name())
+	err = offlinesync.SyncOfflineActivity(context.Background(), v, f.Name())
 	require.NoError(t, err)
 
 	assert.Eventually(t, func() bool { return numCalls == 1 }, time.Second, 50*time.Millisecond)
@@ -396,7 +397,7 @@ func TestSyncOfflineActivity_MultipleApiKey(t *testing.T) {
 	v.Set("sync-offline-activity", 100)
 	v.Set("plugin", plugin)
 
-	err = offlinesync.SyncOfflineActivity(v, f.Name())
+	err = offlinesync.SyncOfflineActivity(context.Background(), v, f.Name())
 	require.NoError(t, err)
 
 	assert.Eventually(t, func() bool { return numCalls == 1 }, time.Second, 50*time.Millisecond)

--- a/cmd/params/params_internal_test.go
+++ b/cmd/params/params_internal_test.go
@@ -23,31 +23,31 @@ func TestParseBoolOrRegexList(t *testing.T) {
 		},
 		"false string": {
 			Input:    "false",
-			Expected: []regex.Regex{regexp.MustCompile("a^")},
+			Expected: []regex.Regex{regex.NewRegexpWrap(regexp.MustCompile("a^"))},
 		},
 		"true string": {
 			Input:    "true",
-			Expected: []regex.Regex{regexp.MustCompile(".*")},
+			Expected: []regex.Regex{regex.NewRegexpWrap(regexp.MustCompile(".*"))},
 		},
 		"valid regex": {
 			Input: "\t.?\n\t\n \n\t\twakatime.? \t\n",
 			Expected: []regex.Regex{
-				regexp.MustCompile(".?"),
-				regexp.MustCompile("wakatime.?"),
+				regex.NewRegexpWrap(regexp.MustCompile(".?")),
+				regex.NewRegexpWrap(regexp.MustCompile("wakatime.?")),
 			},
 		},
 		"valid regex with windows style": {
 			Input: "\t.?\r\n\t\t\twakatime.? \t\r\n",
 			Expected: []regex.Regex{
-				regexp.MustCompile(".?"),
-				regexp.MustCompile("wakatime.?"),
+				regex.NewRegexpWrap(regexp.MustCompile(".?")),
+				regex.NewRegexpWrap(regexp.MustCompile("wakatime.?")),
 			},
 		},
 		"valid regex with old mac style": {
 			Input: "\t.?\r\t\t\twakatime.? \t\r",
 			Expected: []regex.Regex{
-				regexp.MustCompile(".?"),
-				regexp.MustCompile("wakatime.?"),
+				regex.NewRegexpWrap(regexp.MustCompile(".?")),
+				regex.NewRegexpWrap(regexp.MustCompile("wakatime.?")),
 			},
 		},
 	}

--- a/cmd/today/today_test.go
+++ b/cmd/today/today_test.go
@@ -1,6 +1,7 @@
 package today_test
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -59,7 +60,7 @@ func TestToday(t *testing.T) {
 	v.Set("api-url", testServerURL)
 	v.Set("plugin", plugin)
 
-	output, err := today.Today(v)
+	output, err := today.Today(context.Background(), v)
 	require.NoError(t, err)
 
 	assert.Equal(t, "10 secs", output)
@@ -83,7 +84,7 @@ func TestToday_ErrApi(t *testing.T) {
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("api-url", testServerURL)
 
-	_, err := today.Today(v)
+	_, err := today.Today(context.Background(), v)
 	require.Error(t, err)
 
 	var errapi api.Err
@@ -116,7 +117,7 @@ func TestToday_ErrAuth(t *testing.T) {
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("api-url", testServerURL)
 
-	_, err := today.Today(v)
+	_, err := today.Today(context.Background(), v)
 	require.Error(t, err)
 
 	var errauth api.ErrAuth
@@ -150,7 +151,7 @@ func TestToday_ErrBadRequest(t *testing.T) {
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("api-url", testServerURL)
 
-	_, err := today.Today(v)
+	_, err := today.Today(context.Background(), v)
 	require.Error(t, err)
 
 	var errbadRequest api.ErrBadRequest
@@ -168,7 +169,7 @@ func TestToday_ErrBadRequest(t *testing.T) {
 
 func TestToday_ErrAuth_UnsetAPIKey(t *testing.T) {
 	v := viper.New()
-	_, err := today.Today(v)
+	_, err := today.Today(context.Background(), v)
 	require.Error(t, err)
 
 	var errauth api.ErrAuth

--- a/cmd/todaygoal/todaygoal_test.go
+++ b/cmd/todaygoal/todaygoal_test.go
@@ -1,6 +1,7 @@
 package todaygoal_test
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -61,7 +62,7 @@ func TestGoal(t *testing.T) {
 	v.Set("plugin", plugin)
 	v.Set("today-goal", "00000000-0000-4000-8000-000000000000")
 
-	output, err := todaygoal.Goal(v)
+	output, err := todaygoal.Goal(context.Background(), v)
 	require.NoError(t, err)
 
 	assert.Equal(t, "3 hrs 23 mins", output)
@@ -88,7 +89,7 @@ func TestGoal_ErrApi(t *testing.T) {
 	v.Set("api-url", testServerURL)
 	v.Set("today-goal", "00000000-0000-4000-8000-000000000000")
 
-	_, err := todaygoal.Goal(v)
+	_, err := todaygoal.Goal(context.Background(), v)
 	require.Error(t, err)
 
 	var errapi api.Err
@@ -124,7 +125,7 @@ func TestGoal_ErrAuth(t *testing.T) {
 	v.Set("api-url", testServerURL)
 	v.Set("today-goal", "00000000-0000-4000-8000-000000000000")
 
-	_, err := todaygoal.Goal(v)
+	_, err := todaygoal.Goal(context.Background(), v)
 	require.Error(t, err)
 
 	var errauth api.ErrAuth
@@ -160,7 +161,7 @@ func TestGoal_ErrBadRequest(t *testing.T) {
 	v.Set("api-url", testServerURL)
 	v.Set("today-goal", "00000000-0000-4000-8000-000000000000")
 
-	_, err := todaygoal.Goal(v)
+	_, err := todaygoal.Goal(context.Background(), v)
 	require.Error(t, err)
 
 	var errbadRequest api.ErrBadRequest
@@ -178,7 +179,7 @@ func TestGoal_ErrBadRequest(t *testing.T) {
 
 func TestGoal_ErrAuth_UnsetAPIKey(t *testing.T) {
 	v := viper.New()
-	_, err := todaygoal.Goal(v)
+	_, err := todaygoal.Goal(context.Background(), v)
 	require.Error(t, err)
 
 	var errauth api.ErrAuth
@@ -198,7 +199,7 @@ func TestLoadParams_GoalID(t *testing.T) {
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("today-goal", "00000000-0000-4000-8000-000000000001")
 
-	params, err := todaygoal.LoadParams(v)
+	params, err := todaygoal.LoadParams(context.Background(), v)
 	require.NoError(t, err)
 
 	assert.Equal(t, "00000000-0000-4000-8000-000000000001", params.GoalID)

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/wakatime/wakatime-cli/pkg/exitcode"
@@ -9,7 +10,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-func runVersion(v *viper.Viper) (int, error) {
+func runVersion(_ context.Context, v *viper.Viper) (int, error) {
 	if v.GetBool("verbose") {
 		fmt.Printf(
 			"wakatime-cli\n  Version: %s\n  Commit: %s\n  Built: %s\n  OS/Arch: %s/%s\n",

--- a/main_test.go
+++ b/main_test.go
@@ -4,6 +4,7 @@ package main_test
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -59,6 +60,8 @@ func testSendHeartbeats(t *testing.T, projectFolder, entity, p string) {
 	apiURL, router, close := setupTestServer()
 	defer close()
 
+	ctx := context.Background()
+
 	var numCalls int
 
 	subfolders := project.CountSlashesInProjectFolder(projectFolder)
@@ -71,7 +74,7 @@ func testSendHeartbeats(t *testing.T, projectFolder, entity, p string) {
 		assert.Equal(t, []string{"application/json"}, req.Header["Accept"])
 		assert.Equal(t, []string{"application/json"}, req.Header["Content-Type"])
 		assert.Equal(t, []string{"Basic MDAwMDAwMDAtMDAwMC00MDAwLTgwMDAtMDAwMDAwMDAwMDAw"}, req.Header["Authorization"])
-		assert.Equal(t, []string{heartbeat.UserAgent("")}, req.Header["User-Agent"])
+		assert.Equal(t, []string{heartbeat.UserAgent(ctx, "")}, req.Header["User-Agent"])
 
 		// check body
 		expectedBodyTpl, err := os.ReadFile("testdata/api_heartbeats_request_template.json")
@@ -86,7 +89,7 @@ func testSendHeartbeats(t *testing.T, projectFolder, entity, p string) {
 			entityPath,
 			p,
 			subfolders,
-			heartbeat.UserAgent(""),
+			heartbeat.UserAgent(ctx, ""),
 		)
 
 		body, err := io.ReadAll(req.Body)
@@ -155,6 +158,8 @@ func TestSendHeartbeats_SecondaryApiKey(t *testing.T) {
 	apiURL, router, close := setupTestServer()
 	defer close()
 
+	ctx := context.Background()
+
 	var numCalls int
 
 	rootPath, _ := filepath.Abs(".")
@@ -168,7 +173,7 @@ func TestSendHeartbeats_SecondaryApiKey(t *testing.T) {
 		assert.Equal(t, []string{"application/json"}, req.Header["Accept"])
 		assert.Equal(t, []string{"application/json"}, req.Header["Content-Type"])
 		assert.Equal(t, []string{"Basic MDAwMDAwMDAtMDAwMC00MDAwLTgwMDAtMDAwMDAwMDAwMDAx"}, req.Header["Authorization"])
-		assert.Equal(t, []string{heartbeat.UserAgent("")}, req.Header["User-Agent"])
+		assert.Equal(t, []string{heartbeat.UserAgent(ctx, "")}, req.Header["User-Agent"])
 
 		// check body
 		expectedBodyTpl, err := os.ReadFile("testdata/api_heartbeats_request_template.json")
@@ -183,7 +188,7 @@ func TestSendHeartbeats_SecondaryApiKey(t *testing.T) {
 			entityPath,
 			"wakatime-cli",
 			subfolders,
-			heartbeat.UserAgent(""),
+			heartbeat.UserAgent(ctx, ""),
 		)
 
 		body, err := io.ReadAll(req.Body)
@@ -246,6 +251,8 @@ func TestSendHeartbeats_ExtraHeartbeats(t *testing.T) {
 	apiURL, router, close := setupTestServer()
 	defer close()
 
+	ctx := context.Background()
+
 	var numCalls int
 
 	router.HandleFunc("/users/current/heartbeats.bulk", func(w http.ResponseWriter, req *http.Request) {
@@ -256,7 +263,7 @@ func TestSendHeartbeats_ExtraHeartbeats(t *testing.T) {
 		assert.Equal(t, []string{"application/json"}, req.Header["Accept"])
 		assert.Equal(t, []string{"application/json"}, req.Header["Content-Type"])
 		assert.Equal(t, []string{"Basic MDAwMDAwMDAtMDAwMC00MDAwLTgwMDAtMDAwMDAwMDAwMDAw"}, req.Header["Authorization"])
-		assert.Equal(t, []string{heartbeat.UserAgent("")}, req.Header["User-Agent"])
+		assert.Equal(t, []string{heartbeat.UserAgent(ctx, "")}, req.Header["User-Agent"])
 
 		var filename string
 
@@ -324,7 +331,7 @@ func TestSendHeartbeats_ExtraHeartbeats(t *testing.T) {
 		"--verbose",
 	)
 
-	offlineCount, err := offline.CountHeartbeats(offlineQueueFile.Name())
+	offlineCount, err := offline.CountHeartbeats(ctx, offlineQueueFile.Name())
 	require.NoError(t, err)
 
 	assert.Equal(t, 1, offlineCount)
@@ -336,6 +343,8 @@ func TestSendHeartbeats_ExtraHeartbeats_SyncLegacyOfflineActivity(t *testing.T) 
 	apiURL, router, close := setupTestServer()
 	defer close()
 
+	ctx := context.Background()
+
 	var numCalls int
 
 	router.HandleFunc("/users/current/heartbeats.bulk", func(w http.ResponseWriter, req *http.Request) {
@@ -346,7 +355,7 @@ func TestSendHeartbeats_ExtraHeartbeats_SyncLegacyOfflineActivity(t *testing.T) 
 		assert.Equal(t, []string{"application/json"}, req.Header["Accept"])
 		assert.Equal(t, []string{"application/json"}, req.Header["Content-Type"])
 		assert.Equal(t, []string{"Basic MDAwMDAwMDAtMDAwMC00MDAwLTgwMDAtMDAwMDAwMDAwMDAw"}, req.Header["Authorization"])
-		assert.Equal(t, []string{heartbeat.UserAgent("")}, req.Header["User-Agent"])
+		assert.Equal(t, []string{heartbeat.UserAgent(ctx, "")}, req.Header["User-Agent"])
 
 		var filename string
 
@@ -454,7 +463,7 @@ func TestSendHeartbeats_ExtraHeartbeats_SyncLegacyOfflineActivity(t *testing.T) 
 
 	assert.NoFileExists(t, offlineQueueFileLegacy.Name())
 
-	offlineCount, err := offline.CountHeartbeats(offlineQueueFile.Name())
+	offlineCount, err := offline.CountHeartbeats(ctx, offlineQueueFile.Name())
 	require.NoError(t, err)
 
 	assert.Zero(t, offlineCount)
@@ -465,6 +474,8 @@ func TestSendHeartbeats_ExtraHeartbeats_SyncLegacyOfflineActivity(t *testing.T) 
 func TestSendHeartbeats_Err(t *testing.T) {
 	apiURL, router, close := setupTestServer()
 	defer close()
+
+	ctx := context.Background()
 
 	var numCalls int
 
@@ -481,7 +492,7 @@ func TestSendHeartbeats_Err(t *testing.T) {
 		assert.Equal(t, []string{"application/json"}, req.Header["Accept"])
 		assert.Equal(t, []string{"application/json"}, req.Header["Content-Type"])
 		assert.Equal(t, []string{"Basic MDAwMDAwMDAtMDAwMC00MDAwLTgwMDAtMDAwMDAwMDAwMDAw"}, req.Header["Authorization"])
-		assert.Equal(t, []string{heartbeat.UserAgent("")}, req.Header["User-Agent"])
+		assert.Equal(t, []string{heartbeat.UserAgent(ctx, "")}, req.Header["User-Agent"])
 
 		// check body
 		expectedBodyTpl, err := os.ReadFile("testdata/api_heartbeats_request_template.json")
@@ -496,7 +507,7 @@ func TestSendHeartbeats_Err(t *testing.T) {
 			entityPath,
 			"wakatime-cli",
 			subfolders,
-			heartbeat.UserAgent(""),
+			heartbeat.UserAgent(ctx, ""),
 		)
 
 		body, err := io.ReadAll(req.Body)
@@ -561,6 +572,8 @@ func TestSendHeartbeats_ErrAuth_InvalidAPIKEY(t *testing.T) {
 	apiURL, router, close := setupTestServer()
 	defer close()
 
+	ctx := context.Background()
+
 	var numCalls int
 
 	router.HandleFunc("/users/current/heartbeats.bulk", func(_ http.ResponseWriter, _ *http.Request) {
@@ -611,7 +624,7 @@ func TestSendHeartbeats_ErrAuth_InvalidAPIKEY(t *testing.T) {
 
 	assert.Empty(t, out)
 
-	count, err := offline.CountHeartbeats(offlineQueueFile.Name())
+	count, err := offline.CountHeartbeats(ctx, offlineQueueFile.Name())
 	require.NoError(t, err)
 
 	assert.Equal(t, 1, count)
@@ -620,6 +633,8 @@ func TestSendHeartbeats_ErrAuth_InvalidAPIKEY(t *testing.T) {
 }
 
 func TestSendHeartbeats_MalformedConfig(t *testing.T) {
+	ctx := context.Background()
+
 	tmpDir := t.TempDir()
 
 	tmpInternalConfigFile, err := os.CreateTemp(tmpDir, "wakatime-internal.cfg")
@@ -650,13 +665,15 @@ func TestSendHeartbeats_MalformedConfig(t *testing.T) {
 
 	assert.Empty(t, out)
 
-	count, err := offline.CountHeartbeats(offlineQueueFile.Name())
+	count, err := offline.CountHeartbeats(ctx, offlineQueueFile.Name())
 	require.NoError(t, err)
 
 	assert.Equal(t, 1, count)
 }
 
 func TestSendHeartbeats_MalformedInternalConfig(t *testing.T) {
+	ctx := context.Background()
+
 	tmpDir := t.TempDir()
 
 	offlineQueueFile, err := os.CreateTemp(tmpDir, "")
@@ -687,7 +704,7 @@ func TestSendHeartbeats_MalformedInternalConfig(t *testing.T) {
 
 	assert.Empty(t, out)
 
-	count, err := offline.CountHeartbeats(offlineQueueFile.Name())
+	count, err := offline.CountHeartbeats(ctx, offlineQueueFile.Name())
 	require.NoError(t, err)
 
 	assert.Equal(t, 1, count)
@@ -702,6 +719,8 @@ func TestFileExperts(t *testing.T) {
 
 	subfolders := project.CountSlashesInProjectFolder(projectFolder)
 
+	ctx := context.Background()
+
 	var numCalls int
 
 	router.HandleFunc("/users/current/file_experts",
@@ -713,7 +732,7 @@ func TestFileExperts(t *testing.T) {
 			assert.Equal(t, []string{"application/json"}, req.Header["Accept"])
 			assert.Equal(t, []string{"application/json"}, req.Header["Content-Type"])
 			assert.Equal(t, []string{"Basic MDAwMDAwMDAtMDAwMC00MDAwLTgwMDAtMDAwMDAwMDAwMDAw"}, req.Header["Authorization"])
-			assert.Equal(t, []string{heartbeat.UserAgent("")}, req.Header["User-Agent"])
+			assert.Equal(t, []string{heartbeat.UserAgent(ctx, "")}, req.Header["User-Agent"])
 
 			// check body
 			expectedBodyTpl, err := os.ReadFile("testdata/api_file_experts_request_template.json")
@@ -777,6 +796,8 @@ func TestTodayGoal(t *testing.T) {
 	apiURL, router, close := setupTestServer()
 	defer close()
 
+	ctx := context.Background()
+
 	var numCalls int
 
 	tmpDir := t.TempDir()
@@ -799,7 +820,7 @@ func TestTodayGoal(t *testing.T) {
 			assert.Equal(t, http.MethodGet, req.Method)
 			assert.Equal(t, []string{"application/json"}, req.Header["Accept"])
 			assert.Equal(t, []string{"Basic MDAwMDAwMDAtMDAwMC00MDAwLTgwMDAtMDAwMDAwMDAwMDAw"}, req.Header["Authorization"])
-			assert.Equal(t, []string{heartbeat.UserAgent("")}, req.Header["User-Agent"])
+			assert.Equal(t, []string{heartbeat.UserAgent(ctx, "")}, req.Header["User-Agent"])
 
 			// write response
 			f, err := os.Open("testdata/api_goals_id_response.json")
@@ -830,6 +851,8 @@ func TestTodaySummary(t *testing.T) {
 	apiURL, router, close := setupTestServer()
 	defer close()
 
+	ctx := context.Background()
+
 	var numCalls int
 
 	tmpDir := t.TempDir()
@@ -851,7 +874,7 @@ func TestTodaySummary(t *testing.T) {
 		assert.Equal(t, http.MethodGet, req.Method)
 		assert.Equal(t, []string{"application/json"}, req.Header["Accept"])
 		assert.Equal(t, []string{"Basic MDAwMDAwMDAtMDAwMC00MDAwLTgwMDAtMDAwMDAwMDAwMDAw"}, req.Header["Authorization"])
-		assert.Equal(t, []string{heartbeat.UserAgent("")}, req.Header["User-Agent"])
+		assert.Equal(t, []string{heartbeat.UserAgent(ctx, "")}, req.Header["User-Agent"])
 
 		// write response
 		f, err := os.Open("testdata/api_statusbar_today_response.json")
@@ -976,6 +999,8 @@ func TestPrintOfflineHeartbeats(t *testing.T) {
 	apiURL, router, close := setupTestServer()
 	defer close()
 
+	ctx := context.Background()
+
 	router.HandleFunc("/users/current/heartbeats.bulk", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 		_, err := io.Copy(w, strings.NewReader("500 error test"))
@@ -1054,7 +1079,7 @@ func TestPrintOfflineHeartbeats(t *testing.T) {
 	offlineHeartbeatStr := fmt.Sprintf(
 		string(offlineHeartbeat),
 		entity, subfolders,
-		heartbeat.UserAgent(""),
+		heartbeat.UserAgent(ctx, ""),
 	)
 
 	assert.Equal(t, offlineHeartbeatStr+"\n", out)
@@ -1062,13 +1087,13 @@ func TestPrintOfflineHeartbeats(t *testing.T) {
 
 func TestUserAgent(t *testing.T) {
 	out := runWakatimeCli(t, &bytes.Buffer{}, "--user-agent")
-	assert.Equal(t, fmt.Sprintf("%s\n", heartbeat.UserAgent("")), out)
+	assert.Equal(t, fmt.Sprintf("%s\n", heartbeat.UserAgent(context.Background(), "")), out)
 }
 
 func TestUserAgentWithPlugin(t *testing.T) {
 	out := runWakatimeCli(t, &bytes.Buffer{}, "--user-agent", "--plugin", "Wakatime/1.0.4")
 
-	assert.Equal(t, fmt.Sprintf("%s\n", heartbeat.UserAgent("Wakatime/1.0.4")), out)
+	assert.Equal(t, fmt.Sprintf("%s\n", heartbeat.UserAgent(context.Background(), "Wakatime/1.0.4")), out)
 }
 
 func TestVersion(t *testing.T) {

--- a/pkg/api/diagnostic.go
+++ b/pkg/api/diagnostic.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -24,10 +25,17 @@ type diagnosticsBody struct {
 }
 
 // SendDiagnostics sends diagnostics to the WakaTime api.
-func (c *Client) SendDiagnostics(plugin string, panicked bool, diagnostics ...diagnostic.Diagnostic) error {
+func (c *Client) SendDiagnostics(
+	ctx context.Context,
+	plugin string,
+	panicked bool,
+	diagnostics ...diagnostic.Diagnostic,
+) error {
+	logger := log.Extract(ctx)
+
 	url := c.baseURL + "/plugins/errors"
 
-	log.Debugf("sending diagnostic data to api at %s", url)
+	logger.Debugf("sending diagnostic data to api at %s", url)
 
 	body := diagnosticsBody{
 		Architecture: version.Arch,
@@ -62,7 +70,7 @@ func (c *Client) SendDiagnostics(plugin string, panicked bool, diagnostics ...di
 
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := c.Do(req)
+	resp, err := c.Do(ctx, req)
 	if err != nil {
 		return Err{Err: fmt.Errorf("failed making request to %q: %s", url, err)}
 	}

--- a/pkg/api/diagnostic_test.go
+++ b/pkg/api/diagnostic_test.go
@@ -1,6 +1,7 @@
 package api_test
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -75,7 +76,7 @@ func TestClient_SendDiagnostics(t *testing.T) {
 	}
 
 	c := api.NewClient(url)
-	err := c.SendDiagnostics("vim", false, diagnostics...)
+	err := c.SendDiagnostics(context.Background(), "vim", false, diagnostics...)
 	require.NoError(t, err)
 
 	assert.Eventually(t, func() bool { return numCalls == 1 }, time.Second, 50*time.Millisecond)

--- a/pkg/api/fileexperts.go
+++ b/pkg/api/fileexperts.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -17,7 +18,9 @@ import (
 // ErrRequest is returned upon request failure with no received response from api.
 // ErrAuth is returned upon receiving a 401 Unauthorized api response.
 // Err is returned on any other api response related error.
-func (c *Client) FileExperts(heartbeats []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+func (c *Client) FileExperts(ctx context.Context, heartbeats []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+	logger := log.Extract(ctx)
+
 	url := c.baseURL + "/users/current/file_experts"
 
 	// change from heartbeat.Heartbeat to fileexpert.Entity
@@ -33,7 +36,7 @@ func (c *Client) FileExperts(heartbeats []heartbeat.Heartbeat) ([]heartbeat.Resu
 		return nil, fmt.Errorf("failed to json encode body: %s", err)
 	}
 
-	log.Debugf("file-experts: %s", string(data))
+	logger.Debugf("file-experts: %s", string(data))
 
 	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(data))
 	if err != nil {
@@ -45,7 +48,7 @@ func (c *Client) FileExperts(heartbeats []heartbeat.Heartbeat) ([]heartbeat.Resu
 	// set auth header here for every request due to multiple api key support
 	setAuthHeader(req, heartbeats[0].APIKey)
 
-	resp, err := c.Do(req)
+	resp, err := c.Do(ctx, req)
 	if err != nil {
 		return nil, Err{Err: fmt.Errorf("failed making request to %q: %s", url, err)}
 	}

--- a/pkg/api/fileexperts_test.go
+++ b/pkg/api/fileexperts_test.go
@@ -1,6 +1,7 @@
 package api_test
 
 import (
+	"context"
 	"errors"
 	"io"
 	"net/http"
@@ -17,6 +18,8 @@ import (
 )
 
 func TestClient_FileExperts(t *testing.T) {
+	ctx := context.Background()
+
 	tests := []int{
 		http.StatusOK,
 		http.StatusAccepted,
@@ -56,7 +59,7 @@ func TestClient_FileExperts(t *testing.T) {
 			})
 
 			c := api.NewClient(url)
-			results, err := c.FileExperts([]heartbeat.Heartbeat{
+			results, err := c.FileExperts(ctx, []heartbeat.Heartbeat{
 				{
 					APIKey:           "00000000-0000-4000-8000-000000000000",
 					Entity:           "/tmp/main.go",
@@ -131,7 +134,7 @@ func TestClient_FileExperts_Err(t *testing.T) {
 	})
 
 	c := api.NewClient(url)
-	_, err := c.FileExperts([]heartbeat.Heartbeat{
+	_, err := c.FileExperts(context.Background(), []heartbeat.Heartbeat{
 		{
 			APIKey:           "00000000-0000-4000-8000-000000000000",
 			Entity:           "/tmp/main.go",
@@ -160,7 +163,7 @@ func TestClient_FileExperts_ErrAuth(t *testing.T) {
 	})
 
 	c := api.NewClient(url)
-	_, err := c.FileExperts([]heartbeat.Heartbeat{
+	_, err := c.FileExperts(context.Background(), []heartbeat.Heartbeat{
 		{
 			APIKey:           "00000000-0000-4000-8000-000000000000",
 			Entity:           "/tmp/main.go",
@@ -189,7 +192,7 @@ func TestClient_FileExperts_ErrBadRequest(t *testing.T) {
 	})
 
 	c := api.NewClient(url)
-	_, err := c.FileExperts([]heartbeat.Heartbeat{
+	_, err := c.FileExperts(context.Background(), []heartbeat.Heartbeat{
 		{
 			APIKey:           "00000000-0000-4000-8000-000000000000",
 			Entity:           "/tmp/main.go",
@@ -207,7 +210,7 @@ func TestClient_FileExperts_ErrBadRequest(t *testing.T) {
 
 func TestClient_FileExperts_InvalidUrl(t *testing.T) {
 	c := api.NewClient("invalid-url")
-	_, err := c.FileExperts([]heartbeat.Heartbeat{
+	_, err := c.FileExperts(context.Background(), []heartbeat.Heartbeat{
 		{
 			APIKey:           "00000000-0000-4000-8000-000000000000",
 			Entity:           "/tmp/main.go",

--- a/pkg/api/goal.go
+++ b/pkg/api/goal.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -14,7 +15,7 @@ import (
 // ErrRequest is returned upon request failure with no received response from api.
 // ErrAuth is returned upon receiving a 401 Unauthorized api response.
 // Err is returned on any other api response related error.
-func (c *Client) Goal(id string) (*goal.Goal, error) {
+func (c *Client) Goal(ctx context.Context, id string) (*goal.Goal, error) {
 	url := c.baseURL + "/users/current/goals/" + id
 
 	req, err := http.NewRequest(http.MethodGet, url, nil)
@@ -24,7 +25,7 @@ func (c *Client) Goal(id string) (*goal.Goal, error) {
 
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := c.Do(req)
+	resp, err := c.Do(ctx, req)
 	if err != nil {
 		return nil, Err{Err: fmt.Errorf("failed to make request to %q: %s", url, err)}
 	}

--- a/pkg/api/goal_test.go
+++ b/pkg/api/goal_test.go
@@ -1,6 +1,7 @@
 package api_test
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -40,7 +41,7 @@ func TestClient_Goal(t *testing.T) {
 		})
 
 	c := api.NewClient(u)
-	goal, err := c.Goal("00000000-0000-4000-8000-000000000000")
+	goal, err := c.Goal(context.Background(), "00000000-0000-4000-8000-000000000000")
 
 	require.NoError(t, err)
 
@@ -65,8 +66,10 @@ func TestClient_GoalWithTimeout(t *testing.T) {
 		})
 
 	opts := []api.Option{api.WithTimeout(20 * time.Millisecond)}
+
 	c := api.NewClient(u, opts...)
-	_, err := c.Goal("00000000-0000-4000-8000-000000000000")
+
+	_, err := c.Goal(context.Background(), "00000000-0000-4000-8000-000000000000")
 	require.Error(t, err)
 
 	errMsg := fmt.Sprintf("error %q does not contain string 'Timeout'", err)
@@ -95,7 +98,8 @@ func TestClient_Goal_Err(t *testing.T) {
 		})
 
 	c := api.NewClient(u)
-	_, err := c.Goal("00000000-0000-4000-8000-000000000000")
+
+	_, err := c.Goal(context.Background(), "00000000-0000-4000-8000-000000000000")
 
 	var apierr api.Err
 
@@ -117,7 +121,8 @@ func TestClient_Goal_ErrAuth(t *testing.T) {
 		})
 
 	c := api.NewClient(u)
-	_, err := c.Goal("00000000-0000-4000-8000-000000000000")
+
+	_, err := c.Goal(context.Background(), "00000000-0000-4000-8000-000000000000")
 
 	var errauth api.ErrAuth
 
@@ -140,7 +145,8 @@ func TestClient_Goal_ErrBadRequest(t *testing.T) {
 		})
 
 	c := api.NewClient(u)
-	_, err := c.Goal("00000000-0000-4000-8000-000000000000")
+
+	_, err := c.Goal(context.Background(), "00000000-0000-4000-8000-000000000000")
 
 	var errbadRequest api.ErrBadRequest
 
@@ -150,7 +156,8 @@ func TestClient_Goal_ErrBadRequest(t *testing.T) {
 
 func TestClient_Goal_ErrInvalidUrl(t *testing.T) {
 	c := api.NewClient("invalid-url")
-	_, err := c.Goal("00000000-0000-4000-8000-000000000000")
+
+	_, err := c.Goal(context.Background(), "00000000-0000-4000-8000-000000000000")
 
 	var apierr api.Err
 

--- a/pkg/api/heartbeat_test.go
+++ b/pkg/api/heartbeat_test.go
@@ -1,6 +1,7 @@
 package api_test
 
 import (
+	"context"
 	"errors"
 	"io"
 	"net/http"
@@ -55,7 +56,7 @@ func TestClient_SendHeartbeats(t *testing.T) {
 			})
 
 			c := api.NewClient(url)
-			results, err := c.SendHeartbeats(testHeartbeats())
+			results, err := c.SendHeartbeats(context.Background(), testHeartbeats())
 			require.NoError(t, err)
 
 			// check via assert.Equal on complete slice here, to assert exact order of results,
@@ -127,7 +128,7 @@ func TestClient_SendHeartbeats_MultipleApiKey(t *testing.T) {
 	hh := testHeartbeats()
 	hh[1].APIKey = "00000000-0000-4000-8000-000000000001"
 
-	_, err := c.SendHeartbeats(hh)
+	_, err := c.SendHeartbeats(context.Background(), hh)
 	require.NoError(t, err)
 
 	assert.Eventually(t, func() bool { return numCalls == 2 }, time.Second, 50*time.Millisecond)
@@ -146,7 +147,8 @@ func TestClient_SendHeartbeats_Err(t *testing.T) {
 	})
 
 	c := api.NewClient(url)
-	_, err := c.SendHeartbeats(testHeartbeats())
+
+	_, err := c.SendHeartbeats(context.Background(), testHeartbeats())
 
 	var errapi api.Err
 
@@ -168,7 +170,8 @@ func TestClient_SendHeartbeats_ErrAuth(t *testing.T) {
 	})
 
 	c := api.NewClient(url)
-	_, err := c.SendHeartbeats(testHeartbeats())
+
+	_, err := c.SendHeartbeats(context.Background(), testHeartbeats())
 
 	var errauth api.ErrAuth
 
@@ -190,7 +193,8 @@ func TestClient_SendHeartbeats_ErrBadRequest(t *testing.T) {
 	})
 
 	c := api.NewClient(url)
-	_, err := c.SendHeartbeats(testHeartbeats())
+
+	_, err := c.SendHeartbeats(context.Background(), testHeartbeats())
 
 	var errbadRequest api.ErrBadRequest
 
@@ -201,7 +205,8 @@ func TestClient_SendHeartbeats_ErrBadRequest(t *testing.T) {
 
 func TestClient_SendHeartbeats_InvalidUrl(t *testing.T) {
 	c := api.NewClient("invalid-url")
-	_, err := c.SendHeartbeats(testHeartbeats())
+
+	_, err := c.SendHeartbeats(context.Background(), testHeartbeats())
 
 	var apierr api.Err
 
@@ -212,7 +217,7 @@ func TestParseHeartbeatResponses(t *testing.T) {
 	data, err := os.ReadFile("testdata/api_heartbeats_response.json")
 	require.NoError(t, err)
 
-	results, err := api.ParseHeartbeatResponses(data)
+	results, err := api.ParseHeartbeatResponses(context.Background(), data)
 	require.NoError(t, err)
 
 	// check via assert.Equal on complete slice here, to assert exact order of results,
@@ -260,7 +265,7 @@ func TestParseHeartbeatResponses_Error(t *testing.T) {
 	data, err := os.ReadFile("testdata/api_heartbeats_response_error.json")
 	require.NoError(t, err)
 
-	results, err := api.ParseHeartbeatResponses(data)
+	results, err := api.ParseHeartbeatResponses(context.Background(), data)
 	require.NoError(t, err)
 
 	// asserting here the exact order of results, which is assumed to exactly match the request order
@@ -281,7 +286,7 @@ func TestParseHeartbeatResponses_Errors(t *testing.T) {
 	data, err := os.ReadFile("testdata/api_heartbeats_response_errors.json")
 	require.NoError(t, err)
 
-	results, err := api.ParseHeartbeatResponses(data)
+	results, err := api.ParseHeartbeatResponses(context.Background(), data)
 	require.NoError(t, err)
 
 	// asserting here the exact order of results, which is assumed to exactly match the request order

--- a/pkg/api/option_test.go
+++ b/pkg/api/option_test.go
@@ -1,6 +1,7 @@
 package api_test
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
 	"net/http"
@@ -19,6 +20,8 @@ import (
 )
 
 func TestOption_WithAuth(t *testing.T) {
+	ctx := context.Background()
+
 	tests := map[string]struct {
 		User            string
 		AuthHeaderValue string
@@ -55,7 +58,8 @@ func TestOption_WithAuth(t *testing.T) {
 			require.NoError(t, err)
 
 			c := api.NewClient("", []api.Option{withAuth}...)
-			resp, err := c.Do(req)
+
+			resp, err := c.Do(ctx, req)
 			require.NoError(t, err)
 
 			defer resp.Body.Close()
@@ -83,7 +87,8 @@ func TestOption_WithHostname(t *testing.T) {
 	require.NoError(t, err)
 
 	c := api.NewClient("", opts...)
-	resp, err := c.Do(req)
+
+	resp, err := c.Do(context.Background(), req)
 	require.NoError(t, err)
 
 	defer resp.Body.Close()
@@ -109,7 +114,8 @@ func TestOption_WithInvalidHostname(t *testing.T) {
 	require.NoError(t, err)
 
 	c := api.NewClient("", opts...)
-	resp, err := c.Do(req)
+
+	resp, err := c.Do(context.Background(), req)
 	require.NoError(t, err)
 
 	defer resp.Body.Close()
@@ -118,6 +124,8 @@ func TestOption_WithInvalidHostname(t *testing.T) {
 }
 
 func TestOption_WithNTLM(t *testing.T) {
+	ctx := context.Background()
+
 	tests := map[string]string{
 		"default":  `domain\\john:123456`,
 		"useronly": `domain\\john`,
@@ -159,7 +167,8 @@ func TestOption_WithNTLM(t *testing.T) {
 			require.NoError(t, err)
 
 			c := api.NewClient("", []api.Option{withNTLM}...)
-			resp, err := c.Do(req)
+
+			resp, err := c.Do(ctx, req)
 			require.NoError(t, err)
 
 			defer resp.Body.Close()
@@ -172,6 +181,8 @@ func TestOption_WithNTLM(t *testing.T) {
 func TestOption_WithNTLMRequestRetry(t *testing.T) {
 	url, router, close := setupTestServer()
 	defer close()
+
+	ctx := context.Background()
 
 	var numCalls int
 
@@ -211,14 +222,15 @@ func TestOption_WithNTLMRequestRetry(t *testing.T) {
 		assert.Equal(t, []string{"NTLM " + base64.StdEncoding.EncodeToString(msg)}, authHeader)
 	})
 
-	withNTLMRetry, err := api.WithNTLMRequestRetry(`domain\\john:secret`)
+	withNTLMRetry, err := api.WithNTLMRequestRetry(ctx, `domain\\john:secret`)
 	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	require.NoError(t, err)
 
 	c := api.NewClient("", []api.Option{withNTLMRetry}...)
-	resp, err := c.Do(req)
+
+	resp, err := c.Do(ctx, req)
 	require.NoError(t, err)
 
 	defer resp.Body.Close()
@@ -245,7 +257,8 @@ func TestOption_WithProxy(t *testing.T) {
 	require.NoError(t, err)
 
 	c := api.NewClient("", opts...)
-	resp, err := c.Do(req)
+
+	resp, err := c.Do(context.Background(), req)
 	require.NoError(t, err)
 
 	defer resp.Body.Close()
@@ -256,6 +269,8 @@ func TestOption_WithProxy(t *testing.T) {
 func TestOption_WithUserAgent(t *testing.T) {
 	url, router, tearDown := setupTestServer()
 	defer tearDown()
+
+	ctx := context.Background()
 
 	var numCalls int
 
@@ -276,13 +291,14 @@ func TestOption_WithUserAgent(t *testing.T) {
 		numCalls++
 	})
 
-	opts := []api.Option{api.WithUserAgent("testplugin")}
+	opts := []api.Option{api.WithUserAgent(ctx, "testplugin")}
 
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	require.NoError(t, err)
 
 	c := api.NewClient("", opts...)
-	resp, err := c.Do(req)
+
+	resp, err := c.Do(ctx, req)
 	require.NoError(t, err)
 
 	defer resp.Body.Close()
@@ -293,6 +309,8 @@ func TestOption_WithUserAgent(t *testing.T) {
 func TestOption_WithUserAgentUnknownPlugin(t *testing.T) {
 	url, router, tearDown := setupTestServer()
 	defer tearDown()
+
+	ctx := context.Background()
 
 	var numCalls int
 
@@ -313,13 +331,14 @@ func TestOption_WithUserAgentUnknownPlugin(t *testing.T) {
 		numCalls++
 	})
 
-	opts := []api.Option{api.WithUserAgent("")}
+	opts := []api.Option{api.WithUserAgent(ctx, "")}
 
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	require.NoError(t, err)
 
 	c := api.NewClient("", opts...)
-	resp, err := c.Do(req)
+
+	resp, err := c.Do(ctx, req)
 	require.NoError(t, err)
 
 	defer resp.Body.Close()
@@ -345,7 +364,8 @@ func TestOption_WithTimezone(t *testing.T) {
 	require.NoError(t, err)
 
 	c := api.NewClient("", opts...)
-	resp, err := c.Do(req)
+
+	resp, err := c.Do(context.Background(), req)
 	require.NoError(t, err)
 
 	defer resp.Body.Close()

--- a/pkg/api/statusbar.go
+++ b/pkg/api/statusbar.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -14,7 +15,7 @@ import (
 // ErrRequest is returned upon request failure with no received response from api.
 // ErrAuth is returned upon receiving a 401 Unauthorized api response.
 // Err is returned on any other api response related error.
-func (c *Client) Today() (*summary.Summary, error) {
+func (c *Client) Today(ctx context.Context) (*summary.Summary, error) {
 	url := c.baseURL + "/users/current/statusbar/today"
 
 	req, err := http.NewRequest(http.MethodGet, url, nil)
@@ -27,7 +28,7 @@ func (c *Client) Today() (*summary.Summary, error) {
 	q := req.URL.Query()
 	req.URL.RawQuery = q.Encode()
 
-	resp, err := c.Do(req)
+	resp, err := c.Do(ctx, req)
 	if err != nil {
 		return nil, Err{fmt.Errorf("failed to make request to %q: %s", url, err)}
 	}

--- a/pkg/api/statusbar_test.go
+++ b/pkg/api/statusbar_test.go
@@ -1,6 +1,7 @@
 package api_test
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -40,8 +41,8 @@ func TestClient_StatusBar(t *testing.T) {
 	})
 
 	c := api.NewClient(u)
-	s, err := c.Today()
 
+	s, err := c.Today(context.Background())
 	require.NoError(t, err)
 
 	assert.Equal(t, s, testSummary())
@@ -65,7 +66,8 @@ func TestClient_StatusBarWithTimeout(t *testing.T) {
 
 	opts := []api.Option{api.WithTimeout(20 * time.Millisecond)}
 	c := api.NewClient(u, opts...)
-	_, err := c.Today()
+
+	_, err := c.Today(context.Background())
 	require.Error(t, err)
 
 	errMsg := fmt.Sprintf("error %q does not contain string 'Timeout'", err)
@@ -93,7 +95,8 @@ func TestClient_StatusBar_Err(t *testing.T) {
 	})
 
 	c := api.NewClient(u)
-	_, err := c.Today()
+
+	_, err := c.Today(context.Background())
 
 	var apierr api.Err
 
@@ -114,7 +117,8 @@ func TestClient_StatusBar_ErrAuth(t *testing.T) {
 	})
 
 	c := api.NewClient(u)
-	_, err := c.Today()
+
+	_, err := c.Today(context.Background())
 
 	var errauth api.ErrAuth
 
@@ -136,7 +140,8 @@ func TestClient_StatusBar_ErrBadRequest(t *testing.T) {
 	})
 
 	c := api.NewClient(u)
-	_, err := c.Today()
+
+	_, err := c.Today(context.Background())
 
 	var errbadRequest api.ErrBadRequest
 
@@ -146,7 +151,8 @@ func TestClient_StatusBar_ErrBadRequest(t *testing.T) {
 
 func TestClient_StatusBar_InvalidUrl(t *testing.T) {
 	c := api.NewClient("invalid-url")
-	_, err := c.Today()
+
+	_, err := c.Today(context.Background())
 
 	var apierr api.Err
 

--- a/pkg/api/transport_other.go
+++ b/pkg/api/transport_other.go
@@ -3,9 +3,10 @@
 package api
 
 import (
+	"context"
 	"crypto/x509"
 )
 
-func loadSystemRoots() (*x509.CertPool, error) {
+func loadSystemRoots(_ context.Context) (*x509.CertPool, error) {
 	return x509.SystemCertPool()
 }

--- a/pkg/api/transport_windows.go
+++ b/pkg/api/transport_windows.go
@@ -3,6 +3,7 @@
 package api
 
 import (
+	"context"
 	"crypto/x509"
 	"runtime/debug"
 	"syscall"
@@ -11,10 +12,12 @@ import (
 	"github.com/wakatime/wakatime-cli/pkg/log"
 )
 
-func loadSystemRoots() (*x509.CertPool, error) {
+func loadSystemRoots(ctx context.Context) (*x509.CertPool, error) {
 	defer func() {
+		logger := log.Extract(ctx)
+
 		if err := recover(); err != nil {
-			log.Errorf("failed to load system roots on Windows. panicked: %v. Stack: %s", err, string(debug.Stack()))
+			logger.Errorf("failed to load system roots on Windows. panicked: %v. Stack: %s", err, string(debug.Stack()))
 		}
 	}()
 

--- a/pkg/deps/c.go
+++ b/pkg/deps/c.go
@@ -1,6 +1,7 @@
 package deps
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"regexp"
@@ -34,7 +35,9 @@ type ParserC struct {
 }
 
 // Parse parses dependencies from C file content using the C lexer.
-func (p *ParserC) Parse(filepath string) ([]string, error) {
+func (p *ParserC) Parse(ctx context.Context, filepath string) ([]string, error) {
+	logger := log.Extract(ctx)
+
 	reader, err := file.OpenNoLock(filepath) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
@@ -42,7 +45,7 @@ func (p *ParserC) Parse(filepath string) ([]string, error) {
 
 	defer func() {
 		if err := reader.Close(); err != nil {
-			log.Debugf("failed to close file: %s", err)
+			logger.Debugf("failed to close file: %s", err)
 		}
 	}()
 

--- a/pkg/deps/c_test.go
+++ b/pkg/deps/c_test.go
@@ -1,6 +1,7 @@
 package deps_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/wakatime/wakatime-cli/pkg/deps"
@@ -12,7 +13,7 @@ import (
 func TestParserC_Parse(t *testing.T) {
 	parser := deps.ParserC{}
 
-	dependencies, err := parser.Parse("testdata/c.c")
+	dependencies, err := parser.Parse(context.Background(), "testdata/c.c")
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{

--- a/pkg/deps/cpp.go
+++ b/pkg/deps/cpp.go
@@ -1,6 +1,7 @@
 package deps
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"regexp"
@@ -34,7 +35,9 @@ type ParserCPP struct {
 }
 
 // Parse parses dependencies from C++ file content using the C lexer.
-func (p *ParserCPP) Parse(filepath string) ([]string, error) {
+func (p *ParserCPP) Parse(ctx context.Context, filepath string) ([]string, error) {
+	logger := log.Extract(ctx)
+
 	reader, err := file.OpenNoLock(filepath) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
@@ -42,7 +45,7 @@ func (p *ParserCPP) Parse(filepath string) ([]string, error) {
 
 	defer func() {
 		if err := reader.Close(); err != nil {
-			log.Debugf("failed to close file: %s", err)
+			logger.Debugf("failed to close file: %s", err)
 		}
 	}()
 

--- a/pkg/deps/cpp_test.go
+++ b/pkg/deps/cpp_test.go
@@ -1,6 +1,7 @@
 package deps_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,7 +12,7 @@ import (
 func TestParserCPP_Parse(t *testing.T) {
 	parser := deps.ParserCPP{}
 
-	dependencies, err := parser.Parse("testdata/cpp.cpp")
+	dependencies, err := parser.Parse(context.Background(), "testdata/cpp.cpp")
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{

--- a/pkg/deps/csharp.go
+++ b/pkg/deps/csharp.go
@@ -1,6 +1,7 @@
 package deps
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"regexp"
@@ -35,7 +36,9 @@ type ParserCSharp struct {
 }
 
 // Parse parses dependencies from C# file content using the chroma C# lexer.
-func (p *ParserCSharp) Parse(filepath string) ([]string, error) {
+func (p *ParserCSharp) Parse(ctx context.Context, filepath string) ([]string, error) {
+	logger := log.Extract(ctx)
+
 	reader, err := file.OpenNoLock(filepath) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
@@ -43,7 +46,7 @@ func (p *ParserCSharp) Parse(filepath string) ([]string, error) {
 
 	defer func() {
 		if err := reader.Close(); err != nil {
-			log.Debugf("failed to close file: %s", err)
+			logger.Debugf("failed to close file: %s", err)
 		}
 	}()
 

--- a/pkg/deps/csharp_test.go
+++ b/pkg/deps/csharp_test.go
@@ -1,6 +1,7 @@
 package deps_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/wakatime/wakatime-cli/pkg/deps"
@@ -12,7 +13,7 @@ import (
 func TestParserCSharp_Parse(t *testing.T) {
 	parser := deps.ParserCSharp{}
 
-	dependencies, err := parser.Parse("testdata/csharp.cs")
+	dependencies, err := parser.Parse(context.Background(), "testdata/csharp.cs")
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{

--- a/pkg/deps/elm.go
+++ b/pkg/deps/elm.go
@@ -1,6 +1,7 @@
 package deps
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"strings"
@@ -31,7 +32,9 @@ type ParserElm struct {
 }
 
 // Parse parses dependencies from Elm file content using the chroma Elm lexer.
-func (p *ParserElm) Parse(filepath string) ([]string, error) {
+func (p *ParserElm) Parse(ctx context.Context, filepath string) ([]string, error) {
+	logger := log.Extract(ctx)
+
 	reader, err := file.OpenNoLock(filepath) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
@@ -39,7 +42,7 @@ func (p *ParserElm) Parse(filepath string) ([]string, error) {
 
 	defer func() {
 		if err := reader.Close(); err != nil {
-			log.Debugf("failed to close file: %s", err)
+			logger.Debugf("failed to close file: %s", err)
 		}
 	}()
 

--- a/pkg/deps/elm_test.go
+++ b/pkg/deps/elm_test.go
@@ -1,6 +1,7 @@
 package deps_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/wakatime/wakatime-cli/pkg/deps"
@@ -12,7 +13,7 @@ import (
 func TestParserElm_Parse(t *testing.T) {
 	parser := deps.ParserElm{}
 
-	dependencies, err := parser.Parse("testdata/elm.elm")
+	dependencies, err := parser.Parse(context.Background(), "testdata/elm.elm")
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{

--- a/pkg/deps/golang.go
+++ b/pkg/deps/golang.go
@@ -1,6 +1,7 @@
 package deps
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"regexp"
@@ -34,7 +35,9 @@ type ParserGo struct {
 }
 
 // Parse parses dependencies from Golang file content using the chroma Golang lexer.
-func (p *ParserGo) Parse(filepath string) ([]string, error) {
+func (p *ParserGo) Parse(ctx context.Context, filepath string) ([]string, error) {
+	logger := log.Extract(ctx)
+
 	reader, err := file.OpenNoLock(filepath) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
@@ -42,7 +45,7 @@ func (p *ParserGo) Parse(filepath string) ([]string, error) {
 
 	defer func() {
 		if err := reader.Close(); err != nil {
-			log.Debugf("failed to close file: %s", err)
+			logger.Debugf("failed to close file: %s", err)
 		}
 	}()
 

--- a/pkg/deps/golang_test.go
+++ b/pkg/deps/golang_test.go
@@ -1,6 +1,7 @@
 package deps_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/wakatime/wakatime-cli/pkg/deps"
@@ -12,7 +13,7 @@ import (
 func TestParserGo_Parse(t *testing.T) {
 	parser := deps.ParserGo{}
 
-	dependencies, err := parser.Parse("testdata/golang.go")
+	dependencies, err := parser.Parse(context.Background(), "testdata/golang.go")
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{

--- a/pkg/deps/haskell.go
+++ b/pkg/deps/haskell.go
@@ -1,6 +1,7 @@
 package deps
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"strings"
@@ -31,7 +32,9 @@ type ParserHaskell struct {
 }
 
 // Parse parses dependencies from Haskell file content using the chroma Haskell lexer.
-func (p *ParserHaskell) Parse(filepath string) ([]string, error) {
+func (p *ParserHaskell) Parse(ctx context.Context, filepath string) ([]string, error) {
+	logger := log.Extract(ctx)
+
 	reader, err := file.OpenNoLock(filepath) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
@@ -39,7 +42,7 @@ func (p *ParserHaskell) Parse(filepath string) ([]string, error) {
 
 	defer func() {
 		if err := reader.Close(); err != nil {
-			log.Debugf("failed to close file: %s", err)
+			logger.Debugf("failed to close file: %s", err)
 		}
 	}()
 

--- a/pkg/deps/haskell_test.go
+++ b/pkg/deps/haskell_test.go
@@ -1,6 +1,7 @@
 package deps_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/wakatime/wakatime-cli/pkg/deps"
@@ -12,7 +13,7 @@ import (
 func TestParserHaskell_Parse(t *testing.T) {
 	parser := deps.ParserHaskell{}
 
-	dependencies, err := parser.Parse("testdata/haskell.hs")
+	dependencies, err := parser.Parse(context.Background(), "testdata/haskell.hs")
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{

--- a/pkg/deps/haxe.go
+++ b/pkg/deps/haxe.go
@@ -1,6 +1,7 @@
 package deps
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"regexp"
@@ -33,7 +34,9 @@ type ParserHaxe struct {
 }
 
 // Parse parses dependencies from Haxe file content using the chroma Haxe lexer.
-func (p *ParserHaxe) Parse(filepath string) ([]string, error) {
+func (p *ParserHaxe) Parse(ctx context.Context, filepath string) ([]string, error) {
+	logger := log.Extract(ctx)
+
 	reader, err := file.OpenNoLock(filepath) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
@@ -41,7 +44,7 @@ func (p *ParserHaxe) Parse(filepath string) ([]string, error) {
 
 	defer func() {
 		if err := reader.Close(); err != nil {
-			log.Debugf("failed to close file: %s", err)
+			logger.Debugf("failed to close file: %s", err)
 		}
 	}()
 

--- a/pkg/deps/haxe_test.go
+++ b/pkg/deps/haxe_test.go
@@ -1,6 +1,7 @@
 package deps_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/wakatime/wakatime-cli/pkg/deps"
@@ -12,7 +13,7 @@ import (
 func TestParserHaxe_Parse(t *testing.T) {
 	parser := deps.ParserHaxe{}
 
-	dependencies, err := parser.Parse("testdata/haxe.hx")
+	dependencies, err := parser.Parse(context.Background(), "testdata/haxe.hx")
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{

--- a/pkg/deps/html.go
+++ b/pkg/deps/html.go
@@ -1,6 +1,7 @@
 package deps
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"regexp"
@@ -35,7 +36,9 @@ type ParserHTML struct {
 }
 
 // Parse parses dependencies from HTML file content via ReadCloser using the chroma HTML lexer.
-func (p *ParserHTML) Parse(filepath string) ([]string, error) {
+func (p *ParserHTML) Parse(ctx context.Context, filepath string) ([]string, error) {
+	logger := log.Extract(ctx)
+
 	reader, err := file.OpenNoLock(filepath) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
@@ -43,7 +46,7 @@ func (p *ParserHTML) Parse(filepath string) ([]string, error) {
 
 	defer func() {
 		if err := reader.Close(); err != nil {
-			log.Debugf("failed to close file: %s", err)
+			logger.Debugf("failed to close file: %s", err)
 		}
 	}()
 

--- a/pkg/deps/html_test.go
+++ b/pkg/deps/html_test.go
@@ -1,6 +1,7 @@
 package deps_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/wakatime/wakatime-cli/pkg/deps"
@@ -10,6 +11,8 @@ import (
 )
 
 func TestParserHTML_Parse(t *testing.T) {
+	ctx := context.Background()
+
 	tests := map[string]struct {
 		Filepath string
 		Expected []string
@@ -37,7 +40,7 @@ func TestParserHTML_Parse(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			parser := deps.ParserHTML{}
 
-			dependencies, err := parser.Parse(test.Filepath)
+			dependencies, err := parser.Parse(ctx, test.Filepath)
 			require.NoError(t, err)
 
 			assert.Equal(t, test.Expected, dependencies)

--- a/pkg/deps/java.go
+++ b/pkg/deps/java.go
@@ -1,6 +1,7 @@
 package deps
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"regexp"
@@ -37,7 +38,9 @@ type ParserJava struct {
 }
 
 // Parse parses dependencies from Java file content using the chroma Java lexer.
-func (p *ParserJava) Parse(filepath string) ([]string, error) {
+func (p *ParserJava) Parse(ctx context.Context, filepath string) ([]string, error) {
+	logger := log.Extract(ctx)
+
 	reader, err := file.OpenNoLock(filepath) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
@@ -45,7 +48,7 @@ func (p *ParserJava) Parse(filepath string) ([]string, error) {
 
 	defer func() {
 		if err := reader.Close(); err != nil {
-			log.Debugf("failed to close file: %s", err)
+			logger.Debugf("failed to close file: %s", err)
 		}
 	}()
 

--- a/pkg/deps/java_test.go
+++ b/pkg/deps/java_test.go
@@ -1,6 +1,7 @@
 package deps_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/wakatime/wakatime-cli/pkg/deps"
@@ -12,7 +13,7 @@ import (
 func TestParserJava_Parse(t *testing.T) {
 	parser := deps.ParserJava{}
 
-	dependencies, err := parser.Parse("testdata/java.java")
+	dependencies, err := parser.Parse(context.Background(), "testdata/java.java")
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{

--- a/pkg/deps/javascript.go
+++ b/pkg/deps/javascript.go
@@ -1,6 +1,7 @@
 package deps
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"regexp"
@@ -34,7 +35,9 @@ type ParserJavaScript struct {
 }
 
 // Parse parses dependencies from JavaScript file content using the chroma JavaScript lexer.
-func (p *ParserJavaScript) Parse(filepath string) ([]string, error) {
+func (p *ParserJavaScript) Parse(ctx context.Context, filepath string) ([]string, error) {
+	logger := log.Extract(ctx)
+
 	reader, err := file.OpenNoLock(filepath) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
@@ -42,7 +45,7 @@ func (p *ParserJavaScript) Parse(filepath string) ([]string, error) {
 
 	defer func() {
 		if err := reader.Close(); err != nil {
-			log.Debugf("failed to close file: %s", err)
+			logger.Debugf("failed to close file: %s", err)
 		}
 	}()
 

--- a/pkg/deps/javascript_test.go
+++ b/pkg/deps/javascript_test.go
@@ -1,6 +1,7 @@
 package deps_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/wakatime/wakatime-cli/pkg/deps"
@@ -10,6 +11,8 @@ import (
 )
 
 func TestParserJavaScript_Parse(t *testing.T) {
+	ctx := context.Background()
+
 	tests := map[string]struct {
 		Filepath string
 		Expected []string
@@ -69,7 +72,7 @@ func TestParserJavaScript_Parse(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			parser := deps.ParserJavaScript{}
 
-			dependencies, err := parser.Parse(test.Filepath)
+			dependencies, err := parser.Parse(ctx, test.Filepath)
 			require.NoError(t, err)
 
 			assert.Equal(t, test.Expected, dependencies)

--- a/pkg/deps/json.go
+++ b/pkg/deps/json.go
@@ -1,6 +1,7 @@
 package deps
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -43,7 +44,9 @@ type ParserJSON struct {
 }
 
 // Parse parses dependencies from JSON file content using the chroma JSON lexer.
-func (p *ParserJSON) Parse(filepath string) ([]string, error) {
+func (p *ParserJSON) Parse(ctx context.Context, filepath string) ([]string, error) {
+	logger := log.Extract(ctx)
+
 	reader, err := file.OpenNoLock(filepath) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
@@ -51,7 +54,7 @@ func (p *ParserJSON) Parse(filepath string) ([]string, error) {
 
 	defer func() {
 		if err := reader.Close(); err != nil {
-			log.Debugf("failed to close file: %s", err)
+			logger.Debugf("failed to close file: %s", err)
 		}
 	}()
 

--- a/pkg/deps/json_test.go
+++ b/pkg/deps/json_test.go
@@ -1,6 +1,7 @@
 package deps_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/wakatime/wakatime-cli/pkg/deps"
@@ -10,6 +11,8 @@ import (
 )
 
 func TestParserJSON_Parse(t *testing.T) {
+	ctx := context.Background()
+
 	tests := map[string]struct {
 		Filepath string
 		Expected []string
@@ -49,7 +52,7 @@ func TestParserJSON_Parse(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			parser := deps.ParserJSON{}
 
-			dependencies, err := parser.Parse(test.Filepath)
+			dependencies, err := parser.Parse(ctx, test.Filepath)
 			require.NoError(t, err)
 
 			assert.Equal(t, test.Expected, dependencies)

--- a/pkg/deps/kotlin.go
+++ b/pkg/deps/kotlin.go
@@ -1,6 +1,7 @@
 package deps
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"regexp"
@@ -34,7 +35,9 @@ type ParserKotlin struct {
 }
 
 // Parse parses dependencies from Kotlin file content using the chroma Kotlin lexer.
-func (p *ParserKotlin) Parse(filepath string) ([]string, error) {
+func (p *ParserKotlin) Parse(ctx context.Context, filepath string) ([]string, error) {
+	logger := log.Extract(ctx)
+
 	reader, err := file.OpenNoLock(filepath) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
@@ -42,7 +45,7 @@ func (p *ParserKotlin) Parse(filepath string) ([]string, error) {
 
 	defer func() {
 		if err := reader.Close(); err != nil {
-			log.Debugf("failed to close file: %s", err)
+			logger.Debugf("failed to close file: %s", err)
 		}
 	}()
 

--- a/pkg/deps/kotlin_test.go
+++ b/pkg/deps/kotlin_test.go
@@ -1,6 +1,7 @@
 package deps_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/wakatime/wakatime-cli/pkg/deps"
@@ -12,7 +13,7 @@ import (
 func TestParserKotlin_Parse(t *testing.T) {
 	parser := deps.ParserKotlin{}
 
-	dependencies, err := parser.Parse("testdata/kotlin.kt")
+	dependencies, err := parser.Parse(context.Background(), "testdata/kotlin.kt")
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{

--- a/pkg/deps/objectivec.go
+++ b/pkg/deps/objectivec.go
@@ -1,6 +1,7 @@
 package deps
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"strings"
@@ -31,7 +32,9 @@ type ParserObjectiveC struct {
 }
 
 // Parse parses dependencies from Objective-C file content using the chroma Objective-C lexer.
-func (p *ParserObjectiveC) Parse(filepath string) ([]string, error) {
+func (p *ParserObjectiveC) Parse(ctx context.Context, filepath string) ([]string, error) {
+	logger := log.Extract(ctx)
+
 	reader, err := file.OpenNoLock(filepath) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
@@ -39,7 +42,7 @@ func (p *ParserObjectiveC) Parse(filepath string) ([]string, error) {
 
 	defer func() {
 		if err := reader.Close(); err != nil {
-			log.Debugf("failed to close file: %s", err)
+			logger.Debugf("failed to close file: %s", err)
 		}
 	}()
 

--- a/pkg/deps/objectivec_test.go
+++ b/pkg/deps/objectivec_test.go
@@ -1,6 +1,7 @@
 package deps_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/wakatime/wakatime-cli/pkg/deps"
@@ -12,7 +13,7 @@ import (
 func TestParserObjectiveC_Parse(t *testing.T) {
 	parser := deps.ParserObjectiveC{}
 
-	dependencies, err := parser.Parse("testdata/objective_c.m")
+	dependencies, err := parser.Parse(context.Background(), "testdata/objective_c.m")
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{

--- a/pkg/deps/php.go
+++ b/pkg/deps/php.go
@@ -1,6 +1,7 @@
 package deps
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"regexp"
@@ -40,7 +41,9 @@ type ParserPHP struct {
 }
 
 // Parse parses dependencies from PHP file content using the chroma PHP lexer.
-func (p *ParserPHP) Parse(filepath string) ([]string, error) {
+func (p *ParserPHP) Parse(ctx context.Context, filepath string) ([]string, error) {
+	logger := log.Extract(ctx)
+
 	reader, err := file.OpenNoLock(filepath) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
@@ -48,7 +51,7 @@ func (p *ParserPHP) Parse(filepath string) ([]string, error) {
 
 	defer func() {
 		if err := reader.Close(); err != nil {
-			log.Debugf("failed to close file: %s", err)
+			logger.Debugf("failed to close file: %s", err)
 		}
 	}()
 

--- a/pkg/deps/php_test.go
+++ b/pkg/deps/php_test.go
@@ -1,6 +1,7 @@
 package deps_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/wakatime/wakatime-cli/pkg/deps"
@@ -12,7 +13,7 @@ import (
 func TestParserPHP_Parse(t *testing.T) {
 	parser := deps.ParserPHP{}
 
-	dependencies, err := parser.Parse("testdata/php.php")
+	dependencies, err := parser.Parse(context.Background(), "testdata/php.php")
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{

--- a/pkg/deps/python.go
+++ b/pkg/deps/python.go
@@ -1,6 +1,7 @@
 package deps
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"regexp"
@@ -37,7 +38,9 @@ type ParserPython struct {
 }
 
 // Parse parses dependencies from Python file content using the chroma Python lexer.
-func (p *ParserPython) Parse(filepath string) ([]string, error) {
+func (p *ParserPython) Parse(ctx context.Context, filepath string) ([]string, error) {
+	logger := log.Extract(ctx)
+
 	reader, err := file.OpenNoLock(filepath) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
@@ -45,7 +48,7 @@ func (p *ParserPython) Parse(filepath string) ([]string, error) {
 
 	defer func() {
 		if err := reader.Close(); err != nil {
-			log.Debugf("failed to close file: %s", err)
+			logger.Debugf("failed to close file: %s", err)
 		}
 	}()
 

--- a/pkg/deps/python_test.go
+++ b/pkg/deps/python_test.go
@@ -1,6 +1,7 @@
 package deps_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/wakatime/wakatime-cli/pkg/deps"
@@ -12,7 +13,7 @@ import (
 func TestParserPython_Parse(t *testing.T) {
 	parser := deps.ParserPython{}
 
-	dependencies, err := parser.Parse("testdata/python.py")
+	dependencies, err := parser.Parse(context.Background(), "testdata/python.py")
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{

--- a/pkg/deps/rust.go
+++ b/pkg/deps/rust.go
@@ -1,6 +1,7 @@
 package deps
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"strings"
@@ -33,7 +34,9 @@ type ParserRust struct {
 }
 
 // Parse parses dependencies from Rust file content using the chroma Rust lexer.
-func (p *ParserRust) Parse(filepath string) ([]string, error) {
+func (p *ParserRust) Parse(ctx context.Context, filepath string) ([]string, error) {
+	logger := log.Extract(ctx)
+
 	reader, err := file.OpenNoLock(filepath) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
@@ -41,7 +44,7 @@ func (p *ParserRust) Parse(filepath string) ([]string, error) {
 
 	defer func() {
 		if err := reader.Close(); err != nil {
-			log.Debugf("failed to close file: %s", err)
+			logger.Debugf("failed to close file: %s", err)
 		}
 	}()
 

--- a/pkg/deps/rust_test.go
+++ b/pkg/deps/rust_test.go
@@ -1,6 +1,7 @@
 package deps_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/wakatime/wakatime-cli/pkg/deps"
@@ -12,7 +13,7 @@ import (
 func TestParserRust_Parse(t *testing.T) {
 	parser := deps.ParserRust{}
 
-	dependencies, err := parser.Parse("testdata/rust.rs")
+	dependencies, err := parser.Parse(context.Background(), "testdata/rust.rs")
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{

--- a/pkg/deps/scala.go
+++ b/pkg/deps/scala.go
@@ -1,6 +1,7 @@
 package deps
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"strings"
@@ -31,7 +32,9 @@ type ParserScala struct {
 }
 
 // Parse parses dependencies from Scala file content using the chroma Scala lexer.
-func (p *ParserScala) Parse(filepath string) ([]string, error) {
+func (p *ParserScala) Parse(ctx context.Context, filepath string) ([]string, error) {
+	logger := log.Extract(ctx)
+
 	reader, err := file.OpenNoLock(filepath) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
@@ -39,7 +42,7 @@ func (p *ParserScala) Parse(filepath string) ([]string, error) {
 
 	defer func() {
 		if err := reader.Close(); err != nil {
-			log.Debugf("failed to close file: %s", err)
+			logger.Debugf("failed to close file: %s", err)
 		}
 	}()
 

--- a/pkg/deps/scala_test.go
+++ b/pkg/deps/scala_test.go
@@ -1,6 +1,7 @@
 package deps_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/wakatime/wakatime-cli/pkg/deps"
@@ -12,7 +13,7 @@ import (
 func TestParserScala_Parse(t *testing.T) {
 	parser := deps.ParserScala{}
 
-	dependencies, err := parser.Parse("testdata/scala.scala")
+	dependencies, err := parser.Parse(context.Background(), "testdata/scala.scala")
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{

--- a/pkg/deps/swift.go
+++ b/pkg/deps/swift.go
@@ -1,6 +1,7 @@
 package deps
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"regexp"
@@ -34,7 +35,9 @@ type ParserSwift struct {
 }
 
 // Parse parses dependencies from Swift file content using the chroma Swift lexer.
-func (p *ParserSwift) Parse(filepath string) ([]string, error) {
+func (p *ParserSwift) Parse(ctx context.Context, filepath string) ([]string, error) {
+	logger := log.Extract(ctx)
+
 	reader, err := file.OpenNoLock(filepath) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
@@ -42,7 +45,7 @@ func (p *ParserSwift) Parse(filepath string) ([]string, error) {
 
 	defer func() {
 		if err := reader.Close(); err != nil {
-			log.Debugf("failed to close file: %s", err)
+			logger.Debugf("failed to close file: %s", err)
 		}
 	}()
 

--- a/pkg/deps/swift_test.go
+++ b/pkg/deps/swift_test.go
@@ -1,6 +1,7 @@
 package deps_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/wakatime/wakatime-cli/pkg/deps"
@@ -12,7 +13,7 @@ import (
 func TestParserSwift_Parse(t *testing.T) {
 	parser := deps.ParserSwift{}
 
-	dependencies, err := parser.Parse("testdata/swift.swift")
+	dependencies, err := parser.Parse(context.Background(), "testdata/swift.swift")
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{

--- a/pkg/deps/unknown.go
+++ b/pkg/deps/unknown.go
@@ -1,6 +1,7 @@
 package deps
 
 import (
+	"context"
 	"path/filepath"
 	"strings"
 )
@@ -21,7 +22,7 @@ type ParserUnknown struct {
 }
 
 // Parse parses dependencies from any file content via ReadCloser using the chroma golang lexer.
-func (p *ParserUnknown) Parse(fp string) ([]string, error) {
+func (p *ParserUnknown) Parse(_ context.Context, fp string) ([]string, error) {
 	p.init()
 	defer p.init()
 

--- a/pkg/deps/unknown_test.go
+++ b/pkg/deps/unknown_test.go
@@ -1,6 +1,7 @@
 package deps_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/wakatime/wakatime-cli/pkg/deps"
@@ -10,6 +11,8 @@ import (
 )
 
 func TestParserUnknown_Parse(t *testing.T) {
+	ctx := context.Background()
+
 	tests := map[string]struct {
 		Filepath string
 		Expected []string
@@ -32,7 +35,7 @@ func TestParserUnknown_Parse(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			parser := deps.ParserUnknown{}
 
-			dependencies, err := parser.Parse(test.Filepath)
+			dependencies, err := parser.Parse(ctx, test.Filepath)
 			require.NoError(t, err)
 
 			assert.Equal(t, test.Expected, dependencies)

--- a/pkg/deps/vbnet.go
+++ b/pkg/deps/vbnet.go
@@ -1,6 +1,7 @@
 package deps
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"regexp"
@@ -35,7 +36,9 @@ type ParserVbNet struct {
 }
 
 // Parse parses dependencies from VB.Net file content using the chroma VB.Net lexer.
-func (p *ParserVbNet) Parse(filepath string) ([]string, error) {
+func (p *ParserVbNet) Parse(ctx context.Context, filepath string) ([]string, error) {
+	logger := log.Extract(ctx)
+
 	reader, err := file.OpenNoLock(filepath) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
@@ -43,7 +46,7 @@ func (p *ParserVbNet) Parse(filepath string) ([]string, error) {
 
 	defer func() {
 		if err := reader.Close(); err != nil {
-			log.Debugf("failed to close file: %s", err)
+			logger.Debugf("failed to close file: %s", err)
 		}
 	}()
 

--- a/pkg/deps/vbnet_test.go
+++ b/pkg/deps/vbnet_test.go
@@ -1,6 +1,7 @@
 package deps_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/wakatime/wakatime-cli/pkg/deps"
@@ -12,7 +13,7 @@ import (
 func TestParserVbNet_Parse(t *testing.T) {
 	parser := deps.ParserVbNet{}
 
-	dependencies, err := parser.Parse("testdata/vbnet.vb")
+	dependencies, err := parser.Parse(context.Background(), "testdata/vbnet.vb")
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{

--- a/pkg/fileexperts/fileexperts.go
+++ b/pkg/fileexperts/fileexperts.go
@@ -1,6 +1,7 @@
 package fileexperts
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -47,19 +48,19 @@ type (
 
 // Caller calls wakatime api to get the file expert.
 type Caller interface {
-	FileExperts(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error)
+	FileExperts(context.Context, []heartbeat.Heartbeat) ([]heartbeat.Result, error)
 }
 
 // NewHandle creates a new Handle, which acts like a processing pipeline,
 // with a caller eventually requesting the API.
 func NewHandle(caller Caller, opts ...heartbeat.HandleOption) heartbeat.Handle {
-	return func(heartbeats []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+	return func(ctx context.Context, hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
 		var handle heartbeat.Handle = caller.FileExperts
 		for i := len(opts) - 1; i >= 0; i-- {
 			handle = opts[i](handle)
 		}
 
-		return handle(heartbeats)
+		return handle(ctx, hh)
 	}
 }
 

--- a/pkg/fileexperts/validation.go
+++ b/pkg/fileexperts/validation.go
@@ -1,6 +1,8 @@
 package fileexperts
 
 import (
+	"context"
+
 	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 	"github.com/wakatime/wakatime-cli/pkg/log"
 )
@@ -10,21 +12,22 @@ import (
 // before sending it to the API.
 func WithValidation() heartbeat.HandleOption {
 	return func(next heartbeat.Handle) heartbeat.Handle {
-		return func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
-			log.Debugln("execute fileexperts validation")
+		return func(ctx context.Context, hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+			logger := log.Extract(ctx)
+			logger.Debugln("execute fileexperts validation")
 
 			var filtered []heartbeat.Heartbeat
 
 			for _, h := range hh {
 				if !Validate(h) {
-					log.Debugf("missing required fields for fileexperts")
+					logger.Debugf("missing required fields for fileexperts")
 					continue
 				}
 
 				filtered = append(filtered, h)
 			}
 
-			return next(filtered)
+			return next(ctx, filtered)
 		}
 	}
 }

--- a/pkg/fileexperts/validation_test.go
+++ b/pkg/fileexperts/validation_test.go
@@ -1,6 +1,7 @@
 package fileexperts_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/wakatime/wakatime-cli/pkg/fileexperts"
@@ -12,7 +13,7 @@ import (
 
 func TestWithValidation(t *testing.T) {
 	opt := fileexperts.WithValidation()
-	h := opt(func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+	h := opt(func(_ context.Context, hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
 		assert.Equal(t, []heartbeat.Heartbeat{
 			{
 				Entity:           "/path/to/file",
@@ -28,7 +29,7 @@ func TestWithValidation(t *testing.T) {
 		}, nil
 	})
 
-	result, err := h([]heartbeat.Heartbeat{
+	result, err := h(context.Background(), []heartbeat.Heartbeat{
 		{
 			Entity:           "/path/to/file",
 			Project:          heartbeat.PointerTo("wakatime"),

--- a/pkg/filestats/filestats_test.go
+++ b/pkg/filestats/filestats_test.go
@@ -2,6 +2,7 @@ package filestats_test
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"testing"
 
@@ -14,7 +15,7 @@ import (
 
 func TestWithDetection(t *testing.T) {
 	opt := filestats.WithDetection()
-	handle := opt(func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+	handle := opt(func(_ context.Context, hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
 		assert.Len(t, hh, 2)
 		assert.Contains(t, hh, heartbeat.Heartbeat{
 			EntityType: heartbeat.FileType,
@@ -34,7 +35,7 @@ func TestWithDetection(t *testing.T) {
 		}, nil
 	})
 
-	result, err := handle([]heartbeat.Heartbeat{
+	result, err := handle(context.Background(), []heartbeat.Heartbeat{
 		{
 			EntityType: heartbeat.FileType,
 			Entity:     "testdata/first.txt",
@@ -55,7 +56,7 @@ func TestWithDetection(t *testing.T) {
 
 func TestWithDetection_RemoteFile(t *testing.T) {
 	opt := filestats.WithDetection()
-	handle := opt(func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+	handle := opt(func(_ context.Context, hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
 		assert.Len(t, hh, 1)
 		assert.Contains(t, hh, heartbeat.Heartbeat{
 			EntityType: heartbeat.FileType,
@@ -69,7 +70,7 @@ func TestWithDetection_RemoteFile(t *testing.T) {
 		}, nil
 	})
 
-	result, err := handle([]heartbeat.Heartbeat{
+	result, err := handle(context.Background(), []heartbeat.Heartbeat{
 		{
 			EntityType: heartbeat.FileType,
 			Entity:     "ssh://192.168.1.1/path/to/remote/main.go",
@@ -95,7 +96,7 @@ func TestWithDetection_MaxFileSizeExceeded(t *testing.T) {
 	require.NoError(t, err)
 
 	opt := filestats.WithDetection()
-	handle := opt(func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+	handle := opt(func(_ context.Context, hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
 		assert.Equal(t, hh, []heartbeat.Heartbeat{
 			{
 				EntityType: heartbeat.FileType,
@@ -107,7 +108,7 @@ func TestWithDetection_MaxFileSizeExceeded(t *testing.T) {
 		return []heartbeat.Result{}, nil
 	})
 
-	_, err = handle([]heartbeat.Heartbeat{
+	_, err = handle(context.Background(), []heartbeat.Heartbeat{
 		{
 			EntityType: heartbeat.FileType,
 			Entity:     f.Name(),

--- a/pkg/heartbeat/entity_modifier_internal_test.go
+++ b/pkg/heartbeat/entity_modifier_internal_test.go
@@ -1,6 +1,7 @@
 package heartbeat
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -10,6 +11,8 @@ import (
 )
 
 func TestIsXCodePlayground(t *testing.T) {
+	ctx := context.Background()
+
 	tests := map[string]struct {
 		Dir      string
 		Expected bool
@@ -34,7 +37,7 @@ func TestIsXCodePlayground(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			ret := isXCodePlayground(test.Dir)
+			ret := isXCodePlayground(ctx, test.Dir)
 
 			assert.Equal(t, test.Expected, ret)
 		})
@@ -42,6 +45,8 @@ func TestIsXCodePlayground(t *testing.T) {
 }
 
 func TestIsXCodeProject(t *testing.T) {
+	ctx := context.Background()
+
 	tests := map[string]struct {
 		Dir      string
 		Expected bool
@@ -58,7 +63,7 @@ func TestIsXCodeProject(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			ret := isXCodeProject(test.Dir)
+			ret := isXCodeProject(ctx, test.Dir)
 
 			assert.Equal(t, test.Expected, ret)
 		})

--- a/pkg/heartbeat/entity_modify.go
+++ b/pkg/heartbeat/entity_modify.go
@@ -1,6 +1,7 @@
 package heartbeat
 
 import (
+	"context"
 	"path/filepath"
 	"strings"
 
@@ -11,39 +12,41 @@ import (
 // can be used in a heartbeat processing pipeline to change an entity path.
 func WithEntityModifier() HandleOption {
 	return func(next Handle) Handle {
-		return func(hh []Heartbeat) ([]Result, error) {
-			log.Debugln("execute heartbeat entity modifier")
+		return func(ctx context.Context, hh []Heartbeat) ([]Result, error) {
+			logger := log.Extract(ctx)
+			logger.Debugln("execute heartbeat entity modifier")
 
 			for n, h := range hh {
 				// Support XCode playgrounds
-				if h.EntityType == FileType && isXCodePlayground(h.Entity) {
+				if h.EntityType == FileType && isXCodePlayground(ctx, h.Entity) {
 					hh[n].Entity = filepath.Join(h.Entity, "Contents.swift")
 				}
+
 				// Support XCode projects
-				if h.EntityType == FileType && isXCodeProject(h.Entity) {
+				if h.EntityType == FileType && isXCodeProject(ctx, h.Entity) {
 					hh[n].Entity = filepath.Join(h.Entity, "project.pbxproj")
 				}
 			}
 
-			return next(hh)
+			return next(ctx, hh)
 		}
 	}
 }
 
-func isXCodePlayground(fp string) bool {
+func isXCodePlayground(ctx context.Context, fp string) bool {
 	if !(strings.HasSuffix(fp, ".playground") ||
 		strings.HasSuffix(fp, ".xcplayground") ||
 		strings.HasSuffix(fp, ".xcplaygroundpage")) {
 		return false
 	}
 
-	return isDir(fp)
+	return isDir(ctx, fp)
 }
 
-func isXCodeProject(fp string) bool {
+func isXCodeProject(ctx context.Context, fp string) bool {
 	if !(strings.HasSuffix(fp, ".xcodeproj")) {
 		return false
 	}
 
-	return isDir(fp)
+	return isDir(ctx, fp)
 }

--- a/pkg/heartbeat/entity_modify_test.go
+++ b/pkg/heartbeat/entity_modify_test.go
@@ -1,6 +1,7 @@
 package heartbeat_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -19,7 +20,7 @@ func TestWithEntityModifier_XCodePlayground(t *testing.T) {
 
 	opt := heartbeat.WithEntityModifier()
 
-	handle := opt(func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+	handle := opt(func(_ context.Context, hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
 		assert.Equal(t, []heartbeat.Heartbeat{
 			{
 				Entity:     filepath.Join(tmpDir, "wakatime.playground", "Contents.swift"),
@@ -34,7 +35,7 @@ func TestWithEntityModifier_XCodePlayground(t *testing.T) {
 		}, nil
 	})
 
-	result, err := handle([]heartbeat.Heartbeat{
+	result, err := handle(context.Background(), []heartbeat.Heartbeat{
 		{
 			Entity:     filepath.Join(tmpDir, "wakatime.playground"),
 			EntityType: heartbeat.FileType,

--- a/pkg/heartbeat/format_test.go
+++ b/pkg/heartbeat/format_test.go
@@ -1,6 +1,7 @@
 package heartbeat_test
 
 import (
+	"context"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -16,7 +17,7 @@ import (
 func TestWithFormatting(t *testing.T) {
 	opt := heartbeat.WithFormatting()
 
-	handle := opt(func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+	handle := opt(func(_ context.Context, hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
 		entity, err := filepath.Abs(hh[0].Entity)
 		require.NoError(t, err)
 
@@ -40,7 +41,7 @@ func TestWithFormatting(t *testing.T) {
 		}, nil
 	})
 
-	result, err := handle([]heartbeat.Heartbeat{{
+	result, err := handle(context.Background(), []heartbeat.Heartbeat{{
 		Entity:     "testdata/main.go",
 		EntityType: heartbeat.FileType,
 	}})
@@ -63,7 +64,7 @@ func TestFormat_NetworkMount(t *testing.T) {
 		EntityType: heartbeat.FileType,
 	}
 
-	r := heartbeat.Format(h)
+	r := heartbeat.Format(context.Background(), h)
 
 	assert.Equal(t, heartbeat.Heartbeat{
 		Entity:     `\\192.168.1.1/apilibrary.sl`,

--- a/pkg/heartbeat/sanitize_test.go
+++ b/pkg/heartbeat/sanitize_test.go
@@ -1,6 +1,7 @@
 package heartbeat_test
 
 import (
+	"context"
 	"regexp"
 	"testing"
 
@@ -13,10 +14,10 @@ import (
 
 func TestWithSanitization_ObfuscateFile(t *testing.T) {
 	opt := heartbeat.WithSanitization(heartbeat.SanitizeConfig{
-		FilePatterns: []regex.Regex{regexp.MustCompile(".*")},
+		FilePatterns: []regex.Regex{regex.NewRegexpWrap(regexp.MustCompile(".*"))},
 	})
 
-	handle := opt(func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+	handle := opt(func(_ context.Context, hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
 		assert.Equal(t, []heartbeat.Heartbeat{
 			{
 				Category:   heartbeat.CodingCategory,
@@ -37,7 +38,7 @@ func TestWithSanitization_ObfuscateFile(t *testing.T) {
 		}, nil
 	})
 
-	result, err := handle([]heartbeat.Heartbeat{testHeartbeat()})
+	result, err := handle(context.Background(), []heartbeat.Heartbeat{testHeartbeat()})
 	require.NoError(t, err)
 
 	assert.Equal(t, []heartbeat.Result{
@@ -48,6 +49,8 @@ func TestWithSanitization_ObfuscateFile(t *testing.T) {
 }
 
 func TestSanitize_Obfuscate(t *testing.T) {
+	ctx := context.Background()
+
 	tests := map[string]struct {
 		Heartbeat heartbeat.Heartbeat
 		Expected  heartbeat.Heartbeat
@@ -115,8 +118,8 @@ func TestSanitize_Obfuscate(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			r := heartbeat.Sanitize(test.Heartbeat, heartbeat.SanitizeConfig{
-				FilePatterns: []regex.Regex{regexp.MustCompile(".*")},
+			r := heartbeat.Sanitize(ctx, test.Heartbeat, heartbeat.SanitizeConfig{
+				FilePatterns: []regex.Regex{regex.NewRegexpWrap(regexp.MustCompile(".*"))},
 			})
 
 			assert.Equal(t, test.Expected, r)
@@ -125,9 +128,9 @@ func TestSanitize_Obfuscate(t *testing.T) {
 }
 
 func TestSanitize_ObfuscateFile_SkipBranchIfNotMatching(t *testing.T) {
-	r := heartbeat.Sanitize(testHeartbeat(), heartbeat.SanitizeConfig{
-		FilePatterns:   []regex.Regex{regexp.MustCompile(".*")},
-		BranchPatterns: []regex.Regex{regexp.MustCompile("not_matching")},
+	r := heartbeat.Sanitize(context.Background(), testHeartbeat(), heartbeat.SanitizeConfig{
+		FilePatterns:   []regex.Regex{regex.NewRegexpWrap(regexp.MustCompile(".*"))},
+		BranchPatterns: []regex.Regex{regex.NewRegexpWrap(regexp.MustCompile("not_matching"))},
 	})
 
 	assert.Equal(t, heartbeat.Heartbeat{
@@ -147,9 +150,9 @@ func TestSanitize_ObfuscateFile_NilFields(t *testing.T) {
 	h := testHeartbeat()
 	h.Branch = nil
 
-	r := heartbeat.Sanitize(h, heartbeat.SanitizeConfig{
-		FilePatterns:   []regex.Regex{regexp.MustCompile(".*")},
-		BranchPatterns: []regex.Regex{regexp.MustCompile(".*")},
+	r := heartbeat.Sanitize(context.Background(), h, heartbeat.SanitizeConfig{
+		FilePatterns:   []regex.Regex{regex.NewRegexpWrap(regexp.MustCompile(".*"))},
+		BranchPatterns: []regex.Regex{regex.NewRegexpWrap(regexp.MustCompile(".*"))},
 	})
 
 	assert.Equal(t, heartbeat.Heartbeat{
@@ -165,8 +168,8 @@ func TestSanitize_ObfuscateFile_NilFields(t *testing.T) {
 }
 
 func TestSanitize_ObfuscateProject(t *testing.T) {
-	r := heartbeat.Sanitize(testHeartbeat(), heartbeat.SanitizeConfig{
-		ProjectPatterns: []regex.Regex{regexp.MustCompile(".*")},
+	r := heartbeat.Sanitize(context.Background(), testHeartbeat(), heartbeat.SanitizeConfig{
+		ProjectPatterns: []regex.Regex{regex.NewRegexpWrap(regexp.MustCompile(".*"))},
 	})
 
 	assert.Equal(t, heartbeat.Heartbeat{
@@ -182,9 +185,9 @@ func TestSanitize_ObfuscateProject(t *testing.T) {
 }
 
 func TestSanitize_ObfuscateProject_SkipBranchIfNotMatching(t *testing.T) {
-	r := heartbeat.Sanitize(testHeartbeat(), heartbeat.SanitizeConfig{
-		ProjectPatterns: []regex.Regex{regexp.MustCompile(".*")},
-		BranchPatterns:  []regex.Regex{regexp.MustCompile("not_matching")},
+	r := heartbeat.Sanitize(context.Background(), testHeartbeat(), heartbeat.SanitizeConfig{
+		ProjectPatterns: []regex.Regex{regex.NewRegexpWrap(regexp.MustCompile(".*"))},
+		BranchPatterns:  []regex.Regex{regex.NewRegexpWrap(regexp.MustCompile("not_matching"))},
 	})
 
 	assert.Equal(t, heartbeat.Heartbeat{
@@ -204,9 +207,9 @@ func TestSanitize_ObfuscateProject_NilFields(t *testing.T) {
 	h := testHeartbeat()
 	h.Branch = nil
 
-	r := heartbeat.Sanitize(h, heartbeat.SanitizeConfig{
-		ProjectPatterns: []regex.Regex{regexp.MustCompile(".*")},
-		BranchPatterns:  []regex.Regex{regexp.MustCompile(".*")},
+	r := heartbeat.Sanitize(context.Background(), h, heartbeat.SanitizeConfig{
+		ProjectPatterns: []regex.Regex{regex.NewRegexpWrap(regexp.MustCompile(".*"))},
+		BranchPatterns:  []regex.Regex{regex.NewRegexpWrap(regexp.MustCompile(".*"))},
 	})
 
 	assert.Equal(t, heartbeat.Heartbeat{
@@ -222,8 +225,8 @@ func TestSanitize_ObfuscateProject_NilFields(t *testing.T) {
 }
 
 func TestSanitize_ObfuscateBranch(t *testing.T) {
-	r := heartbeat.Sanitize(testHeartbeat(), heartbeat.SanitizeConfig{
-		BranchPatterns: []regex.Regex{regexp.MustCompile(".*")},
+	r := heartbeat.Sanitize(context.Background(), testHeartbeat(), heartbeat.SanitizeConfig{
+		BranchPatterns: []regex.Regex{regex.NewRegexpWrap(regexp.MustCompile(".*"))},
 	})
 
 	assert.Equal(t, heartbeat.Heartbeat{
@@ -247,8 +250,8 @@ func TestSanitize_ObfuscateBranch_NilFields(t *testing.T) {
 	h.Branch = nil
 	h.Project = nil
 
-	r := heartbeat.Sanitize(h, heartbeat.SanitizeConfig{
-		BranchPatterns: []regex.Regex{regexp.MustCompile(".*")},
+	r := heartbeat.Sanitize(context.Background(), h, heartbeat.SanitizeConfig{
+		BranchPatterns: []regex.Regex{regex.NewRegexpWrap(regexp.MustCompile(".*"))},
 	})
 
 	assert.Equal(t, heartbeat.Heartbeat{
@@ -267,7 +270,7 @@ func TestSanitize_ObfuscateBranch_NilFields(t *testing.T) {
 }
 
 func TestSanitize_EmptyConfigDoNothing(t *testing.T) {
-	r := heartbeat.Sanitize(testHeartbeat(), heartbeat.SanitizeConfig{})
+	r := heartbeat.Sanitize(context.Background(), testHeartbeat(), heartbeat.SanitizeConfig{})
 
 	assert.Equal(t, heartbeat.Heartbeat{
 		Branch:         heartbeat.PointerTo("heartbeat"),
@@ -290,7 +293,7 @@ func TestSanitize_EmptyConfigDoNothing_EmptyDependencies(t *testing.T) {
 	h := testHeartbeat()
 	h.Dependencies = []string{}
 
-	r := heartbeat.Sanitize(h, heartbeat.SanitizeConfig{})
+	r := heartbeat.Sanitize(context.Background(), h, heartbeat.SanitizeConfig{})
 
 	assert.Equal(t, heartbeat.Heartbeat{
 		Branch:         heartbeat.PointerTo("heartbeat"),
@@ -313,7 +316,7 @@ func TestSanitize_ObfuscateProjectFolder(t *testing.T) {
 	h.Entity = "/path/to/project/main.go"
 	h.ProjectPath = "/path/to"
 
-	r := heartbeat.Sanitize(h, heartbeat.SanitizeConfig{
+	r := heartbeat.Sanitize(context.Background(), h, heartbeat.SanitizeConfig{
 		HideProjectFolder: true,
 	})
 
@@ -341,7 +344,7 @@ func TestSanitize_ObfuscateProjectFolder_Override(t *testing.T) {
 	h.ProjectPath = "/original/folder"
 	h.ProjectPathOverride = "/path/to"
 
-	r := heartbeat.Sanitize(h, heartbeat.SanitizeConfig{
+	r := heartbeat.Sanitize(context.Background(), h, heartbeat.SanitizeConfig{
 		HideProjectFolder: true,
 	})
 
@@ -368,7 +371,7 @@ func TestSanitize_ObfuscateCredentials_RemoteFile(t *testing.T) {
 	h := testHeartbeat()
 	h.Entity = "ssh://wakatime:1234@192.168.1.1/path/to/remote/main.go"
 
-	r := heartbeat.Sanitize(h, heartbeat.SanitizeConfig{})
+	r := heartbeat.Sanitize(context.Background(), h, heartbeat.SanitizeConfig{})
 
 	assert.Equal(t, heartbeat.Heartbeat{
 		Branch:         heartbeat.PointerTo("heartbeat"),
@@ -388,6 +391,8 @@ func TestSanitize_ObfuscateCredentials_RemoteFile(t *testing.T) {
 }
 
 func TestShouldSanitize(t *testing.T) {
+	ctx := context.Background()
+
 	tests := map[string]struct {
 		Subject  string
 		Regex    []regex.Regex
@@ -396,23 +401,23 @@ func TestShouldSanitize(t *testing.T) {
 		"match_single": {
 			Subject: "fix.123",
 			Regex: []regex.Regex{
-				regexp.MustCompile("fix.*"),
+				regex.NewRegexpWrap(regexp.MustCompile("fix.*")),
 			},
 			Expected: true,
 		},
 		"match_multiple": {
 			Subject: "fix.456",
 			Regex: []regex.Regex{
-				regexp.MustCompile("bar.*"),
-				regexp.MustCompile("fix.*"),
+				regex.NewRegexpWrap(regexp.MustCompile("bar.*")),
+				regex.NewRegexpWrap(regexp.MustCompile("fix.*")),
 			},
 			Expected: true,
 		},
 		"not_match": {
 			Subject: "foo",
 			Regex: []regex.Regex{
-				regexp.MustCompile("bar.*"),
-				regexp.MustCompile("fix.*"),
+				regex.NewRegexpWrap(regexp.MustCompile("bar.*")),
+				regex.NewRegexpWrap(regexp.MustCompile("fix.*")),
 			},
 			Expected: false,
 		},
@@ -420,7 +425,7 @@ func TestShouldSanitize(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			shouldSanitize := heartbeat.ShouldSanitize(test.Subject, test.Regex)
+			shouldSanitize := heartbeat.ShouldSanitize(ctx, test.Subject, test.Regex)
 
 			assert.Equal(t, test.Expected, shouldSanitize)
 		})

--- a/pkg/language/language_test.go
+++ b/pkg/language/language_test.go
@@ -1,6 +1,7 @@
 package language_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -15,7 +16,7 @@ import (
 func TestWithDetection(t *testing.T) {
 	opt := language.WithDetection(language.Config{})
 
-	h := opt(func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+	h := opt(func(_ context.Context, hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
 		assert.Len(t, hh, 1)
 		assert.Equal(t, heartbeat.LanguageGo.String(), *hh[0].Language)
 		assert.Equal(t, []heartbeat.Heartbeat{
@@ -33,7 +34,7 @@ func TestWithDetection(t *testing.T) {
 		}, nil
 	})
 
-	result, err := h([]heartbeat.Heartbeat{
+	result, err := h(context.Background(), []heartbeat.Heartbeat{
 		{
 			Entity:     "testdata/codefiles/golang.go",
 			EntityType: heartbeat.FileType,
@@ -51,7 +52,7 @@ func TestWithDetection(t *testing.T) {
 func TestWithDetection_Override(t *testing.T) {
 	opt := language.WithDetection(language.Config{})
 
-	h := opt(func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+	h := opt(func(_ context.Context, hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
 		assert.Len(t, hh, 1)
 		assert.Equal(t, heartbeat.LanguagePython.String(), *hh[0].Language)
 		assert.Equal(t, []heartbeat.Heartbeat{
@@ -69,7 +70,7 @@ func TestWithDetection_Override(t *testing.T) {
 		}, nil
 	})
 
-	result, err := h([]heartbeat.Heartbeat{
+	result, err := h(context.Background(), []heartbeat.Heartbeat{
 		{
 			Entity:     "testdata/codefiles/golang.go",
 			EntityType: heartbeat.FileType,
@@ -88,7 +89,7 @@ func TestWithDetection_Override(t *testing.T) {
 func TestWithDetection_NonExistingEntity_Override(t *testing.T) {
 	opt := language.WithDetection(language.Config{})
 
-	h := opt(func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+	h := opt(func(_ context.Context, hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
 		assert.Len(t, hh, 1)
 		assert.Equal(t, heartbeat.LanguagePython.String(), hh[0].LanguageAlternate)
 		assert.Equal(t, []heartbeat.Heartbeat{
@@ -107,7 +108,7 @@ func TestWithDetection_NonExistingEntity_Override(t *testing.T) {
 		}, nil
 	})
 
-	result, err := h([]heartbeat.Heartbeat{
+	result, err := h(context.Background(), []heartbeat.Heartbeat{
 		{
 			Entity:            "nonexisting",
 			EntityType:        heartbeat.FileType,
@@ -126,7 +127,7 @@ func TestWithDetection_NonExistingEntity_Override(t *testing.T) {
 func TestWithDetection_Alternate(t *testing.T) {
 	opt := language.WithDetection(language.Config{})
 
-	h := opt(func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+	h := opt(func(_ context.Context, hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
 		assert.Len(t, hh, 1)
 		assert.Equal(t, []heartbeat.Heartbeat{
 			{
@@ -144,7 +145,7 @@ func TestWithDetection_Alternate(t *testing.T) {
 		}, nil
 	})
 
-	result, err := h([]heartbeat.Heartbeat{
+	result, err := h(context.Background(), []heartbeat.Heartbeat{
 		{
 			Entity:            "testdata/codefiles/unknown.xyz",
 			EntityType:        heartbeat.FileType,
@@ -161,96 +162,96 @@ func TestWithDetection_Alternate(t *testing.T) {
 }
 
 func TestDetect_HeaderFile_Corresponding_C_File(t *testing.T) {
-	lang, err := language.Detect("testdata/codefiles/h_with_c_file/empty.h", false)
+	lang, err := language.Detect(context.Background(), "testdata/codefiles/h_with_c_file/empty.h", false)
 	require.NoError(t, err)
 	assert.Equal(t, heartbeat.LanguageC, lang)
 }
 
 func TestDetect_HeaderFile_With_C_Files(t *testing.T) {
-	lang, err := language.Detect("testdata/codefiles/h_with_any_c_file/empty.h", false)
+	lang, err := language.Detect(context.Background(), "testdata/codefiles/h_with_any_c_file/empty.h", false)
 	require.NoError(t, err)
 	assert.Equal(t, heartbeat.LanguageC, lang)
 }
 
 func TestDetect_HeaderFile_With_C_And_CPP_Files(t *testing.T) {
-	lang, err := language.Detect("testdata/codefiles/h_with_any_c_and_cpp_files/cpp.h", false)
+	lang, err := language.Detect(context.Background(), "testdata/codefiles/h_with_any_c_and_cpp_files/cpp.h", false)
 	require.NoError(t, err)
 
 	assert.Equal(t, heartbeat.LanguageCPP, lang)
 }
 
 func TestDetect_HeaderFile_With_C_And_CXX_Files(t *testing.T) {
-	lang, err := language.Detect("testdata/codefiles/h_with_any_c_and_cxx_files/cpp.h", false)
+	lang, err := language.Detect(context.Background(), "testdata/codefiles/h_with_any_c_and_cxx_files/cpp.h", false)
 	require.NoError(t, err)
 
 	assert.Equal(t, heartbeat.LanguageCPP, lang)
 }
 
 func TestDetect_ObjectiveC_Over_Matlab_MatchingHeader(t *testing.T) {
-	lang, err := language.Detect("testdata/codefiles/with_mat_file/objective-c.m", false)
+	lang, err := language.Detect(context.Background(), "testdata/codefiles/with_mat_file/objective-c.m", false)
 	require.NoError(t, err)
 
 	assert.Equal(t, heartbeat.LanguageObjectiveC, lang)
 }
 
 func TestDetect_ObjectiveC_M_FileInFolder(t *testing.T) {
-	lang, err := language.Detect("testdata/codefiles/with_mat_file/objective-c.h", false)
+	lang, err := language.Detect(context.Background(), "testdata/codefiles/with_mat_file/objective-c.h", false)
 	require.NoError(t, err)
 
 	assert.Equal(t, heartbeat.LanguageObjectiveC, lang)
 }
 
 func TestDetect_ObjectiveCPP_MatchingHeader(t *testing.T) {
-	lang, err := language.Detect("testdata/codefiles/with_mat_file/objective-cpp.mm", false)
+	lang, err := language.Detect(context.Background(), "testdata/codefiles/with_mat_file/objective-cpp.mm", false)
 	require.NoError(t, err)
 
 	assert.Equal(t, heartbeat.LanguageObjectiveCPP, lang)
 }
 
 func TestDetect_ObjectiveCPP_MM_FileInFolder(t *testing.T) {
-	lang, err := language.Detect("testdata/codefiles/with_mat_file/objective-cpp.h", false)
+	lang, err := language.Detect(context.Background(), "testdata/codefiles/with_mat_file/objective-cpp.h", false)
 	require.NoError(t, err)
 
 	assert.Equal(t, heartbeat.LanguageObjectiveCPP, lang)
 }
 
 func TestDetect_ObjectiveC(t *testing.T) {
-	lang, err := language.Detect("testdata/codefiles/objective-c.m", false)
+	lang, err := language.Detect(context.Background(), "testdata/codefiles/objective-c.m", false)
 	require.NoError(t, err)
 
 	assert.Equal(t, heartbeat.LanguageObjectiveC, lang)
 }
 
 func TestDetect_Matlab_Over_ObjectiveC_Mat_FileInFolder(t *testing.T) {
-	lang, err := language.Detect("testdata/codefiles/with_mat_file/empty.m", false)
+	lang, err := language.Detect(context.Background(), "testdata/codefiles/with_mat_file/empty.m", false)
 	require.NoError(t, err)
 
 	assert.Equal(t, heartbeat.LanguageMatlab, lang)
 }
 
 func TestDetect_ObjectiveC_Over_Matlab_NonMatchingHeader(t *testing.T) {
-	lang, err := language.Detect("testdata/codefiles/matlab_with_headers/empty.m", false)
+	lang, err := language.Detect(context.Background(), "testdata/codefiles/matlab_with_headers/empty.m", false)
 	require.NoError(t, err)
 
 	assert.Equal(t, heartbeat.LanguageObjectiveC, lang)
 }
 
 func TestDetect_NonHeaderFile_C_FilesInFolder(t *testing.T) {
-	lang, err := language.Detect("testdata/codefiles/py_with_c_files/see.py", false)
+	lang, err := language.Detect(context.Background(), "testdata/codefiles/py_with_c_files/see.py", false)
 	require.NoError(t, err)
 
 	assert.Equal(t, heartbeat.LanguagePython, lang)
 }
 
 func TestDetect_Perl_Over_Prolog(t *testing.T) {
-	lang, err := language.Detect("testdata/codefiles/perl.pl", false)
+	lang, err := language.Detect(context.Background(), "testdata/codefiles/perl.pl", false)
 	require.NoError(t, err)
 
 	assert.Equal(t, heartbeat.LanguagePerl, lang)
 }
 
 func TestDetect_FSharp_Over_Forth(t *testing.T) {
-	lang, err := language.Detect("testdata/codefiles/fsharp.fs", false)
+	lang, err := language.Detect(context.Background(), "testdata/codefiles/fsharp.fs", false)
 	require.NoError(t, err)
 
 	assert.Equal(t, heartbeat.LanguageFSharp, lang)
@@ -259,6 +260,8 @@ func TestDetect_FSharp_Over_Forth(t *testing.T) {
 func TestDetect_ChromaTopLanguagesRetrofit(t *testing.T) {
 	err := lexer.RegisterAll()
 	require.NoError(t, err)
+
+	ctx := context.Background()
 
 	tests := map[string]struct {
 		Filepaths     []string
@@ -908,7 +911,7 @@ func TestDetect_ChromaTopLanguagesRetrofit(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			for _, filepath := range test.Filepaths {
-				lang, err := language.Detect(filepath, test.GuessLanguage)
+				lang, err := language.Detect(ctx, filepath, test.GuessLanguage)
 				require.NoError(t, err)
 
 				assert.Equal(t, test.Expected, lang, fmt.Sprintf("Got: %q, want: %q", lang, test.Expected))

--- a/pkg/lexer/ruby.go
+++ b/pkg/lexer/ruby.go
@@ -2,7 +2,6 @@ package lexer
 
 import (
 	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
-	"github.com/wakatime/wakatime-cli/pkg/log"
 
 	"github.com/alecthomas/chroma/v2/lexers"
 )
@@ -13,13 +12,11 @@ func init() {
 	lexer := lexers.Get(language)
 
 	if lexer == nil {
-		log.Debugf("lexer %q not found", language)
 		return
 	}
 
 	cfg := lexer.Config()
 	if cfg == nil {
-		log.Debugf("lexer %q config not found", language)
 		return
 	}
 

--- a/pkg/log/context.go
+++ b/pkg/log/context.go
@@ -1,0 +1,39 @@
+package log
+
+import "context"
+
+type (
+	ctxMarker struct{}
+
+	ctxLogger struct {
+		logger *Logger
+	}
+)
+
+// nolint:gochecknoglobals
+var ctxMarkerKey = &ctxMarker{}
+
+// Extract takes the call-scoped Logger.
+func Extract(ctx context.Context) *Logger {
+	l, ok := ctx.Value(ctxMarkerKey).(*ctxLogger)
+	if !ok || l == nil {
+		return New(false, false, false)
+	}
+
+	return l.logger
+}
+
+// ToContext adds the log.Logger to the context for extraction later.
+// Returning the new context that has been created.
+func ToContext(ctx context.Context, logger *Logger) context.Context {
+	l := &ctxLogger{
+		logger: logger,
+	}
+
+	return context.WithValue(ctx, ctxMarkerKey, l)
+}
+
+// AddField adds a field to the context logger.
+func AddField(ctx context.Context, key string, value any) {
+	Extract(ctx).WithField(key, value)
+}

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -1,0 +1,45 @@
+package log_test
+
+import (
+	"testing"
+
+	"github.com/wakatime/wakatime-cli/pkg/log"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLog_IsMetricsEnabled(t *testing.T) {
+	logger := log.New(false, false, true)
+
+	assert.True(t, logger.IsMetricsEnabled())
+}
+
+func TestLog_IsMetricsEnabled_Disabled(t *testing.T) {
+	logger := log.New(false, false, false)
+
+	assert.False(t, logger.IsMetricsEnabled())
+}
+
+func TestLog_IsVerboseEnabled(t *testing.T) {
+	logger := log.New(true, false, false)
+
+	assert.True(t, logger.IsVerboseEnabled())
+}
+
+func TestLog_IsVerboseEnabled_Disabled(t *testing.T) {
+	logger := log.New(false, false, false)
+
+	assert.False(t, logger.IsVerboseEnabled())
+}
+
+func TestLog_SendDiagsOnErrors(t *testing.T) {
+	logger := log.New(false, true, false)
+
+	assert.True(t, logger.SendDiagsOnErrors())
+}
+
+func TestLog_SendDiagsOnErrors_Disabled(t *testing.T) {
+	logger := log.New(false, false, false)
+
+	assert.False(t, logger.SendDiagsOnErrors())
+}

--- a/pkg/offline/legacy.go
+++ b/pkg/offline/legacy.go
@@ -1,6 +1,7 @@
 package offline
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 
@@ -17,7 +18,7 @@ const dbLegacyFilename = ".wakatime.bdb"
 // the user's $HOME folder cannot be detected, it defaults to the
 // current directory.
 // This is used to support the old db file name and will be removed in the future.
-func QueueFilepathLegacy(v *viper.Viper) (string, error) {
+func QueueFilepathLegacy(ctx context.Context, v *viper.Viper) (string, error) {
 	paramFile := vipertools.GetString(v, "offline-queue-file-legacy")
 	if paramFile != "" {
 		p, err := homedir.Expand(paramFile)
@@ -28,7 +29,7 @@ func QueueFilepathLegacy(v *viper.Viper) (string, error) {
 		return p, nil
 	}
 
-	home, _, err := ini.WakaHomeDir()
+	home, _, err := ini.WakaHomeDir(ctx)
 	if err != nil {
 		return dbFilename, fmt.Errorf("failed getting user's home directory, defaulting to current directory: %s", err)
 	}

--- a/pkg/offline/legacy_test.go
+++ b/pkg/offline/legacy_test.go
@@ -1,6 +1,7 @@
 package offline_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -15,6 +16,8 @@ import (
 func TestQueueFilepathLegacy(t *testing.T) {
 	home, err := os.UserHomeDir()
 	require.NoError(t, err)
+
+	ctx := context.Background()
 
 	tests := map[string]struct {
 		ViperValue string
@@ -42,7 +45,7 @@ func TestQueueFilepathLegacy(t *testing.T) {
 			defer os.Unsetenv("WAKATIME_HOME")
 
 			v := viper.New()
-			queueFilepath, err := offline.QueueFilepathLegacy(v)
+			queueFilepath, err := offline.QueueFilepathLegacy(ctx, v)
 			require.NoError(t, err)
 
 			assert.Equal(t, test.Expected, queueFilepath)

--- a/pkg/project/file_test.go
+++ b/pkg/project/file_test.go
@@ -1,6 +1,7 @@
 package project_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -26,7 +27,7 @@ func TestFile_Detect_FileExists(t *testing.T) {
 		Filepath: filepath.Join(tmpDir, ".wakatime-project"),
 	}
 
-	result, detected, err := f.Detect()
+	result, detected, err := f.Detect(context.Background())
 	require.NoError(t, err)
 
 	expected := project.Result{
@@ -58,7 +59,7 @@ func TestFile_Detect_ParentFolderExists(t *testing.T) {
 		Filepath: dir,
 	}
 
-	result, detected, err := f.Detect()
+	result, detected, err := f.Detect(context.Background())
 	require.NoError(t, err)
 
 	expected := project.Result{
@@ -83,7 +84,7 @@ func TestFile_Detect_NoFileFound(t *testing.T) {
 		Filepath: tmpDir,
 	}
 
-	result, detected, err := f.Detect()
+	result, detected, err := f.Detect(context.Background())
 	require.NoError(t, err)
 
 	expected := project.Result{}
@@ -102,7 +103,7 @@ func TestFile_Detect_InvalidPath(t *testing.T) {
 		Filepath: tmpFile.Name(),
 	}
 
-	_, detected, err := f.Detect()
+	_, detected, err := f.Detect(context.Background())
 	require.NoError(t, err)
 
 	assert.False(t, detected)
@@ -121,6 +122,8 @@ func TestFindFileOrDirectory(t *testing.T) {
 		"testdata/wakatime-project",
 		filepath.Join(tmpDir, ".wakatime-project"),
 	)
+
+	ctx := context.Background()
 
 	tests := map[string]struct {
 		Filepath string
@@ -141,7 +144,7 @@ func TestFindFileOrDirectory(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			fp, ok := project.FindFileOrDirectory(test.Filepath, test.Filename)
+			fp, ok := project.FindFileOrDirectory(ctx, test.Filepath, test.Filename)
 			require.True(t, ok)
 
 			assert.Equal(t, test.Expected, fp)

--- a/pkg/project/filter_test.go
+++ b/pkg/project/filter_test.go
@@ -1,6 +1,7 @@
 package project_test
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -26,7 +27,7 @@ func TestWithFiltering(t *testing.T) {
 	opt := project.WithFiltering(project.FilterConfig{
 		ExcludeUnknownProject: true,
 	})
-	h := opt(func(hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+	h := opt(func(_ context.Context, hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
 		assert.Equal(t, []heartbeat.Heartbeat{
 			{
 				Branch:         heartbeat.PointerTo("heartbeat"),
@@ -52,7 +53,7 @@ func TestWithFiltering(t *testing.T) {
 		}, nil
 	})
 
-	result, err := h([]heartbeat.Heartbeat{first, second})
+	result, err := h(context.Background(), []heartbeat.Heartbeat{first, second})
 	require.NoError(t, err)
 
 	assert.Equal(t, []heartbeat.Result{

--- a/pkg/project/git_test.go
+++ b/pkg/project/git_test.go
@@ -1,6 +1,7 @@
 package project_test
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -24,7 +25,7 @@ func TestGit_Detect(t *testing.T) {
 		Filepath: filepath.Join(fp, "wakatime-cli/src/pkg/file.go"),
 	}
 
-	result, detected, err := g.Detect()
+	result, detected, err := g.Detect(context.Background())
 	require.NoError(t, err)
 
 	assert.True(t, detected)
@@ -43,7 +44,7 @@ func TestGit_Detect_BranchWithSlash(t *testing.T) {
 		Filepath: filepath.Join(fp, "wakatime-cli/src/pkg/file.go"),
 	}
 
-	result, detected, err := g.Detect()
+	result, detected, err := g.Detect(context.Background())
 	require.NoError(t, err)
 
 	assert.True(t, detected)
@@ -62,7 +63,7 @@ func TestGit_Detect_DetachedHead(t *testing.T) {
 		Filepath: filepath.Join(fp, "wakatime-cli/src/pkg/file.go"),
 	}
 
-	result, detected, err := g.Detect()
+	result, detected, err := g.Detect(context.Background())
 	require.NoError(t, err)
 
 	assert.True(t, detected)
@@ -101,7 +102,7 @@ func TestGit_Detect_GitConfigFile_File(t *testing.T) {
 				Filepath: test.Filepath,
 			}
 
-			result, detected, err := g.Detect()
+			result, detected, err := g.Detect(context.Background())
 			require.NoError(t, err)
 
 			assert.True(t, detected)
@@ -126,7 +127,7 @@ func TestGit_Detect_GitConfigFile_File_MalformedHEAD(t *testing.T) {
 		Filepath: filepath.Join(fp, "wakatime-cli/src/pkg/file.go"),
 	}
 
-	result, detected, err := g.Detect()
+	result, detected, err := g.Detect(context.Background())
 	require.NoError(t, err)
 
 	assert.True(t, detected)
@@ -145,7 +146,7 @@ func TestGit_Detect_Worktree(t *testing.T) {
 		Filepath: filepath.Join(fp, "api/src/pkg/file.go"),
 	}
 
-	result, detected, err := g.Detect()
+	result, detected, err := g.Detect(context.Background())
 	require.NoError(t, err)
 
 	assert.True(t, detected)
@@ -165,7 +166,7 @@ func TestGit_Detect_WorktreeGitRemote(t *testing.T) {
 		ProjectFromGitRemote: true,
 	}
 
-	result, detected, err := g.Detect()
+	result, detected, err := g.Detect(context.Background())
 	require.NoError(t, err)
 
 	assert.True(t, detected)
@@ -184,7 +185,7 @@ func TestGit_Detect_Worktree_BareRepo(t *testing.T) {
 		Filepath: filepath.Join(fp, "wakatime-cli/master/src/pkg/file.go"),
 	}
 
-	result, detected, err := g.Detect()
+	result, detected, err := g.Detect(context.Background())
 	require.NoError(t, err)
 
 	assert.True(t, detected)
@@ -204,7 +205,7 @@ func TestGit_Detect_WorktreeGitRemote_BareRepo(t *testing.T) {
 		ProjectFromGitRemote: true,
 	}
 
-	result, detected, err := g.Detect()
+	result, detected, err := g.Detect(context.Background())
 	require.NoError(t, err)
 
 	assert.True(t, detected)
@@ -221,10 +222,10 @@ func TestGit_Detect_Submodule(t *testing.T) {
 
 	g := project.Git{
 		Filepath:                  filepath.Join(fp, "wakatime-cli/lib/billing/src/lib/lib.cpp"),
-		SubmoduleDisabledPatterns: []regex.Regex{regexp.MustCompile("not_matching")},
+		SubmoduleDisabledPatterns: []regex.Regex{regex.NewRegexpWrap(regexp.MustCompile("not_matching"))},
 	}
 
-	result, detected, err := g.Detect()
+	result, detected, err := g.Detect(context.Background())
 	require.NoError(t, err)
 
 	assert.True(t, detected)
@@ -241,10 +242,10 @@ func TestGit_Detect_SubmoduleDisabled(t *testing.T) {
 
 	g := project.Git{
 		Filepath:                  filepath.Join(fp, "wakatime-cli/lib/billing/src/lib/lib.cpp"),
-		SubmoduleDisabledPatterns: []regex.Regex{regexp.MustCompile(".*billing.*")},
+		SubmoduleDisabledPatterns: []regex.Regex{regex.NewRegexpWrap(regexp.MustCompile(".*billing.*"))},
 	}
 
-	result, detected, err := g.Detect()
+	result, detected, err := g.Detect(context.Background())
 	require.NoError(t, err)
 
 	assert.True(t, detected)
@@ -264,12 +265,12 @@ func TestGit_Detect_SubmoduleProjectMap_NotMatch(t *testing.T) {
 		SubmoduleProjectMapPatterns: []project.MapPattern{
 			{
 				Name:  "my-project-1",
-				Regex: regexp.MustCompile(formatRegex("not_matching")),
+				Regex: regex.NewRegexpWrap(regexp.MustCompile(formatRegex("not_matching"))),
 			},
 		},
 	}
 
-	result, detected, err := g.Detect()
+	result, detected, err := g.Detect(context.Background())
 	require.NoError(t, err)
 
 	assert.True(t, detected)
@@ -289,12 +290,12 @@ func TestGit_Detect_SubmoduleProjectMap(t *testing.T) {
 		SubmoduleProjectMapPatterns: []project.MapPattern{
 			{
 				Name:  "my-project-1",
-				Regex: regexp.MustCompile(formatRegex(".*billing.*")),
+				Regex: regex.NewRegexpWrap(regexp.MustCompile(formatRegex(".*billing.*"))),
 			},
 		},
 	}
 
-	result, detected, err := g.Detect()
+	result, detected, err := g.Detect(context.Background())
 	require.NoError(t, err)
 
 	assert.True(t, detected)
@@ -312,10 +313,10 @@ func TestGit_Detect_SubmoduleGitRemote(t *testing.T) {
 	g := project.Git{
 		Filepath:                  filepath.Join(fp, "wakatime-cli/lib/billing/src/lib/lib.cpp"),
 		ProjectFromGitRemote:      true,
-		SubmoduleDisabledPatterns: []regex.Regex{regexp.MustCompile("not_matching")},
+		SubmoduleDisabledPatterns: []regex.Regex{regex.NewRegexpWrap(regexp.MustCompile("not_matching"))},
 	}
 
-	result, detected, err := g.Detect()
+	result, detected, err := g.Detect(context.Background())
 	require.NoError(t, err)
 
 	assert.True(t, detected)

--- a/pkg/project/map_test.go
+++ b/pkg/project/map_test.go
@@ -1,12 +1,14 @@
 package project_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"regexp"
 	"testing"
 
 	"github.com/wakatime/wakatime-cli/pkg/project"
+	"github.com/wakatime/wakatime-cli/pkg/regex"
 
 	"github.com/gandarez/go-realpath"
 	"github.com/stretchr/testify/assert"
@@ -25,12 +27,12 @@ func TestMap_Detect(t *testing.T) {
 		Patterns: []project.MapPattern{
 			{
 				Name:  "my-project-1",
-				Regex: regexp.MustCompile(formatRegex(filepath.Join(wd, "testdata"))),
+				Regex: regex.NewRegexpWrap(regexp.MustCompile(formatRegex(filepath.Join(wd, "testdata")))),
 			},
 		},
 	}
 
-	result, detected, err := m.Detect()
+	result, detected, err := m.Detect(context.Background())
 	require.NoError(t, err)
 
 	assert.True(t, detected)
@@ -51,16 +53,16 @@ func TestMap_Detect_RegexReplace(t *testing.T) {
 		Patterns: []project.MapPattern{
 			{
 				Name:  "my-project-1",
-				Regex: regexp.MustCompile(formatRegex(filepath.Join(wd, "path", "to", "otherfolder"))),
+				Regex: regex.NewRegexpWrap(regexp.MustCompile(formatRegex(filepath.Join(wd, "path", "to", "otherfolder")))),
 			},
 			{
 				Name:  "my-project-2-{0}",
-				Regex: regexp.MustCompile(formatRegex(filepath.Join(wd, `test([a-zA-Z]+)`))),
+				Regex: regex.NewRegexpWrap(regexp.MustCompile(formatRegex(filepath.Join(wd, `test([a-zA-Z]+)`)))),
 			},
 		},
 	}
 
-	result, detected, err := m.Detect()
+	result, detected, err := m.Detect(context.Background())
 	require.NoError(t, err)
 
 	assert.True(t, detected)
@@ -78,16 +80,16 @@ func TestMap_Detect_NoMatch(t *testing.T) {
 		Patterns: []project.MapPattern{
 			{
 				Name:  "my_project_1",
-				Regex: regexp.MustCompile(formatRegex(filepath.Join(wd, "path", "to", "otherfolder"))),
+				Regex: regex.NewRegexpWrap(regexp.MustCompile(formatRegex(filepath.Join(wd, "path", "to", "otherfolder")))),
 			},
 			{
 				Name:  "my_project_2",
-				Regex: regexp.MustCompile(formatRegex(filepath.Join(wd, "path", "to", "temp"))),
+				Regex: regex.NewRegexpWrap(regexp.MustCompile(formatRegex(filepath.Join(wd, "path", "to", "temp")))),
 			},
 		},
 	}
 
-	result, detected, err := m.Detect()
+	result, detected, err := m.Detect(context.Background())
 	require.NoError(t, err)
 
 	assert.False(t, detected)
@@ -101,7 +103,7 @@ func TestMap_Detect_ZeroPatterns(t *testing.T) {
 		Patterns: []project.MapPattern{},
 	}
 
-	_, detected, err := m.Detect()
+	_, detected, err := m.Detect(context.Background())
 	require.NoError(t, err)
 
 	assert.False(t, detected)

--- a/pkg/project/mercurial_test.go
+++ b/pkg/project/mercurial_test.go
@@ -1,6 +1,7 @@
 package project_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -18,7 +19,7 @@ func TestMercurial_Detect(t *testing.T) {
 		Filepath: filepath.Join(fp, "wakatime-cli/src/pkg/file.go"),
 	}
 
-	result, detected, err := m.Detect()
+	result, detected, err := m.Detect(context.Background())
 	require.NoError(t, err)
 
 	assert.True(t, detected)
@@ -37,7 +38,7 @@ func TestMercurial_Detect_BranchWithSlash(t *testing.T) {
 		Filepath: filepath.Join(fp, "wakatime-cli/src/pkg/file.go"),
 	}
 
-	result, detected, err := m.Detect()
+	result, detected, err := m.Detect(context.Background())
 	require.NoError(t, err)
 
 	assert.True(t, detected)
@@ -56,7 +57,7 @@ func TestMercurial_Detect_NoBranch(t *testing.T) {
 		Filepath: filepath.Join(fp, "wakatime-cli/src/pkg/file.go"),
 	}
 
-	result, detected, err := m.Detect()
+	result, detected, err := m.Detect(context.Background())
 	require.NoError(t, err)
 
 	assert.True(t, detected)

--- a/pkg/project/subversion_test.go
+++ b/pkg/project/subversion_test.go
@@ -1,6 +1,7 @@
 package project_test
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -21,7 +22,7 @@ func TestSubversion_Detect(t *testing.T) {
 		Filepath: filepath.Join(fp, "wakatime-cli", "src", "pkg", "file.go"),
 	}
 
-	result, detected, err := s.Detect()
+	result, detected, err := s.Detect(context.Background())
 	require.NoError(t, err)
 
 	assert.True(t, detected)
@@ -41,7 +42,7 @@ func TestSubversion_Detect_Branch(t *testing.T) {
 		Filepath: filepath.Join(fp, "wakatime-cli/src/pkg/file.go"),
 	}
 
-	result, detected, err := s.Detect()
+	result, detected, err := s.Detect(context.Background())
 	require.NoError(t, err)
 
 	assert.True(t, detected)

--- a/pkg/project/tfvc.go
+++ b/pkg/project/tfvc.go
@@ -1,6 +1,7 @@
 package project
 
 import (
+	"context"
 	"path/filepath"
 	"runtime"
 )
@@ -12,7 +13,7 @@ type Tfvc struct {
 }
 
 // Detect gets information about the tfvc project for a given file.
-func (t Tfvc) Detect() (Result, bool, error) {
+func (t Tfvc) Detect(ctx context.Context) (Result, bool, error) {
 	var fp string
 
 	// Take only the directory
@@ -26,7 +27,7 @@ func (t Tfvc) Detect() (Result, bool, error) {
 	}
 
 	// Find for tf/properties.tf1 file
-	tfDirectory, found := FindFileOrDirectory(fp, filepath.Join(tfFolderName, "properties.tf1"))
+	tfDirectory, found := FindFileOrDirectory(ctx, fp, filepath.Join(tfFolderName, "properties.tf1"))
 	if !found {
 		return Result{}, false, nil
 	}

--- a/pkg/project/tfvc_test.go
+++ b/pkg/project/tfvc_test.go
@@ -1,6 +1,7 @@
 package project_test
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -24,7 +25,7 @@ func TestTfvc_Detect(t *testing.T) {
 		Filepath: filepath.Join(fp, "wakatime-cli", "src", "pkg", "file.go"),
 	}
 
-	result, detected, err := s.Detect()
+	result, detected, err := s.Detect(context.Background())
 	require.NoError(t, err)
 
 	assert.True(t, detected)
@@ -46,7 +47,7 @@ func TestTfvc_Detect_Windows(t *testing.T) {
 		Filepath: filepath.Join(fp, "wakatime-cli", "src", "pkg", "file.go"),
 	}
 
-	result, detected, err := s.Detect()
+	result, detected, err := s.Detect(context.Background())
 	require.NoError(t, err)
 
 	assert.True(t, detected)

--- a/pkg/regex/regex_internal_test.go
+++ b/pkg/regex/regex_internal_test.go
@@ -1,6 +1,7 @@
 package regex
 
 import (
+	"context"
 	"testing"
 
 	"github.com/dlclark/regexp2"
@@ -10,6 +11,8 @@ import (
 )
 
 func TestRegexp2Wrap_MatchString(t *testing.T) {
+	ctx := context.Background()
+
 	tests := map[string]bool{
 		"gopher":             false,
 		"gophergopher":       true,
@@ -25,12 +28,14 @@ func TestRegexp2Wrap_MatchString(t *testing.T) {
 				rgx: r2,
 			}
 
-			assert.Equal(t, expected, r.MatchString(str))
+			assert.Equal(t, expected, r.MatchString(ctx, str))
 		})
 	}
 }
 
 func TestRegexp2Wrap_FindStringSubmatch(t *testing.T) {
+	ctx := context.Background()
+
 	tests := map[string]struct {
 		String   string
 		Expected []string
@@ -54,7 +59,7 @@ func TestRegexp2Wrap_FindStringSubmatch(t *testing.T) {
 				rgx: r2,
 			}
 
-			matches := r.FindStringSubmatch(test.String)
+			matches := r.FindStringSubmatch(ctx, test.String)
 
 			assert.Equal(t, test.Expected, matches)
 		})

--- a/pkg/system/system_linux.go
+++ b/pkg/system/system_linux.go
@@ -3,6 +3,7 @@
 package system
 
 import (
+	"context"
 	"fmt"
 	"runtime"
 	"strings"
@@ -12,14 +13,16 @@ import (
 )
 
 // OSName returns the runtime machine's operating system name.
-func OSName() string {
+func OSName(ctx context.Context) string {
 	os := runtime.GOOS
 
 	var buf syscall.Utsname
 
+	logger := log.Extract(ctx)
+
 	err := syscall.Uname(&buf)
 	if err != nil {
-		log.Debugf("Uname error: %s", err)
+		logger.Debugf("Uname error: %s", err)
 
 		return os
 	}

--- a/pkg/system/system_other.go
+++ b/pkg/system/system_other.go
@@ -3,10 +3,11 @@
 package system
 
 import (
+	"context"
 	"runtime"
 )
 
 // OSName returns the runtime machine's operating system name.
-func OSName() string {
+func OSName(_ context.Context) string {
 	return runtime.GOOS
 }

--- a/pkg/system/system_other_test.go
+++ b/pkg/system/system_other_test.go
@@ -1,0 +1,22 @@
+//go:build !linux
+
+package system_test
+
+import (
+	"context"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/wakatime/wakatime-cli/pkg/system"
+)
+
+func TestOSName(t *testing.T) {
+	if runtime.GOOS != "darwin" && runtime.GOOS != "windows" {
+		t.Skip("skipping test on non-darwin and non-windows system")
+	}
+
+	name := system.OSName(context.Background())
+
+	assert.Equal(t, runtime.GOOS, name)
+}


### PR DESCRIPTION
This PR replaces the static logger with a more flexible way injected in the context.

The reason for this is to make tests more concise without workarounds by removing skipped ones. It also make log enabled everywhere through the context by simply calling `log.Extract(ctx)`. Although it changes lots of files, the main change is around the `log` package and the other files added context as parameter.

Tests that were skipped in Windows:
* TestSendHeartbeats_RateLimited
* TestRunCmd_BackoffNotLogged
* TestRunCmd_BackoffLoggedWithVerbose
* TestWithDetection_SshConfig_Hostname
* TestWithDetection_SshConfig_UserKnownHostsFile_Mismatch
* TestWithDetection_SshConfig_UserKnownHostsFile_Match
* TestWithDetection_Filtered

Other tests fixed:
* TestLoadHeartbeatParams_ExtraHeartbeats_NoData

In the future we can also inject the viper instance.