### PR TITLE
Improve file pkg

### DIFF
--- a/pkg/api/option.go
+++ b/pkg/api/option.go
@@ -121,7 +121,7 @@ func WithProxy(proxyURL string) (Option, error) {
 
 // WithSSLCertFile overrides the default CA certs file to trust specified cert file.
 func WithSSLCertFile(ctx context.Context, filepath string) (Option, error) {
-	caCert, err := file.ReadHeadAsBytes(ctx, filepath, 0) // nolint:gosec
+	caCert, err := file.ReadHead(ctx, filepath, 0) // nolint:gosec
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/deps/c.go
+++ b/pkg/deps/c.go
@@ -34,7 +34,7 @@ type ParserC struct {
 
 // Parse parses dependencies from C file content using the C lexer.
 func (p *ParserC) Parse(ctx context.Context, filepath string) ([]string, error) {
-	text, err := file.ReadHead(ctx, filepath, 0)
+	head, err := file.ReadHead(ctx, filepath, 0)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read: %s", err)
 	}
@@ -47,7 +47,7 @@ func (p *ParserC) Parse(ctx context.Context, filepath string) ([]string, error) 
 		return nil, fmt.Errorf("failed to get lexer for %s", heartbeat.LanguageC.String())
 	}
 
-	iter, err := l.Tokenise(nil, text)
+	iter, err := l.Tokenise(nil, string(head))
 	if err != nil {
 		return nil, fmt.Errorf("failed to tokenize file content: %s", err)
 	}

--- a/pkg/deps/cpp.go
+++ b/pkg/deps/cpp.go
@@ -34,7 +34,7 @@ type ParserCPP struct {
 
 // Parse parses dependencies from C++ file content using the C lexer.
 func (p *ParserCPP) Parse(ctx context.Context, filepath string) ([]string, error) {
-	text, err := file.ReadHead(ctx, filepath, 0)
+	head, err := file.ReadHead(ctx, filepath, 0)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read: %s", err)
 	}
@@ -47,7 +47,7 @@ func (p *ParserCPP) Parse(ctx context.Context, filepath string) ([]string, error
 		return nil, fmt.Errorf("failed to get lexer for %s", heartbeat.LanguageCPP.String())
 	}
 
-	iter, err := l.Tokenise(nil, text)
+	iter, err := l.Tokenise(nil, string(head))
 	if err != nil {
 		return nil, fmt.Errorf("failed to tokenize file content: %s", err)
 	}

--- a/pkg/deps/csharp.go
+++ b/pkg/deps/csharp.go
@@ -35,7 +35,7 @@ type ParserCSharp struct {
 
 // Parse parses dependencies from C# file content using the chroma C# lexer.
 func (p *ParserCSharp) Parse(ctx context.Context, filepath string) ([]string, error) {
-	text, err := file.ReadHead(ctx, filepath, 0)
+	head, err := file.ReadHead(ctx, filepath, 0)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read: %s", err)
 	}
@@ -48,7 +48,7 @@ func (p *ParserCSharp) Parse(ctx context.Context, filepath string) ([]string, er
 		return nil, fmt.Errorf("failed to get lexer for %s", heartbeat.LanguageCSharp.String())
 	}
 
-	iter, err := l.Tokenise(nil, text)
+	iter, err := l.Tokenise(nil, string(head))
 	if err != nil {
 		return nil, fmt.Errorf("failed to tokenize file content: %s", err)
 	}

--- a/pkg/deps/elm.go
+++ b/pkg/deps/elm.go
@@ -31,7 +31,7 @@ type ParserElm struct {
 
 // Parse parses dependencies from Elm file content using the chroma Elm lexer.
 func (p *ParserElm) Parse(ctx context.Context, filepath string) ([]string, error) {
-	text, err := file.ReadHead(ctx, filepath, 0)
+	head, err := file.ReadHead(ctx, filepath, 0)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read: %s", err)
 	}
@@ -44,7 +44,7 @@ func (p *ParserElm) Parse(ctx context.Context, filepath string) ([]string, error
 		return nil, fmt.Errorf("failed to get lexer for %s", heartbeat.LanguageElm.String())
 	}
 
-	iter, err := l.Tokenise(nil, text)
+	iter, err := l.Tokenise(nil, string(head))
 	if err != nil {
 		return nil, fmt.Errorf("failed to tokenize file content: %s", err)
 	}

--- a/pkg/deps/golang.go
+++ b/pkg/deps/golang.go
@@ -34,7 +34,7 @@ type ParserGo struct {
 
 // Parse parses dependencies from Golang file content using the chroma Golang lexer.
 func (p *ParserGo) Parse(ctx context.Context, filepath string) ([]string, error) {
-	text, err := file.ReadHead(ctx, filepath, 0)
+	head, err := file.ReadHead(ctx, filepath, 0)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read: %s", err)
 	}
@@ -42,7 +42,7 @@ func (p *ParserGo) Parse(ctx context.Context, filepath string) ([]string, error)
 	p.init()
 	defer p.init()
 
-	iter, err := lexers.Go.Tokenise(nil, text)
+	iter, err := lexers.Go.Tokenise(nil, string(head))
 	if err != nil {
 		return nil, fmt.Errorf("failed to tokenize file content: %s", err)
 	}

--- a/pkg/deps/haskell.go
+++ b/pkg/deps/haskell.go
@@ -31,7 +31,7 @@ type ParserHaskell struct {
 
 // Parse parses dependencies from Haskell file content using the chroma Haskell lexer.
 func (p *ParserHaskell) Parse(ctx context.Context, filepath string) ([]string, error) {
-	text, err := file.ReadHead(ctx, filepath, 0)
+	head, err := file.ReadHead(ctx, filepath, 0)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read: %s", err)
 	}
@@ -44,7 +44,7 @@ func (p *ParserHaskell) Parse(ctx context.Context, filepath string) ([]string, e
 		return nil, fmt.Errorf("failed to get lexer for %s", heartbeat.LanguageHaskell.String())
 	}
 
-	iter, err := l.Tokenise(nil, text)
+	iter, err := l.Tokenise(nil, string(head))
 	if err != nil {
 		return nil, fmt.Errorf("failed to tokenize file content: %s", err)
 	}

--- a/pkg/deps/haxe.go
+++ b/pkg/deps/haxe.go
@@ -33,7 +33,7 @@ type ParserHaxe struct {
 
 // Parse parses dependencies from Haxe file content using the chroma Haxe lexer.
 func (p *ParserHaxe) Parse(ctx context.Context, filepath string) ([]string, error) {
-	text, err := file.ReadHead(ctx, filepath, 0)
+	head, err := file.ReadHead(ctx, filepath, 0)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read: %s", err)
 	}
@@ -41,7 +41,7 @@ func (p *ParserHaxe) Parse(ctx context.Context, filepath string) ([]string, erro
 	p.init()
 	defer p.init()
 
-	iter, err := lexers.Haxe.Tokenise(nil, text)
+	iter, err := lexers.Haxe.Tokenise(nil, string(head))
 	if err != nil {
 		return nil, fmt.Errorf("failed to tokenize file content: %s", err)
 	}

--- a/pkg/deps/html.go
+++ b/pkg/deps/html.go
@@ -35,7 +35,7 @@ type ParserHTML struct {
 
 // Parse parses dependencies from HTML file content via ReadCloser using the chroma HTML lexer.
 func (p *ParserHTML) Parse(ctx context.Context, filepath string) ([]string, error) {
-	text, err := file.ReadHead(ctx, filepath, 0)
+	head, err := file.ReadHead(ctx, filepath, 0)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read: %s", err)
 	}
@@ -43,7 +43,7 @@ func (p *ParserHTML) Parse(ctx context.Context, filepath string) ([]string, erro
 	p.init()
 	defer p.init()
 
-	iter, err := lexers.HTML.Tokenise(nil, text)
+	iter, err := lexers.HTML.Tokenise(nil, string(head))
 	if err != nil {
 		return nil, fmt.Errorf("failed to tokenize file content: %s", err)
 	}

--- a/pkg/deps/java.go
+++ b/pkg/deps/java.go
@@ -40,7 +40,7 @@ func (p *ParserJava) Parse(ctx context.Context, filepath string) ([]string, erro
 	p.init()
 	defer p.init()
 
-	text, err := file.ReadHead(ctx, filepath, 0)
+	head, err := file.ReadHead(ctx, filepath, 0)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read: %s", err)
 	}
@@ -50,7 +50,7 @@ func (p *ParserJava) Parse(ctx context.Context, filepath string) ([]string, erro
 		return nil, fmt.Errorf("failed to get lexer for %s", heartbeat.LanguageJava.String())
 	}
 
-	iter, err := l.Tokenise(nil, text)
+	iter, err := l.Tokenise(nil, string(head))
 	if err != nil {
 		return nil, fmt.Errorf("failed to tokenize file content: %s", err)
 	}

--- a/pkg/deps/javascript.go
+++ b/pkg/deps/javascript.go
@@ -34,7 +34,7 @@ type ParserJavaScript struct {
 
 // Parse parses dependencies from JavaScript file content using the chroma JavaScript lexer.
 func (p *ParserJavaScript) Parse(ctx context.Context, filepath string) ([]string, error) {
-	text, err := file.ReadHead(ctx, filepath, 0)
+	head, err := file.ReadHead(ctx, filepath, 0)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read: %s", err)
 	}
@@ -47,7 +47,7 @@ func (p *ParserJavaScript) Parse(ctx context.Context, filepath string) ([]string
 		return nil, fmt.Errorf("failed to get lexer for %s", heartbeat.LanguageJavaScript.String())
 	}
 
-	iter, err := l.Tokenise(nil, text)
+	iter, err := l.Tokenise(nil, string(head))
 	if err != nil {
 		return nil, fmt.Errorf("failed to tokenize file content: %s", err)
 	}

--- a/pkg/deps/json.go
+++ b/pkg/deps/json.go
@@ -43,7 +43,7 @@ type ParserJSON struct {
 
 // Parse parses dependencies from JSON file content using the chroma JSON lexer.
 func (p *ParserJSON) Parse(ctx context.Context, filepath string) ([]string, error) {
-	text, err := file.ReadHead(ctx, filepath, 0)
+	head, err := file.ReadHead(ctx, filepath, 0)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read: %s", err)
 	}
@@ -59,7 +59,7 @@ func (p *ParserJSON) Parse(ctx context.Context, filepath string) ([]string, erro
 		return nil, fmt.Errorf("failed to get lexer for %s", heartbeat.LanguageJSON.String())
 	}
 
-	iter, err := l.Tokenise(nil, text)
+	iter, err := l.Tokenise(nil, string(head))
 	if err != nil {
 		return nil, fmt.Errorf("failed to tokenize file content: %s", err)
 	}

--- a/pkg/deps/kotlin.go
+++ b/pkg/deps/kotlin.go
@@ -34,7 +34,7 @@ type ParserKotlin struct {
 
 // Parse parses dependencies from Kotlin file content using the chroma Kotlin lexer.
 func (p *ParserKotlin) Parse(ctx context.Context, filepath string) ([]string, error) {
-	text, err := file.ReadHead(ctx, filepath, 0)
+	head, err := file.ReadHead(ctx, filepath, 0)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read: %s", err)
 	}
@@ -47,7 +47,7 @@ func (p *ParserKotlin) Parse(ctx context.Context, filepath string) ([]string, er
 		return nil, fmt.Errorf("failed to get lexer for %s", heartbeat.LanguageKotlin.String())
 	}
 
-	iter, err := l.Tokenise(nil, text)
+	iter, err := l.Tokenise(nil, string(head))
 	if err != nil {
 		return nil, fmt.Errorf("failed to tokenize file content: %s", err)
 	}

--- a/pkg/deps/objectivec.go
+++ b/pkg/deps/objectivec.go
@@ -31,7 +31,7 @@ type ParserObjectiveC struct {
 
 // Parse parses dependencies from Objective-C file content using the chroma Objective-C lexer.
 func (p *ParserObjectiveC) Parse(ctx context.Context, filepath string) ([]string, error) {
-	text, err := file.ReadHead(ctx, filepath, 0)
+	head, err := file.ReadHead(ctx, filepath, 0)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read: %s", err)
 	}
@@ -44,7 +44,7 @@ func (p *ParserObjectiveC) Parse(ctx context.Context, filepath string) ([]string
 		return nil, fmt.Errorf("failed to get lexer for %s", heartbeat.LanguageObjectiveC.String())
 	}
 
-	iter, err := l.Tokenise(nil, text)
+	iter, err := l.Tokenise(nil, string(head))
 	if err != nil {
 		return nil, fmt.Errorf("failed to tokenize file content: %s", err)
 	}

--- a/pkg/deps/php.go
+++ b/pkg/deps/php.go
@@ -40,7 +40,7 @@ type ParserPHP struct {
 
 // Parse parses dependencies from PHP file content using the chroma PHP lexer.
 func (p *ParserPHP) Parse(ctx context.Context, filepath string) ([]string, error) {
-	text, err := file.ReadHead(ctx, filepath, 0)
+	head, err := file.ReadHead(ctx, filepath, 0)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read: %s", err)
 	}
@@ -53,7 +53,7 @@ func (p *ParserPHP) Parse(ctx context.Context, filepath string) ([]string, error
 		return nil, fmt.Errorf("failed to get lexer for %s", heartbeat.LanguagePHP.String())
 	}
 
-	iter, err := l.Tokenise(nil, text)
+	iter, err := l.Tokenise(nil, string(head))
 	if err != nil {
 		return nil, fmt.Errorf("failed to tokenize file content: %s", err)
 	}

--- a/pkg/deps/python.go
+++ b/pkg/deps/python.go
@@ -37,7 +37,7 @@ type ParserPython struct {
 
 // Parse parses dependencies from Python file content using the chroma Python lexer.
 func (p *ParserPython) Parse(ctx context.Context, filepath string) ([]string, error) {
-	text, err := file.ReadHead(ctx, filepath, 0)
+	head, err := file.ReadHead(ctx, filepath, 0)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read: %s", err)
 	}
@@ -50,7 +50,7 @@ func (p *ParserPython) Parse(ctx context.Context, filepath string) ([]string, er
 		return nil, fmt.Errorf("failed to get lexer for %s", heartbeat.LanguagePython.String())
 	}
 
-	iter, err := l.Tokenise(nil, text)
+	iter, err := l.Tokenise(nil, string(head))
 	if err != nil {
 		return nil, fmt.Errorf("failed to tokenize file content: %s", err)
 	}

--- a/pkg/deps/rust.go
+++ b/pkg/deps/rust.go
@@ -33,7 +33,7 @@ type ParserRust struct {
 
 // Parse parses dependencies from Rust file content using the chroma Rust lexer.
 func (p *ParserRust) Parse(ctx context.Context, filepath string) ([]string, error) {
-	text, err := file.ReadHead(ctx, filepath, 0)
+	head, err := file.ReadHead(ctx, filepath, 0)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read: %s", err)
 	}
@@ -46,7 +46,7 @@ func (p *ParserRust) Parse(ctx context.Context, filepath string) ([]string, erro
 		return nil, fmt.Errorf("failed to get lexer for %s", heartbeat.LanguageRust.String())
 	}
 
-	iter, err := l.Tokenise(nil, text)
+	iter, err := l.Tokenise(nil, string(head))
 	if err != nil {
 		return nil, fmt.Errorf("failed to tokenize file content: %s", err)
 	}

--- a/pkg/deps/scala.go
+++ b/pkg/deps/scala.go
@@ -31,7 +31,7 @@ type ParserScala struct {
 
 // Parse parses dependencies from Scala file content using the chroma Scala lexer.
 func (p *ParserScala) Parse(ctx context.Context, filepath string) ([]string, error) {
-	text, err := file.ReadHead(ctx, filepath, 0)
+	head, err := file.ReadHead(ctx, filepath, 0)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read: %s", err)
 	}
@@ -44,7 +44,7 @@ func (p *ParserScala) Parse(ctx context.Context, filepath string) ([]string, err
 		return nil, fmt.Errorf("failed to get lexer for %s", heartbeat.LanguageScala.String())
 	}
 
-	iter, err := l.Tokenise(nil, text)
+	iter, err := l.Tokenise(nil, string(head))
 	if err != nil {
 		return nil, fmt.Errorf("failed to tokenize file content: %s", err)
 	}

--- a/pkg/deps/swift.go
+++ b/pkg/deps/swift.go
@@ -34,7 +34,7 @@ type ParserSwift struct {
 
 // Parse parses dependencies from Swift file content using the chroma Swift lexer.
 func (p *ParserSwift) Parse(ctx context.Context, filepath string) ([]string, error) {
-	text, err := file.ReadHead(ctx, filepath, 0)
+	head, err := file.ReadHead(ctx, filepath, 0)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read: %s", err)
 	}
@@ -47,7 +47,7 @@ func (p *ParserSwift) Parse(ctx context.Context, filepath string) ([]string, err
 		return nil, fmt.Errorf("failed to get lexer for %s", heartbeat.LanguageSwift.String())
 	}
 
-	iter, err := l.Tokenise(nil, text)
+	iter, err := l.Tokenise(nil, string(head))
 	if err != nil {
 		return nil, fmt.Errorf("failed to tokenize file content: %s", err)
 	}

--- a/pkg/deps/vbnet.go
+++ b/pkg/deps/vbnet.go
@@ -35,7 +35,7 @@ type ParserVbNet struct {
 
 // Parse parses dependencies from VB.Net file content using the chroma VB.Net lexer.
 func (p *ParserVbNet) Parse(ctx context.Context, filepath string) ([]string, error) {
-	text, err := file.ReadHead(ctx, filepath, 0)
+	head, err := file.ReadHead(ctx, filepath, 0)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read: %s", err)
 	}
@@ -48,7 +48,7 @@ func (p *ParserVbNet) Parse(ctx context.Context, filepath string) ([]string, err
 		return nil, fmt.Errorf("failed to get lexer for %s", heartbeat.LanguageVBNet.String())
 	}
 
-	iter, err := l.Tokenise(nil, text)
+	iter, err := l.Tokenise(nil, string(head))
 	if err != nil {
 		return nil, fmt.Errorf("failed to tokenize file content: %s", err)
 	}

--- a/pkg/file/file_windows.go
+++ b/pkg/file/file_windows.go
@@ -30,6 +30,7 @@ func openFileNolog(name string, flag int, _ os.FileMode) (*os.File, error) {
 		return nil, &os.PathError{Op: "open", Path: name, Err: syscall.ENOENT}
 	}
 	path := fixLongPath(name)
+
 	r, e := syscallOpen(path, flag)
 	if e != nil {
 		// We should return EISDIR when we are trying to open a directory with write access.
@@ -37,18 +38,22 @@ func openFileNolog(name string, flag int, _ os.FileMode) (*os.File, error) {
 			pathp, e1 := syscall.UTF16PtrFromString(path)
 			if e1 == nil {
 				var fa syscall.Win32FileAttributeData
+
 				e1 = syscall.GetFileAttributesEx(pathp, syscall.GetFileExInfoStandard, (*byte)(unsafe.Pointer(&fa)))
 				if e1 == nil && fa.FileAttributes&syscall.FILE_ATTRIBUTE_DIRECTORY != 0 {
 					e = syscall.EISDIR
 				}
 			}
 		}
+
 		return nil, &os.PathError{Op: "open", Path: name, Err: e}
 	}
-	f, e := os.NewFile(uintptr(r), name), nil
-	if e != nil {
-		return nil, &os.PathError{Op: "open", Path: name, Err: e}
+
+	f := os.NewFile(uintptr(r), name)
+	if f == nil {
+		return nil, &os.PathError{Op: "new file", Path: name, Err: e}
 	}
+
 	return f, nil
 }
 
@@ -56,11 +61,14 @@ func syscallOpen(path string, mode int) (fd syscall.Handle, err error) {
 	if len(path) == 0 {
 		return syscall.InvalidHandle, syscall.ERROR_FILE_NOT_FOUND
 	}
+
 	pathp, err := syscall.UTF16PtrFromString(path)
 	if err != nil {
 		return syscall.InvalidHandle, err
 	}
+
 	var access uint32
+
 	switch mode & (syscall.O_RDONLY | syscall.O_WRONLY | syscall.O_RDWR) {
 	case syscall.O_RDONLY:
 		access = syscall.GENERIC_READ
@@ -76,12 +84,16 @@ func syscallOpen(path string, mode int) (fd syscall.Handle, err error) {
 		access &^= syscall.GENERIC_WRITE
 		access |= syscall.FILE_APPEND_DATA
 	}
+
 	sharemode := uint32(syscall.FILE_SHARE_READ | syscall.FILE_SHARE_WRITE | syscall.FILE_SHARE_DELETE)
+
 	var sa *syscall.SecurityAttributes
 	if mode&syscall.O_CLOEXEC == 0 {
 		sa = makeInheritSa()
 	}
+
 	var createmode uint32
+
 	switch {
 	case mode&(syscall.O_CREAT|syscall.O_EXCL) == (syscall.O_CREAT | syscall.O_EXCL):
 		createmode = syscall.CREATE_NEW
@@ -94,22 +106,28 @@ func syscallOpen(path string, mode int) (fd syscall.Handle, err error) {
 	default:
 		createmode = syscall.OPEN_EXISTING
 	}
+
 	var attrs uint32 = syscall.FILE_ATTRIBUTE_NORMAL
+
 	if createmode == syscall.OPEN_EXISTING && access == syscall.GENERIC_READ {
 		// Necessary for opening directory handles.
 		attrs |= syscall.FILE_FLAG_BACKUP_SEMANTICS
 	}
+
 	if mode&syscall.O_SYNC != 0 {
 		const _FILE_FLAG_WRITE_THROUGH = 0x80000000
 		attrs |= _FILE_FLAG_WRITE_THROUGH
 	}
+
 	return syscall.CreateFile(pathp, access, sharemode, sa, createmode, attrs, 0)
 }
 
 func makeInheritSa() *syscall.SecurityAttributes {
 	var sa syscall.SecurityAttributes
+
 	sa.Length = uint32(unsafe.Sizeof(sa))
 	sa.InheritHandle = 1
+
 	return &sa
 }
 
@@ -118,10 +136,12 @@ func isAbs(path string) (b bool) {
 	if v == "" {
 		return false
 	}
+
 	path = path[len(v):]
 	if path == "" {
 		return false
 	}
+
 	return os.IsPathSeparator(path[0])
 }
 
@@ -129,6 +149,7 @@ func volumeName(path string) (v string) {
 	if len(path) < 2 {
 		return ""
 	}
+
 	// with drive letter
 	c := path[0]
 	if path[1] == ':' &&
@@ -136,6 +157,7 @@ func volumeName(path string) (v string) {
 			'A' <= c && c <= 'Z') {
 		return path[:2]
 	}
+
 	// is it UNC
 	if l := len(path); l >= 5 && os.IsPathSeparator(path[0]) && os.IsPathSeparator(path[1]) &&
 		!os.IsPathSeparator(path[2]) && path[2] != '.' {
@@ -144,22 +166,27 @@ func volumeName(path string) (v string) {
 			// second, next '\' shouldn't be repeated.
 			if os.IsPathSeparator(path[n]) {
 				n++
+
 				// third, following something characters. its share name.
 				if !os.IsPathSeparator(path[n]) {
 					if path[n] == '.' {
 						break
 					}
+
 					for ; n < l; n++ {
 						if os.IsPathSeparator(path[n]) {
 							break
 						}
 					}
+
 					return path[:n]
 				}
+
 				break
 			}
 		}
 	}
+
 	return ""
 }
 
@@ -204,6 +231,7 @@ func fixLongPath(path string) string {
 		// Don't canonicalize UNC paths.
 		return path
 	}
+
 	if !isAbs(path) {
 		// Relative path
 		return path
@@ -213,7 +241,9 @@ func fixLongPath(path string) string {
 
 	pathbuf := make([]byte, len(prefix)+len(path)+len(`\`))
 	copy(pathbuf, prefix)
+
 	n := len(path)
+
 	r, w := 0, len(prefix)
 	for r < n {
 		switch {
@@ -229,16 +259,19 @@ func fixLongPath(path string) string {
 		default:
 			pathbuf[w] = '\\'
 			w++
+
 			for ; r < n && !os.IsPathSeparator(path[r]); r++ {
 				pathbuf[w] = path[r]
 				w++
 			}
 		}
 	}
+
 	// A drive's root directory needs a trailing \
 	if w == len(`\\?\c:`) {
 		pathbuf[w] = '\\'
 		w++
 	}
+
 	return string(pathbuf[:w])
 }

--- a/pkg/file/read.go
+++ b/pkg/file/read.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 
 	"github.com/wakatime/wakatime-cli/pkg/log"
@@ -14,19 +15,17 @@ import (
 // language, dependencies, and their line count will be nil. Default is 5 MB.
 const MaxFileSizeSupported = 5 * 1024 * 1024
 
-// ReadHead returns the first max bytes of a file as a string.
-func ReadHead(ctx context.Context, filepath string, max int) (string, error) {
+// ReadHead returns the first max bytes of a file as a byte array.
+func ReadHead(ctx context.Context, filepath string, max int) ([]byte, error) {
 	logger := log.Extract(ctx)
 
-	if max < 1 {
-		max = MaxFileSizeSupported
-	} else if max > MaxFileSizeSupported {
+	if max < 1 || max > MaxFileSizeSupported {
 		max = MaxFileSizeSupported
 	}
 
 	f, err := OpenNoLock(filepath) // nolint:gosec
 	if err != nil {
-		return "", err
+		return nil, fmt.Errorf("failed to open file %q: %s", filepath, err)
 	}
 
 	defer func() {
@@ -39,34 +38,32 @@ func ReadHead(ctx context.Context, filepath string, max int) (string, error) {
 
 	c, err := f.Read(buf)
 	if err != nil && err != io.EOF {
-		return "", err
+		return nil, err
 	}
 
-	return string(buf[:c]), nil
+	return buf[:c], nil
 }
 
 // ReadLines reads a file until max number of lines and return an array of lines.
-func ReadLines(ctx context.Context, filepath string, max int) ([]string, error) {
-	if filepath == "" {
+func ReadLines(ctx context.Context, fp string, max int) ([]string, error) {
+	if fp == "" {
 		return nil, errors.New("filepath cannot be empty")
-	}
-
-	f, err := OpenNoLock(filepath) // nolint:gosec
-	if err != nil {
-		return nil, err
 	}
 
 	logger := log.Extract(ctx)
 
+	file, err := OpenNoLock(fp) // nolint:gosec
+	if err != nil {
+		return nil, fmt.Errorf("failed to open file %q: %s", fp, err)
+	}
+
 	defer func() {
-		if err := f.Close(); err != nil {
-			logger.Debugf("failed to close file '%s': %s", f.Name(), err)
+		if err := file.Close(); err != nil {
+			logger.Debugf("failed to close file '%s': %s", file.Name(), err)
 		}
 	}()
 
-	reader := io.LimitReader(f, MaxFileSizeSupported)
-
-	scanner := bufio.NewScanner(reader)
+	scanner := bufio.NewScanner(file)
 	scanner.Split(bufio.ScanLines)
 
 	var (
@@ -88,14 +85,14 @@ func ReadLines(ctx context.Context, filepath string, max int) ([]string, error) 
 }
 
 // CountLines counts the number of lines in a file.
-func CountLines(ctx context.Context, filepath string) (int, error) {
-	if filepath == "" {
+func CountLines(ctx context.Context, fp string) (int, error) {
+	if fp == "" {
 		return 0, errors.New("filepath cannot be empty")
 	}
 
-	f, err := OpenNoLock(filepath) // nolint:gosec
+	f, err := OpenNoLock(fp) // nolint:gosec
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("failed to open file %q: %s", fp, err)
 	}
 
 	logger := log.Extract(ctx)
@@ -111,41 +108,14 @@ func CountLines(ctx context.Context, filepath string) (int, error) {
 	scanner := bufio.NewScanner(reader)
 	scanner.Split(bufio.ScanLines)
 
-	var count = 0
+	var count int
 	for scanner.Scan() {
 		count++
 	}
 
+	if err := scanner.Err(); err != nil {
+		return count, fmt.Errorf("failed to read file %q: %w", fp, err)
+	}
+
 	return count, nil
-}
-
-// ReadHeadAsBytes returns the first max bytes of a file as a string.
-func ReadHeadAsBytes(ctx context.Context, filepath string, max int) ([]byte, error) {
-	if max < 1 {
-		max = MaxFileSizeSupported
-	} else if max > MaxFileSizeSupported {
-		max = MaxFileSizeSupported
-	}
-
-	f, err := OpenNoLock(filepath) // nolint:gosec
-	if err != nil {
-		return nil, err
-	}
-
-	logger := log.Extract(ctx)
-
-	defer func() {
-		if err := f.Close(); err != nil {
-			logger.Debugf("failed to close file '%s': %s", f.Name(), err)
-		}
-	}()
-
-	buf := make([]byte, max)
-
-	c, err := f.Read(buf)
-	if err != nil && err != io.EOF {
-		return nil, err
-	}
-
-	return buf[:c], nil
 }

--- a/pkg/file/read_test.go
+++ b/pkg/file/read_test.go
@@ -1,0 +1,176 @@
+package file_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/wakatime/wakatime-cli/pkg/file"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadHead(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	f, err := os.CreateTemp(tmpDir, "")
+	require.NoError(t, err)
+
+	defer f.Close()
+
+	// create a temporary file smaller than MaxFileSizeSupported
+	const size = 2 * 1024 * 1024 // 2MB
+
+	data := make([]byte, 1024*1024) // 1MB buffer
+
+	for i := 0; i < size/len(data); i++ {
+		_, err := f.Write(data)
+		require.NoError(t, err)
+	}
+
+	head, err := file.ReadHead(t.Context(), f.Name(), 1*1024*1024)
+	require.NoError(t, err)
+
+	assert.Len(t, head, 1*1024*1024) // should read only 1MB
+}
+
+func TestReadHead_MaxFileSizeSupported(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	f, err := os.CreateTemp(tmpDir, "")
+	require.NoError(t, err)
+
+	defer f.Close()
+
+	// create a temporary file bigger than MaxFileSizeSupported
+	const size = 6 * 1024 * 1024 // 6MB
+
+	data := make([]byte, 1024*1024) // 1MB buffer
+
+	for i := 0; i < size/len(data); i++ {
+		_, err := f.Write(data)
+		require.NoError(t, err)
+	}
+
+	head, err := file.ReadHead(t.Context(), f.Name(), -1)
+	require.NoError(t, err)
+
+	assert.Len(t, head, file.MaxFileSizeSupported) // should read only 5MB
+}
+
+func TestReadHead_NonFile(t *testing.T) {
+	_, err := file.ReadHead(t.Context(), "non-file", 1*1024*1024)
+
+	assert.ErrorContains(t, err, "failed to open file \"non-file\"")
+}
+
+func TestReadLines(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	f, err := os.CreateTemp(tmpDir, "")
+	require.NoError(t, err)
+
+	defer f.Close()
+
+	// Write n lines of random strings
+	for range 2000 {
+		line := "Go\n"
+		_, err := f.WriteString(line)
+		require.NoError(t, err)
+	}
+
+	lines, err := file.ReadLines(t.Context(), f.Name(), 1000)
+	require.NoError(t, err)
+
+	assert.Len(t, lines, 1000) // should read only 1000 lines
+}
+
+func TestReadLines_ZeroLines(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	f, err := os.CreateTemp(tmpDir, "")
+	require.NoError(t, err)
+
+	defer f.Close()
+
+	// Write n lines of random strings
+	for range 2000 {
+		line := "Go\n"
+		_, err := f.WriteString(line)
+		require.NoError(t, err)
+	}
+
+	lines, err := file.ReadLines(t.Context(), f.Name(), 0)
+	require.NoError(t, err)
+
+	assert.Empty(t, lines)
+}
+
+func TestReadLines_NegativeLines(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	f, err := os.CreateTemp(tmpDir, "")
+	require.NoError(t, err)
+
+	defer f.Close()
+
+	// Write n lines of random strings
+	for range 2000 {
+		line := "Go\n"
+		_, err := f.WriteString(line)
+		require.NoError(t, err)
+	}
+
+	lines, err := file.ReadLines(t.Context(), f.Name(), -2)
+	require.NoError(t, err)
+
+	assert.Empty(t, lines)
+}
+
+func TestReadLines_NonFile(t *testing.T) {
+	_, err := file.ReadLines(t.Context(), "non-file", 1*1024*1024)
+
+	assert.ErrorContains(t, err, "failed to open file \"non-file\"")
+}
+
+func TestCountLines(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	f, err := os.CreateTemp(tmpDir, "")
+	require.NoError(t, err)
+
+	defer f.Close()
+
+	// Write n lines of random strings
+	for range 2000 {
+		line := "Go\n"
+		_, err := f.WriteString(line)
+		require.NoError(t, err)
+	}
+
+	lines, err := file.CountLines(t.Context(), f.Name())
+	require.NoError(t, err)
+
+	assert.Equal(t, lines, 2000)
+}
+
+func TestReadLines_EmptyFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	f, err := os.CreateTemp(tmpDir, "")
+	require.NoError(t, err)
+
+	defer f.Close()
+
+	lines, err := file.CountLines(t.Context(), f.Name())
+	require.NoError(t, err)
+
+	assert.Empty(t, lines)
+}
+
+func TestCountLines_NonFile(t *testing.T) {
+	lines, err := file.CountLines(t.Context(), "non-file")
+
+	assert.Empty(t, lines)
+	assert.ErrorContains(t, err, "failed to open file \"non-file\"")
+}

--- a/pkg/language/chroma.go
+++ b/pkg/language/chroma.go
@@ -85,7 +85,7 @@ func detectChromaCustomized(ctx context.Context, fp string, guessLanguage bool) 
 		return heartbeat.LanguageUnknown, 0, false
 	}
 
-	if lexer := lexers.Analyse(head); lexer != nil {
+	if lexer := lexers.Analyse(string(head)); lexer != nil {
 		language, ok := heartbeat.ParseLanguageFromChroma(lexer.Config().Name)
 		if !ok {
 			logger.Warnf("failed to parse language from chroma lexer name %q", lexer.Config().Name)
@@ -139,7 +139,7 @@ func selectByCustomizedPriority(ctx context.Context, fp string, lexers chroma.Pr
 		var weight float32
 
 		if analyser, ok := lexer.(chroma.Analyser); ok {
-			weight = analyser.AnalyseText(head)
+			weight = analyser.AnalyseText(string(head))
 		}
 
 		cfg := lexer.Config()

--- a/pkg/language/language.go
+++ b/pkg/language/language.go
@@ -132,11 +132,13 @@ func detectSpecialCases(ctx context.Context, fp string) (heartbeat.Language, boo
 func detectOverrideCases(ctx context.Context, fp string, language heartbeat.Language, weight float32) heartbeat.Language {
 	logger := log.Extract(ctx)
 
-	text, err := file.ReadHead(ctx, fp, 0)
+	head, err := file.ReadHead(ctx, fp, 0)
 	if err != nil {
 		logger.Debugf("failed to open file: %s", err)
 		return language
 	}
+
+	text := string(head)
 
 	languageVim, weightVim, okVim := detectVimModeline(text)
 	if okVim && weightVim > weight {

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -394,7 +394,7 @@ func (c Client) signerForIdentity(ctx context.Context) (ssh.Signer, error) {
 		return nil, nil
 	}
 
-	key, err := file.ReadHeadAsBytes(ctx, identityFile, 0) // nolint:gosec
+	key, err := file.ReadHead(ctx, identityFile, 0) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to read private key %s: %v", identityFile, err)
 	}


### PR DESCRIPTION
This PR improves `file` package by
- adding missing unit tests
- removing `ReadHeadAsBytes` in order to always return a byte array for `ReadHead`
- renaming `text` by `head` on deps package
- formatting windows file