### PR TITLE
Bump changelog action to v1.5.0

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -644,7 +644,7 @@ jobs:
         # Run only for develop branch
         if: ${{ github.ref == 'refs/heads/develop' }}
         name: Changelog for develop
-        uses: gandarez/changelog-action@v1.4.0
+        uses: gandarez/changelog-action@v1.5.0
         id: changelog-develop
         with:
           current_tag: ${{ github.sha }}


### PR DESCRIPTION
This PR bumps changelog-develop to v1.5.0 to fix blank changelog output.