### PR TITLE
Release v1.106.0

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -43,7 +43,7 @@ jobs:
         run: make vulncheck
       -
         name: Coverage
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: unittests

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -37,6 +37,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"go.uber.org/zap/zapcore"
 	iniv1 "gopkg.in/ini.v1"
 	"gopkg.in/natefinch/lumberjack.v2"
 )
@@ -340,7 +341,9 @@ func runCmd(ctx context.Context, v *viper.Viper, verbose bool, sendDiagsOnErrors
 			verbose = verbose || errwaka.ShouldLogError()
 		}
 
-		if verbose {
+		if errloglevel, ok := err.(wakaerror.LogLevel); ok {
+			logger.Logf(zapcore.Level(errloglevel.LogLevel()), "failed to run command: %s", err)
+		} else if verbose {
 			logger.Errorf("failed to run command: %s", err)
 		}
 

--- a/pkg/api/error.go
+++ b/pkg/api/error.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/wakatime/wakatime-cli/pkg/exitcode"
 	"github.com/wakatime/wakatime-cli/pkg/wakaerror"
+
+	"go.uber.org/zap/zapcore"
 )
 
 // Err represents a general api error.
@@ -118,6 +120,11 @@ func (e ErrBackoff) Error() string {
 // ExitCode method to implement wakaerror.Error interface.
 func (ErrBackoff) ExitCode() int {
 	return exitcode.ErrBackoff
+}
+
+// LogLevel method to implement wakaerror.LogLevel interface.
+func (ErrBackoff) LogLevel() int8 {
+	return int8(zapcore.DebugLevel)
 }
 
 // Message method to implement wakaerror.Error interface.

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -130,6 +130,16 @@ func SetJww(verbose bool, w io.Writer) {
 	}
 }
 
+// Log logs a message at the given level.
+func (l Logger) Log(level zapcore.Level, msg string) {
+	l.entry.Log(level, msg)
+}
+
+// Logf logs a message at the given level.
+func (l Logger) Logf(level zapcore.Level, format string, args ...any) {
+	l.entry.Log(level, fmt.Sprintf(format, args...))
+}
+
 // Debugf logs a message at level Debug.
 func (l *Logger) Debugf(format string, args ...any) {
 	l.entry.Log(zapcore.DebugLevel, fmt.Sprintf(format, args...))

--- a/pkg/wakaerror/wakaerror.go
+++ b/pkg/wakaerror/wakaerror.go
@@ -1,14 +1,22 @@
 package wakaerror
 
-// Error is a custom error interface.
-type Error interface {
-	// ExitCode returns the exit code for the error.
-	ExitCode() int
-	// Message returns the error message.
-	Message() string
-	// SendDiagsOnErrors returns true when diagnostics should be sent on error.
-	SendDiagsOnErrors() bool
-	// ShouldLogError returns true when error should be logged.
-	ShouldLogError() bool
-	error
-}
+type (
+	// Error is a custom error interface.
+	Error interface {
+		// ExitCode returns the exit code for the error.
+		ExitCode() int
+		// Message returns the error message.
+		Message() string
+		// SendDiagsOnErrors returns true when diagnostics should be sent on error.
+		SendDiagsOnErrors() bool
+		// ShouldLogError returns true when error should be logged.
+		ShouldLogError() bool
+		error
+	}
+
+	// LogLevel is a custom log level interface to return log level for error.
+	LogLevel interface {
+		// LogLevel returns the log level for the error.
+		LogLevel() int8
+	}
+)

--- a/pkg/windows/windows.go
+++ b/pkg/windows/windows.go
@@ -115,7 +115,7 @@ func toUncPath(fp string) (string, error) {
 
 	out, err := cmd.Command("net use").Output()
 	if err != nil {
-		return "", fmt.Errorf("failed to execute ls command: %s", err)
+		return "", fmt.Errorf("failed to execute net use command: %s", err)
 	}
 
 	drives, err := parseNetUseOutput(string(out))


### PR DESCRIPTION
Changelog:
* [Bump codecov action to v5](https://github.com/wakatime/wakatime-cli/commit/4e72a97032db84307a9e27209a71a2368a10546c)
* [Fix net use message](https://github.com/wakatime/wakatime-cli/commit/4d9c9f11e689bd7dbe22ca810a002f5bb2e5ce68)
* [Log backoff as debug](https://github.com/wakatime/wakatime-cli/commit/ad9089d4d7ffa0cda836a45ef459126d32deab1c)