### PR TITLE
switch initialization of config parser

### DIFF
--- a/cmd/logfile/logfile.go
+++ b/cmd/logfile/logfile.go
@@ -48,7 +48,7 @@ func LoadParams(ctx context.Context, v *viper.Viper) (Params, error) {
 	if logFile != "" {
 		p, err := homedir.Expand(logFile)
 		if err != nil {
-			return Params{}, fmt.Errorf("failed expanding log file: %s", err)
+			return Params{}, fmt.Errorf("failed to expand log file: %s", err)
 		}
 
 		params.File = p
@@ -58,7 +58,7 @@ func LoadParams(ctx context.Context, v *viper.Viper) (Params, error) {
 
 	folder, err := ini.WakaResourcesDir(ctx)
 	if err != nil {
-		return Params{}, fmt.Errorf("failed getting resource directory: %s", err)
+		return Params{}, fmt.Errorf("failed to get resource directory: %s", err)
 	}
 
 	params.File = filepath.Join(folder, defaultFile)

--- a/cmd/run_internal_test.go
+++ b/cmd/run_internal_test.go
@@ -417,6 +417,31 @@ func TestParseConfigFiles(t *testing.T) {
 		v.GetString("internal.backoff_at"))
 }
 
+func TestParseConfigFiles_MissingAPIKey(t *testing.T) {
+	v := viper.New()
+	v.Set("config", "testdata/.wakatime-empty.cfg")
+	v.Set("internal-config", "testdata/.wakatime-internal.cfg")
+
+	err := parseConfigFiles(context.Background(), v)
+
+	assert.NoError(t, err)
+}
+
+func TestParseConfigFiles_APIKey_FlagTakesPrecedence(t *testing.T) {
+	v := viper.New()
+	v.Set("key", "00000000-0000-4000-8000-000000000000")
+	v.Set("config", "testdata/.wakatime-empty.cfg")
+	v.Set("settings.import_cfg", "")
+	v.Set("internal-config", "testdata/.wakatime-internal.cfg")
+
+	err := parseConfigFiles(context.Background(), v)
+	require.NoError(t, err)
+
+	assert.Equal(t,
+		"00000000-0000-4000-8000-000000000000",
+		v.GetString("key"))
+}
+
 func jsonEscape(t *testing.T, i string) string {
 	b, err := json.Marshal(i)
 	require.NoError(t, err)

--- a/cmd/testdata/.wakatime-empty.cfg
+++ b/cmd/testdata/.wakatime-empty.cfg
@@ -1,0 +1,1 @@
+[settings]

--- a/main_test.go
+++ b/main_test.go
@@ -667,7 +667,7 @@ func TestSendHeartbeats_MalformedConfig(t *testing.T) {
 		"--verbose",
 	)
 
-	assert.Empty(t, out)
+	assert.Contains(t, out, "failed to parse config files")
 
 	count, err := offline.CountHeartbeats(ctx, offlineQueueFile.Name())
 	require.NoError(t, err)
@@ -707,7 +707,7 @@ func TestSendHeartbeats_MalformedInternalConfig(t *testing.T) {
 		"--verbose",
 	)
 
-	assert.Empty(t, out)
+	assert.Contains(t, out, "failed to parse config files")
 
 	count, err := offline.CountHeartbeats(ctx, offlineQueueFile.Name())
 	require.NoError(t, err)

--- a/pkg/log/context.go
+++ b/pkg/log/context.go
@@ -20,8 +20,7 @@ var ctxMarkerKey = &ctxMarker{}
 func Extract(ctx context.Context) *Logger {
 	l, ok := ctx.Value(ctxMarkerKey).(*ctxLogger)
 	if !ok || l == nil {
-		// TODO: It should never happen but if it does,
-		// we should find a way to create a new logger using passed params during initialization
+		// If there's no logger already initialized, then create a new default one
 		return New(os.Stdout)
 	}
 
@@ -31,11 +30,9 @@ func Extract(ctx context.Context) *Logger {
 // ToContext adds the log.Logger to the context for extraction later.
 // Returning the new context that has been created.
 func ToContext(ctx context.Context, logger *Logger) context.Context {
-	l := &ctxLogger{
+	return context.WithValue(ctx, ctxMarkerKey, &ctxLogger{
 		logger: logger,
-	}
-
-	return context.WithValue(ctx, ctxMarkerKey, l)
+	})
 }
 
 // AddField adds a field to the context logger.


### PR DESCRIPTION
This PR fixes the following related issues:
- It parses the configuration file before setup logging.
- When it fails to parse config file it will print to stdout then, making it better to debug and understand possible malformed configuration files. The current behavior to store the heartbeat in the offline queue has been kept.
- It properly inject logger into context.
- It standardize other message strings.