### PR TITLE
Handle panic for goInfo in Windows

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,13 +3,13 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"log"
 	"os"
 
 	"github.com/wakatime/wakatime-cli/pkg/api"
 	"github.com/wakatime/wakatime-cli/pkg/exitcode"
 	"github.com/wakatime/wakatime-cli/pkg/offline"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"gopkg.in/ini.v1"

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/matishsiao/goInfo v0.0.0-20240924010139-10388a85396f
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/sftp v1.13.7
-	github.com/sirupsen/logrus v1.9.3
 	github.com/slongfield/pyfmt v0.0.0-20220222012616-ea85ff4c361f
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/jwalterweatherman v1.1.0
@@ -62,3 +61,5 @@ require (
 	golang.org/x/sys v0.27.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/matishsiao/goInfo => github.com/wakatime/goInfo v0.1.0-wakatime.11

--- a/go.sum
+++ b/go.sum
@@ -99,8 +99,6 @@ github.com/masterzen/azure-sdk-for-go v3.2.0-beta.0.20161014135628-ee4f0065d00c+
 github.com/masterzen/simplexml v0.0.0-20160608183007-4572e39b1ab9/go.mod h1:kCEbxUJlNDEBNbdQMkPSp6yaKcRXVI6f4ddk8Riv4bc=
 github.com/masterzen/winrm v0.0.0-20161014151040-7a535cd943fc/go.mod h1:CfZSN7zwz5gJiFhZJz49Uzk7mEBHIceWmbFmYx7Hf7E=
 github.com/masterzen/xmlpath v0.0.0-20140218185901-13f4951698ad/go.mod h1:A0zPC53iKKKcXYxr4ROjpQRQ5FgJXtelNdSmHHuq/tY=
-github.com/matishsiao/goInfo v0.0.0-20240924010139-10388a85396f h1:XDrsC/9hdgiU9ecceSmYsS2E3fBtFiYc34dAMFgegnM=
-github.com/matishsiao/goInfo v0.0.0-20240924010139-10388a85396f/go.mod h1:aEt7p9Rvh67BYApmZwNDPpgircTO2kgdmDUoF/1QmwA=
 github.com/mattn/go-colorable v0.0.6/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.0-20160806122752-66b8e73f3f5c/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
@@ -126,8 +124,6 @@ github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6g
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
 github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=
 github.com/sergi/go-diff v1.3.1/go.mod h1:aMJSSKb2lpPvRNec0+w3fl7LP9IOFzdc9Pa4NFbPK1I=
-github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
-github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/slongfield/pyfmt v0.0.0-20220222012616-ea85ff4c361f h1:Z2cODYsUxQPofhpYRMQVwWz4yUVpHF+vPi+eUdruUYI=
 github.com/slongfield/pyfmt v0.0.0-20220222012616-ea85ff4c361f/go.mod h1:JqzWyvTuI2X4+9wOHmKSQCYxybB/8j6Ko43qVmXDuZg=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
@@ -148,13 +144,14 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
+github.com/wakatime/goInfo v0.1.0-wakatime.11 h1:v7/UhNjcKCNbBX/oe0LWA6mBbpJ60/km7VS+BcjZ0KU=
+github.com/wakatime/goInfo v0.1.0-wakatime.11/go.mod h1:aEt7p9Rvh67BYApmZwNDPpgircTO2kgdmDUoF/1QmwA=
 github.com/yookoala/realpath v1.0.0 h1:7OA9pj4FZd+oZDsyvXWQvjn5oBdcHRTV44PpdMSuImQ=
 github.com/yookoala/realpath v1.0.0/go.mod h1:gJJMA9wuX7AcqLy1+ffPatSCySA1FQ2S8Ya9AIoYBpE=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
@@ -206,7 +203,6 @@ golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/pkg/api/fileexperts.go
+++ b/pkg/api/fileexperts.go
@@ -88,7 +88,7 @@ func ParseFileExpertsResponse(data []byte) ([]heartbeat.Result, error) {
 	var body fileexperts.FileExperts
 
 	if err := json.Unmarshal(data, &body); err != nil {
-		return nil, fmt.Errorf("failed to parse json response body: %s. body: %q", err, data)
+		return nil, fmt.Errorf("failed to parse json response body: %s. body: %q", err, string(data))
 	}
 
 	return []heartbeat.Result{{FileExpert: &body}}, nil


### PR DESCRIPTION
This PR handles panic for Windows when goInfo fails to get system information and replaces the current goInfo by custom version `v0.1.0-wakatime.10`. It also fix two minor things in `root.go` and `fileexperts.go`

[panic source code](https://github.com/golang/go/blob/master/src/internal/godebug/godebug.go#L161).

```
godebug: Value of name not listed in godebugs.All: winsymlink

goroutine 1 [running]:
runtime/debug.Stack()
C:/hostedtoolcache/windows/go/1.23.3/x64/src/runtime/debug/stack.go:26 +0x5e
github.com/wakatime/wakatime-cli/cmd.runCmd.func1()
D:/a/wakatime-cli/wakatime-cli/cmd/run.go:317 +0x134
panic({0x94fa00?, 0xc000304a70?})
C:/hostedtoolcache/windows/go/1.23.3/x64/src/runtime/panic.go:785 +0x132
internal/godebug.(*Setting).Value.func1()
C:/hostedtoolcache/windows/go/1.23.3/x64/src/internal/godebug/godebug.go:161 +0xb9
sync.(*Once).doSlow(0xc0001f3110?, 0x4?)
C:/hostedtoolcache/windows/go/1.23.3/x64/src/sync/once.go:76 +0xb4
sync.(*Once).Do(...)
C:/hostedtoolcache/windows/go/1.23.3/x64/src/sync/once.go:67
internal/godebug.(*Setting).Value(0x11c3ee0)
C:/hostedtoolcache/windows/go/1.23.3/x64/src/internal/godebug/godebug.go:158 +0x45
os.(*fileStat).Mode(0xc0001f3110)
C:/hostedtoolcache/windows/go/1.23.3/x64/src/os/types_windows.go:167 +0x2b
os.(*fileStat).IsDir(0xc0004813e0?)
C:/hostedtoolcache/windows/go/1.23.3/x64/src/os/types.go:61 +0x13
os/exec.chkStat({0xc0004813e0?, 0xc0001a2fd8?})
C:/hostedtoolcache/windows/go/1.23.3/x64/src/os/exec/lp_windows.go:24 +0x26
os/exec.findExecutable({0xc0001a2fd8, 0x17}, {0xc000141b00, 0xb, 0x64?})
C:/hostedtoolcache/windows/go/1.23.3/x64/src/os/exec/lp_windows.go:50 +0xd4
os/exec.lookPath({0xa49f74, 0x3}, {0xc000141b00, 0xb, 0x10})
C:/hostedtoolcache/windows/go/1.23.3/x64/src/os/exec/lp_windows.go:175 +0x395
os/exec.LookPath({0xa49f74, 0x3})
C:/hostedtoolcache/windows/go/1.23.3/x64/src/os/exec/lp_windows.go:71 +0x35
os/exec.Command({0xa49f74, 0x3}, {0xc000012a80, 0x1, 0x10000000000?})
C:/hostedtoolcache/windows/go/1.23.3/x64/src/os/exec/exec.go:425 +0x2db
github.com/matishsiao/goInfo.GetInfo()
C:/Users/runneradmin/go/pkg/mod/github.com/matishsiao/go!info@v0.0.0-20240924010139-10388a85396f/goInfo_windows.go:13 +0x8f
github.com/wakatime/wakatime-cli/pkg/heartbeat.UserAgent({0xd1f820?, 0xc000449ef0?}, {0xc00011e0c0, 0x1d})
D:/a/wakatime-cli/wakatime-cli/pkg/heartbeat/heartbeat.go:185 +0x7a
github.com/wakatime/wakatime-cli/cmd/heartbeat.buildHeartbeats({_, _}, {{{0x0, 0x0, 0x0}, 0x0, 0x0, {0xc0001c7320, 0xa}, {0xc000110090, ...}, ...}, ...})
D:/a/wakatime-cli/wakatime-cli/cmd/heartbeat/heartbeat.go:238 +0x45
github.com/wakatime/wakatime-cli/cmd/heartbeat.SendHeartbeats({0xd1f820, 0xc000449ef0}, 0xc000106a80, {0xc00013b580, 0x30})
D:/a/wakatime-cli/wakatime-cli/cmd/heartbeat/heartbeat.go:99 +0x308
github.com/wakatime/wakatime-cli/cmd/heartbeat.Run({0xd1f820, 0xc000449ef0}, 0xc000106a80)
D:/a/wakatime-cli/wakatime-cli/cmd/heartbeat/heartbeat.go:42 +0xd2
github.com/wakatime/wakatime-cli/cmd.runCmd({0xd1f820, 0xc000449ef0}, 0xc000106a80, 0x0, 0x0, 0xc56458)
D:/a/wakatime-cli/wakatime-cli/cmd/run.go:335 +0x183
github.com/wakatime/wakatime-cli/cmd.RunCmdWithOfflineSync({0xd1f820, 0xc000449ef0}, 0xc000106a80, 0x0, 0x0, 0x0?)
D:/a/wakatime-cli/wakatime-cli/cmd/run.go:290 +0x2c
github.com/wakatime/wakatime-cli/cmd.RunE(0xc00009c308, 0xc000106a80)
D:/a/wakatime-cli/wakatime-cli/cmd/run.go:145 +0x89a
github.com/wakatime/wakatime-cli/cmd.NewRootCMD.func1(0xc000141500?, {0xa4a3c4?, 0x4?, 0xa4a3c8?})
D:/a/wakatime-cli/wakatime-cli/cmd/root.go:32 +0x17
github.com/spf13/cobra.(*Command).execute(0xc00009c308, {0xc000140010, 0xa, 0xf})
C:/Users/runneradmin/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:985 +0xaaa
github.com/spf13/cobra.(*Command).ExecuteC(0xc00009c308)
C:/Users/runneradmin/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1117 +0x3ff
github.com/spf13/cobra.(*Command).Execute(...)
C:/Users/runneradmin/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1041
github.com/wakatime/wakatime-cli/cmd.Execute()
D:/a/wakatime-cli/wakatime-cli/cmd/root.go:301 +0x18
main.main()
D:/a/wakatime-cli/wakatime-cli/main.go:6 +0xf
```