### PR TITLE
Standardize panic messages

### DIFF
--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"fmt"
+	"runtime/debug"
 	"strings"
 
 	paramscmd "github.com/wakatime/wakatime-cli/cmd/params"
@@ -85,8 +86,8 @@ func newClient(ctx context.Context, params paramscmd.API, opts ...api.Option) (*
 
 func timezone() (name string, err error) {
 	defer func() {
-		if e := recover(); e != nil {
-			err = fmt.Errorf("panicked when detecting timezone: %s", e)
+		if r := recover(); r != nil {
+			err = fmt.Errorf("panicked: failed to get timezone: %v. Stack: %s", r, string(debug.Stack()))
 		}
 	}()
 

--- a/cmd/params/params.go
+++ b/cmd/params/params.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"sync"
@@ -732,7 +733,7 @@ func LoadStatusBarParams(v *viper.Viper) (StatusBar, error) {
 func safeTimeParse(format string, s string) (parsed time.Time, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			err = fmt.Errorf("time.Parse panic: %v", r)
+			err = fmt.Errorf("panicked: failed to time.Parse: %v. Stack: %s", r, string(debug.Stack()))
 		}
 	}()
 


### PR DESCRIPTION
This PR standardizes all panic messages following the format: `panicked: %s. Stack: %s` to include stack trace.