### PR TITLE
[WIP] Add project-level configuration support with .wakatime files

### DIFF
--- a/cmd/heartbeat/heartbeat.go
+++ b/cmd/heartbeat/heartbeat.go
@@ -172,12 +172,14 @@ func LoadParams(ctx context.Context, v *viper.Viper) (paramscmd.Params, error) {
 		return paramscmd.Params{}, errors.New("viper instance unset")
 	}
 
-	apiParams, err := paramscmd.LoadAPIParams(ctx, v)
+	// Load API params with project config support
+	apiParams, err := paramscmd.LoadAPIParamsWithProjectConfig(ctx, v)
 	if err != nil {
 		return paramscmd.Params{}, fmt.Errorf("failed to load API parameters: %w", err)
 	}
 
-	heartbeatParams, err := paramscmd.LoadHeartbeatParams(ctx, v)
+	// Load heartbeat params with project config support
+	heartbeatParams, err := paramscmd.LoadHeartbeatParamsWithProjectConfig(ctx, v)
 	if err != nil {
 		return paramscmd.Params{}, fmt.Errorf("failed to load heartbeat params: %s", err)
 	}

--- a/cmd/params/params.go
+++ b/cmd/params/params.go
@@ -168,6 +168,21 @@ type (
 	}
 )
 
+// LoadAPIParamsWithProjectConfig loads API params from viper.Viper instance
+// with project-level configuration merged in. Returns ErrAuth if failed to retrieve api key.
+func LoadAPIParamsWithProjectConfig(ctx context.Context, v *viper.Viper) (API, error) {
+	// Get the entity first to determine the project config
+	entity := vipertools.FirstNonEmptyString(v, "entity", "file")
+	if entity != "" {
+		// Load project-specific configuration if available
+		mergedViper := project.LoadProjectConfig(ctx, v, entity)
+		return LoadAPIParams(ctx, mergedViper)
+	}
+
+	// Fall back to regular loading if no entity is provided
+	return LoadAPIParams(ctx, v)
+}
+
 // LoadAPIParams loads API params from viper.Viper instance. Returns ErrAuth
 // if failed to retrieve api key.
 func LoadAPIParams(ctx context.Context, v *viper.Viper) (API, error) {
@@ -363,6 +378,22 @@ func LoadAPIKey(ctx context.Context, v *viper.Viper) (string, error) {
 	}
 
 	return apiKey, nil
+}
+
+// LoadHeartbeatParamsWithProjectConfig loads heartbeats params from viper.Viper instance
+// with project-level configuration merged in.
+func LoadHeartbeatParamsWithProjectConfig(ctx context.Context, v *viper.Viper) (Heartbeat, error) {
+	// Get the entity first to determine the project config
+	entity := vipertools.FirstNonEmptyString(v, "entity", "file")
+	if entity == "" {
+		return Heartbeat{}, errors.New("failed to retrieve entity")
+	}
+
+	// Load project-specific configuration if available
+	mergedViper := project.LoadProjectConfig(ctx, v, entity)
+
+	// Use the merged configuration for loading params
+	return LoadHeartbeatParams(ctx, mergedViper)
 }
 
 // LoadHeartbeatParams loads heartbeats params from viper.Viper instance.

--- a/pkg/project/config.go
+++ b/pkg/project/config.go
@@ -1,0 +1,109 @@
+package project
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/wakatime/wakatime-cli/pkg/log"
+
+	"github.com/spf13/viper"
+	"gopkg.in/ini.v1"
+)
+
+const (
+	// WakaTimeConfigFile is the new INI config file which contains project settings
+	// and can override global configuration per project.
+	WakaTimeConfigFile = ".wakatime"
+)
+
+// ConfigDetector detects project configuration from .wakatime files.
+type ConfigDetector struct {
+	Filepath string
+}
+
+// ConfigResult contains both project information and configuration data.
+type ConfigResult struct {
+	Result
+	Config *viper.Viper
+	Found  bool
+}
+
+// DetectConfig finds project configuration from .wakatime INI files.
+// It reads the full configuration file and returns both project info and config.
+func (c ConfigDetector) DetectConfig(ctx context.Context) (ConfigResult, error) {
+	fp, found := FindFileOrDirectory(ctx, c.Filepath, WakaTimeConfigFile)
+	if !found {
+		return ConfigResult{Found: false}, nil
+	}
+
+	logger := log.Extract(ctx)
+	logger.Debugf("wakatime config file found at: %s", fp)
+
+	// Load the INI file
+	cfg, err := ini.LoadSources(ini.LoadOptions{
+		AllowPythonMultilineValues: true,
+		SkipUnrecognizableLines:    true,
+	}, fp)
+	if err != nil {
+		return ConfigResult{}, fmt.Errorf("failed to load config file %s: %s", fp, err)
+	}
+
+	// Create a new viper instance for this project config
+	projectViper := viper.New()
+	projectViper.SetConfigType("ini")
+
+	// Convert INI sections to viper format
+	for _, section := range cfg.Sections() {
+		sectionName := section.Name()
+		if sectionName == "DEFAULT" {
+			// Skip the default section
+			continue
+		}
+
+		for _, key := range section.Keys() {
+			viperKey := fmt.Sprintf("%s.%s", sectionName, key.Name())
+			projectViper.Set(viperKey, key.Value())
+		}
+	}
+
+	// Extract project information from the config
+	result := Result{
+		Folder:  filepath.Dir(fp),
+		Project: filepath.Base(filepath.Dir(fp)),
+	}
+
+	// Check for project section with name and branch
+	if projectSection, err := cfg.GetSection("project"); err == nil {
+		if nameKey, err := projectSection.GetKey("name"); err == nil {
+			result.Project = strings.TrimSpace(nameKey.Value())
+		}
+
+		if branchKey, err := projectSection.GetKey("branch"); err == nil {
+			result.Branch = strings.TrimSpace(branchKey.Value())
+		}
+	}
+
+	return ConfigResult{
+		Result: result,
+		Config: projectViper,
+		Found:  true,
+	}, nil
+}
+
+// Detect implements the Detecter interface for backwards compatibility.
+// It only returns project information without configuration data.
+func (c ConfigDetector) Detect(ctx context.Context) (Result, bool, error) {
+	configResult, err := c.DetectConfig(ctx)
+	if err != nil {
+		return Result{}, false, err
+	}
+
+	return configResult.Result, configResult.Found, nil
+}
+
+// ID returns the detector ID.
+func (ConfigDetector) ID() DetectorID {
+	return FileDetector // Use same ID as File detector for now
+}

--- a/pkg/project/config_test.go
+++ b/pkg/project/config_test.go
@@ -1,0 +1,137 @@
+package project_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/wakatime/wakatime-cli/pkg/project"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigDetector_DetectConfig(t *testing.T) {
+	// Create temporary directory structure
+	tmpDir := t.TempDir()
+	projectDir := filepath.Join(tmpDir, "test-project")
+	require.NoError(t, os.MkdirAll(projectDir, 0755))
+
+	// Create .wakatime config file
+	configContent := `[project]
+name = test-cli-project
+branch = feature/test
+
+[settings]
+api_key = waka_12345678-1234-4123-8123-123456789012
+debug = true
+exclude = .*test.*
+
+[projectmap]
+src/.* = core-module
+`
+	configFile := filepath.Join(projectDir, project.WakaTimeConfigFile)
+	require.NoError(t, os.WriteFile(configFile, []byte(configContent), 0644))
+
+	// Create a test file
+	testFile := filepath.Join(projectDir, "src", "main.go")
+	require.NoError(t, os.MkdirAll(filepath.Dir(testFile), 0755))
+	require.NoError(t, os.WriteFile(testFile, []byte("package main"), 0644))
+
+	tests := []struct {
+		name           string
+		filepath       string
+		wantFound      bool
+		wantProject    string
+		wantBranch     string
+		wantConfigKeys []string
+	}{
+		{
+			name:           "file in project directory",
+			filepath:       testFile,
+			wantFound:      true,
+			wantProject:    "test-cli-project",
+			wantBranch:     "feature/test",
+			wantConfigKeys: []string{"settings.api_key", "settings.debug", "settings.exclude", "projectmap.src/.*"},
+		},
+		{
+			name:      "file outside project",
+			filepath:  filepath.Join(tmpDir, "other", "file.go"),
+			wantFound: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			detector := project.ConfigDetector{
+				Filepath: tt.filepath,
+			}
+
+			result, err := detector.DetectConfig(t.Context())
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.wantFound, result.Found)
+
+			if tt.wantFound {
+				assert.Equal(t, tt.wantProject, result.Project)
+				assert.Equal(t, tt.wantBranch, result.Branch)
+				assert.Equal(t, projectDir, result.Folder)
+
+				// Check that config values are loaded
+				for _, key := range tt.wantConfigKeys {
+					assert.True(t, result.Config.IsSet(key), "expected config key %s to be set", key)
+				}
+
+				// Verify specific values
+				assert.Equal(t, "waka_12345678-1234-4123-8123-123456789012", result.Config.GetString("settings.api_key"))
+				assert.Equal(t, "true", result.Config.GetString("settings.debug"))
+				assert.Equal(t, ".*test.*", result.Config.GetString("settings.exclude"))
+				assert.Equal(t, "core-module", result.Config.GetString("projectmap.src/.*"))
+			}
+		})
+	}
+}
+
+func TestConfigDetector_Detect(t *testing.T) {
+	// Create temporary directory structure
+	tmpDir := t.TempDir()
+	projectDir := filepath.Join(tmpDir, "test-project")
+	require.NoError(t, os.MkdirAll(projectDir, 0755))
+
+	// Create .wakatime config file with minimal project info
+	configContent := `[project]
+name = minimal-project
+branch = main
+`
+	configFile := filepath.Join(projectDir, project.WakaTimeConfigFile)
+	require.NoError(t, os.WriteFile(configFile, []byte(configContent), 0644))
+
+	testFile := filepath.Join(projectDir, "file.txt")
+	require.NoError(t, os.WriteFile(testFile, []byte("test"), 0644))
+
+	detector := project.ConfigDetector{
+		Filepath: testFile,
+	}
+
+	result, found, err := detector.Detect(t.Context())
+	require.NoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, "minimal-project", result.Project)
+	assert.Equal(t, "main", result.Branch)
+	assert.Equal(t, projectDir, result.Folder)
+}
+
+func TestConfigDetector_NoConfigFile(t *testing.T) {
+	// Create temporary directory without config file
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "file.txt")
+	require.NoError(t, os.WriteFile(testFile, []byte("test"), 0644))
+
+	detector := project.ConfigDetector{
+		Filepath: testFile,
+	}
+
+	result, err := detector.DetectConfig(t.Context())
+	require.NoError(t, err)
+	assert.False(t, result.Found)
+}

--- a/pkg/project/projectconfig.go
+++ b/pkg/project/projectconfig.go
@@ -1,0 +1,122 @@
+package project
+
+import (
+	"context"
+	"path/filepath"
+
+	"github.com/wakatime/wakatime-cli/pkg/log"
+
+	"github.com/spf13/viper"
+)
+
+// LoadProjectConfig attempts to load project-specific configuration for the given file path.
+// It searches for .wakatime files in the file's directory hierarchy and merges the configuration
+// with the provided global viper instance.
+// Returns a new viper instance with merged configuration, or the original viper if no project config found.
+func LoadProjectConfig(ctx context.Context, globalViper *viper.Viper, filePath string) *viper.Viper {
+	if filePath == "" {
+		return globalViper
+	}
+
+	logger := log.Extract(ctx)
+
+	// Try to detect project configuration
+	configDetector := ConfigDetector{
+		Filepath: filePath,
+	}
+
+	configResult, err := configDetector.DetectConfig(ctx)
+	if err != nil {
+		logger.Debugf("failed to detect project config for %s: %s", filePath, err)
+		return globalViper
+	}
+
+	if !configResult.Found {
+		logger.Debugf("no project config found for %s", filePath)
+		return globalViper
+	}
+
+	logger.Debugf("merging project config from %s", filepath.Join(filepath.Dir(configResult.Folder), WakaTimeConfigFile))
+
+	// Create a new viper instance for merged configuration
+	mergedViper := viper.New()
+
+	// First, copy all settings from global config
+	allGlobalSettings := globalViper.AllSettings()
+	mergedSettings := deepCopyMap(allGlobalSettings)
+
+	// Then, merge project-specific settings
+	allProjectSettings := configResult.Config.AllSettings()
+	deepMergeMap(mergedSettings, allProjectSettings)
+
+	// Set all merged settings in new viper
+	for key, value := range mergedSettings {
+		mergedViper.Set(key, value)
+	}
+
+	return mergedViper
+}
+
+// GetProjectConfigPath returns the path to the project config file for the given file path,
+// or empty string if no project config is found.
+func GetProjectConfigPath(ctx context.Context, filePath string) string {
+	if filePath == "" {
+		return ""
+	}
+
+	configPath, found := FindFileOrDirectory(ctx, filePath, WakaTimeConfigFile)
+	if !found {
+		return ""
+	}
+
+	return configPath
+}
+
+// deepCopyMap creates a deep copy of a map[string]interface{}.
+func deepCopyMap(original map[string]interface{}) map[string]interface{} {
+	copy := make(map[string]interface{})
+	for key, value := range original {
+		copy[key] = deepCopyValue(value)
+	}
+
+	return copy
+}
+
+// deepCopyValue creates a deep copy of an interface{} value.
+func deepCopyValue(original interface{}) interface{} {
+	switch original := original.(type) {
+	case map[string]interface{}:
+		return deepCopyMap(original)
+	case []interface{}:
+		copy := make([]interface{}, len(original))
+		for i, v := range original {
+			copy[i] = deepCopyValue(v)
+		}
+
+		return copy
+	default:
+		return original
+	}
+}
+
+// deepMergeMap merges source map into destination map recursively.
+func deepMergeMap(dest, source map[string]interface{}) {
+	for key, sourceValue := range source {
+		if destValue, exists := dest[key]; exists {
+			// Both source and dest have this key
+			destMap, destIsMap := destValue.(map[string]interface{})
+			sourceMap, sourceIsMap := sourceValue.(map[string]interface{})
+
+			if destIsMap && sourceIsMap {
+				// Both are maps, merge recursively
+				deepMergeMap(destMap, sourceMap)
+			} else {
+				// One or both are not maps, override with source value
+				dest[key] = deepCopyValue(sourceValue)
+			}
+		} else {
+			// Key only exists in source, copy it
+			dest[key] = deepCopyValue(sourceValue)
+		}
+	}
+}

--- a/pkg/project/projectconfig_test.go
+++ b/pkg/project/projectconfig_test.go
@@ -1,0 +1,136 @@
+package project_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/wakatime/wakatime-cli/pkg/project"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadProjectConfig(t *testing.T) {
+	// Create temporary directory structure
+	tmpDir := t.TempDir()
+	projectDir := filepath.Join(tmpDir, "test-project")
+	require.NoError(t, os.MkdirAll(projectDir, 0755))
+
+	// Create .wakatime config file
+	configContent := `[settings]
+api_key = waka_project-1234-4123-8123-123456789012
+debug = true
+exclude = .*project.*
+
+[projectmap]
+src/.* = project-core
+`
+	configFile := filepath.Join(projectDir, project.WakaTimeConfigFile)
+	require.NoError(t, os.WriteFile(configFile, []byte(configContent), 0644))
+
+	// Create a test file
+	testFile := filepath.Join(projectDir, "src", "main.go")
+	require.NoError(t, os.MkdirAll(filepath.Dir(testFile), 0755))
+	require.NoError(t, os.WriteFile(testFile, []byte("package main"), 0644))
+
+	// Create global viper config
+	globalViper := viper.New()
+	globalViper.Set("settings.api_key", "waka_global-1234-4123-8123-123456789012")
+	globalViper.Set("settings.debug", false)
+	globalViper.Set("settings.timeout", 30)
+	globalViper.Set("projectmap.lib/.*", "global-lib")
+
+	tests := []struct {
+		name       string
+		filepath   string
+		wantMerged bool
+	}{
+		{
+			name:       "file in project with config",
+			filepath:   testFile,
+			wantMerged: true,
+		},
+		{
+			name:       "file outside project",
+			filepath:   filepath.Join(tmpDir, "other", "file.go"),
+			wantMerged: false,
+		},
+		{
+			name:       "empty filepath",
+			filepath:   "",
+			wantMerged: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := project.LoadProjectConfig(t.Context(), globalViper, tt.filepath)
+
+			if tt.wantMerged {
+				// Should have project-specific overrides
+				assert.Equal(t, "waka_project-1234-4123-8123-123456789012", result.GetString("settings.api_key"))
+				assert.Equal(t, true, result.GetBool("settings.debug"))
+				assert.Equal(t, ".*project.*", result.GetString("settings.exclude"))
+				assert.Equal(t, "project-core", result.GetString("projectmap.src/.*"))
+
+				// Should retain global settings not overridden
+				assert.Equal(t, 30, result.GetInt("settings.timeout"))
+				assert.Equal(t, "global-lib", result.GetString("projectmap.lib/.*"))
+			} else {
+				// Should be identical to global config
+				assert.Equal(t, "waka_global-1234-4123-8123-123456789012", result.GetString("settings.api_key"))
+				assert.Equal(t, false, result.GetBool("settings.debug"))
+				assert.Equal(t, 30, result.GetInt("settings.timeout"))
+				assert.Equal(t, "global-lib", result.GetString("projectmap.lib/.*"))
+				assert.Equal(t, "", result.GetString("settings.exclude"))
+			}
+		})
+	}
+}
+
+func TestGetProjectConfigPath(t *testing.T) {
+	// Create temporary directory structure
+	tmpDir := t.TempDir()
+	projectDir := filepath.Join(tmpDir, "test-project")
+	require.NoError(t, os.MkdirAll(projectDir, 0755))
+
+	// Create .wakatime config file
+	configFile := filepath.Join(projectDir, project.WakaTimeConfigFile)
+	require.NoError(t, os.WriteFile(configFile, []byte("[project]\nname=test"), 0644))
+
+	// Create a test file
+	testFile := filepath.Join(projectDir, "src", "main.go")
+	require.NoError(t, os.MkdirAll(filepath.Dir(testFile), 0755))
+	require.NoError(t, os.WriteFile(testFile, []byte("package main"), 0644))
+
+	tests := []struct {
+		name     string
+		filepath string
+		wantPath string
+	}{
+		{
+			name:     "file in project",
+			filepath: testFile,
+			wantPath: configFile,
+		},
+		{
+			name:     "file outside project",
+			filepath: filepath.Join(tmpDir, "other", "file.go"),
+			wantPath: "",
+		},
+		{
+			name:     "empty filepath",
+			filepath: "",
+			wantPath: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := project.GetProjectConfigPath(t.Context(), tt.filepath)
+			assert.Equal(t, tt.wantPath, result)
+		})
+	}
+}


### PR DESCRIPTION
# Summary

Implements project-level configuration support as requested in [#884](https://github.com/wakatime/wakatime-cli/issues/884). This allows projects to override global configuration settings using `.wakatime` files in their directory structure.

