### PR TITLE
Save config-based logger to context for shared use

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -76,6 +76,9 @@ func RunE(cmd *cobra.Command, v *viper.Viper) error {
 
 	// setup logging again to use config file settings if available
 	logger, err = SetupLogging(ctx, v)
+	// save logger back to the context
+	ctx = log.ToContext(ctx, logger)
+
 	if err != nil {
 		logger.Fatalf("failed to setup logging: %s", err)
 	}


### PR DESCRIPTION
The logger configured with setting file was not stored in the context, making it inaccessible across the application.
As a result, settings like `debug = true` in `wakatime.cfg` were not consistently applied since the logger was not shared via the context.

This PR adds a line to ensure the logger is stored in the context.