### PR TITLE
Bump codecov action to v5

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -43,7 +43,7 @@ jobs:
         run: make vulncheck
       -
         name: Coverage
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: unittests


### PR DESCRIPTION
This PR bumps codecov action to latest version (v5) to avoid pipeline warning
```
The following actions use a deprecated Node.js version and will be forced to run on node20: codecov/codecov-action@v3.
```