### PR TITLE
Only log offline warnings when in debug mode

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -104,7 +104,7 @@ func isLocalIPv6(ctx context.Context) bool {
 
 	conn, err := net.Dial("udp", fmt.Sprintf("%s:80", BaseIPAddrv4))
 	if err != nil {
-		logger.Warnf("failed dialing to detect default local ip address: %s", err)
+		logger.Debugf("failed dialing to detect default local ip address: %s", err)
 		return true
 	}
 


### PR DESCRIPTION
Network warnings shouldn't be logged unless `debug = true` because they're normal warnings encountered regularly. The general rule is any warning where the code stats are still saved to the offline db should be suppressed to prevent noise in the `wakatime.log` file, unless `debug = true`.