### PR TITLE
Add new linter usetesting

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,6 +18,7 @@ linters:
     - revive
     - testpackage
     - unconvert
+    - usetesting
     - usestdlibvars
     - whitespace
     - wsl
@@ -54,6 +55,9 @@ linters-settings:
       - name: unused-receiver
       - name: var-declaration
       - name: var-naming
+  usetesting:
+    os-setenv: true
+    os-temp-dir: true
 issues:
   exclude-use-default: false
   exclude-dirs:

--- a/cmd/logfile/logfile_test.go
+++ b/cmd/logfile/logfile_test.go
@@ -132,10 +132,7 @@ func TestLoadParams(t *testing.T) {
 			v.Set("settings.debug", test.ViperDebug)
 			v.Set("verbose", test.ViperDebugConfig)
 
-			err := os.Setenv("WAKATIME_HOME", test.EnvVar)
-			require.NoError(t, err)
-
-			defer os.Unsetenv("WAKATIME_HOME")
+			t.Setenv("WAKATIME_HOME", test.EnvVar)
 
 			params, err := logfile.LoadParams(ctx, v)
 			require.NoError(t, err)

--- a/cmd/params/params_test.go
+++ b/cmd/params/params_test.go
@@ -2093,10 +2093,7 @@ func TestLoadParams_ApiKey_FromVault_Err_Darwin(t *testing.T) {
 func TestLoadAPIParams_APIKeyFromEnv(t *testing.T) {
 	v := viper.New()
 
-	err := os.Setenv("WAKATIME_API_KEY", "00000000-0000-4000-8000-000000000000")
-	require.NoError(t, err)
-
-	defer os.Unsetenv("WAKATIME_API_KEY")
+	t.Setenv("WAKATIME_API_KEY", "00000000-0000-4000-8000-000000000000")
 
 	params, err := cmdparams.LoadAPIParams(context.Background(), v)
 	require.NoError(t, err)
@@ -2107,12 +2104,9 @@ func TestLoadAPIParams_APIKeyFromEnv(t *testing.T) {
 func TestLoadAPIParams_APIKeyFromEnvInvalid(t *testing.T) {
 	v := viper.New()
 
-	err := os.Setenv("WAKATIME_API_KEY", "00000000-0000-4000-0000-000000000000")
-	require.NoError(t, err)
+	t.Setenv("WAKATIME_API_KEY", "00000000-0000-4000-0000-000000000000")
 
-	defer os.Unsetenv("WAKATIME_API_KEY")
-
-	_, err = cmdparams.LoadAPIParams(context.Background(), v)
+	_, err := cmdparams.LoadAPIParams(context.Background(), v)
 	require.Error(t, err)
 
 	var errauth api.ErrAuth
@@ -2125,10 +2119,7 @@ func TestLoadAPIParams_APIKeyFromEnv_ConfigTakesPrecedence(t *testing.T) {
 	v := viper.New()
 	v.Set("settings.api_key", "00000000-0000-4000-8000-000000000000")
 
-	err := os.Setenv("WAKATIME_API_KEY", "10000000-0000-4000-8000-000000000000")
-	require.NoError(t, err)
-
-	defer os.Unsetenv("WAKATIME_API_KEY")
+	t.Setenv("WAKATIME_API_KEY", "10000000-0000-4000-8000-000000000000")
 
 	params, err := cmdparams.LoadAPIParams(context.Background(), v)
 	require.NoError(t, err)
@@ -2370,10 +2361,7 @@ func TestLoadAPIParams_ProxyURL_UserDefinedTakesPrecedenceOverEnvironment(t *tes
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("proxy", "https://john:secret@example.org:8888")
 
-	err := os.Setenv("HTTPS_PROXY", "https://papa:secret@company.org:9000")
-	require.NoError(t, err)
-
-	defer os.Unsetenv("HTTPS_PROXY")
+	t.Setenv("HTTPS_PROXY", "https://papa:secret@company.org:9000")
 
 	params, err := cmdparams.LoadAPIParams(context.Background(), v)
 	require.NoError(t, err)
@@ -2396,10 +2384,7 @@ func TestLoadAPIParams_ProxyURL_FromEnvironment(t *testing.T) {
 	v := viper.New()
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 
-	err := os.Setenv("HTTPS_PROXY", "https://john:secret@example.org:8888")
-	require.NoError(t, err)
-
-	defer os.Unsetenv("HTTPS_PROXY")
+	t.Setenv("HTTPS_PROXY", "https://john:secret@example.org:8888")
 
 	params, err := cmdparams.LoadAPIParams(context.Background(), v)
 	require.NoError(t, err)
@@ -2411,10 +2396,7 @@ func TestLoadAPIParams_ProxyURL_NoProxyFromEnvironment(t *testing.T) {
 	v := viper.New()
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 
-	err := os.Setenv("NO_PROXY", "https://some.org,https://api.wakatime.com")
-	require.NoError(t, err)
-
-	defer os.Unsetenv("NO_PROXY")
+	t.Setenv("NO_PROXY", "https://some.org,https://api.wakatime.com")
 
 	params, err := cmdparams.LoadAPIParams(context.Background(), v)
 	require.NoError(t, err)
@@ -2470,10 +2452,7 @@ func TestLoadAPIParams_Hostname_FlagTakesPrecedence(t *testing.T) {
 	v.Set("hostname", "my-machine")
 	v.Set("settings.hostname", "ignored")
 
-	err := os.Setenv("GITPOD_WORKSPACE_ID", "gitpod")
-	require.NoError(t, err)
-
-	defer os.Unsetenv("GITPOD_WORKSPACE_ID")
+	t.Setenv("GITPOD_WORKSPACE_ID", "gitpod")
 
 	params, err := cmdparams.LoadAPIParams(context.Background(), v)
 	require.NoError(t, err)
@@ -2497,10 +2476,7 @@ func TestLoadAPIParams_Hostname_ConfigTakesPrecedence(t *testing.T) {
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("settings.hostname", "my-machine")
 
-	err := os.Setenv("GITPOD_WORKSPACE_ID", "gitpod")
-	require.NoError(t, err)
-
-	defer os.Unsetenv("GITPOD_WORKSPACE_ID")
+	t.Setenv("GITPOD_WORKSPACE_ID", "gitpod")
 
 	params, err := cmdparams.LoadAPIParams(context.Background(), v)
 	require.NoError(t, err)
@@ -2512,10 +2488,7 @@ func TestLoadAPIParams_Hostname_FromGitpodEnv(t *testing.T) {
 	v := viper.New()
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 
-	err := os.Setenv("GITPOD_WORKSPACE_ID", "gitpod")
-	require.NoError(t, err)
-
-	defer os.Unsetenv("GITPOD_WORKSPACE_ID")
+	t.Setenv("GITPOD_WORKSPACE_ID", "gitpod")
 
 	params, err := cmdparams.LoadAPIParams(context.Background(), v)
 	require.NoError(t, err)

--- a/pkg/file/file_windows.go
+++ b/pkg/file/file_windows.go
@@ -25,7 +25,7 @@ func openFile(name string, flag int, perm os.FileMode) (*os.File, error) {
 }
 
 // openFileNolog is the Windows implementation of OpenFile.
-func openFileNolog(name string, flag int, perm os.FileMode) (*os.File, error) {
+func openFileNolog(name string, flag int, _ os.FileMode) (*os.File, error) {
 	if name == "" {
 		return nil, &os.PathError{Op: "open", Path: name, Err: syscall.ENOENT}
 	}

--- a/pkg/ini/ini_test.go
+++ b/pkg/ini/ini_test.go
@@ -154,10 +154,7 @@ func TestFilePath(t *testing.T) {
 			v := viper.New()
 			v.Set("config", test.ViperValue)
 
-			err := os.Setenv("WAKATIME_HOME", test.EnvVar)
-			require.NoError(t, err)
-
-			defer os.Unsetenv("WAKATIME_HOME")
+			t.Setenv("WAKATIME_HOME", test.EnvVar)
 
 			configFilepath, err := ini.FilePath(ctx, v)
 			require.NoError(t, err)
@@ -196,10 +193,7 @@ func TestInternalFilePath(t *testing.T) {
 			v := viper.New()
 			v.Set("internal-config", test.ViperValue)
 
-			err := os.Setenv("WAKATIME_HOME", test.EnvVar)
-			require.NoError(t, err)
-
-			defer os.Unsetenv("WAKATIME_HOME")
+			t.Setenv("WAKATIME_HOME", test.EnvVar)
 
 			configFilepath, err := ini.InternalFilePath(ctx, v)
 			require.NoError(t, err)

--- a/pkg/offline/legacy_test.go
+++ b/pkg/offline/legacy_test.go
@@ -39,10 +39,7 @@ func TestQueueFilepathLegacy(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			err := os.Setenv("WAKATIME_HOME", test.EnvVar)
-			require.NoError(t, err)
-
-			defer os.Unsetenv("WAKATIME_HOME")
+			t.Setenv("WAKATIME_HOME", test.EnvVar)
 
 			v := viper.New()
 			queueFilepath, err := offline.QueueFilepathLegacy(ctx, v)

--- a/pkg/offline/offline_test.go
+++ b/pkg/offline/offline_test.go
@@ -39,10 +39,7 @@ func TestQueueFilepath(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			err := os.Setenv("WAKATIME_HOME", test.EnvVar)
-			require.NoError(t, err)
-
-			defer os.Unsetenv("WAKATIME_HOME")
+			t.Setenv("WAKATIME_HOME", test.EnvVar)
 
 			folder, err := ini.WakaResourcesDir(ctx)
 			require.NoError(t, err)


### PR DESCRIPTION
This PR adds a new linter `usetesting` to lint the usage of properly testing function in test files.