### PR TITLE
Move viper initialization to vipertools

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,11 +9,10 @@ import (
 	"github.com/wakatime/wakatime-cli/pkg/api"
 	"github.com/wakatime/wakatime-cli/pkg/exitcode"
 	"github.com/wakatime/wakatime-cli/pkg/offline"
+	"github.com/wakatime/wakatime-cli/pkg/vipertools"
 
-	viperini "github.com/go-viper/encoding/ini"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	iniv1 "gopkg.in/ini.v1"
 )
 
 // defaultConfigSection is the default section in the wakatime ini config file.
@@ -21,15 +20,10 @@ const defaultConfigSection = "settings"
 
 // NewRootCMD creates a rootCmd, which represents the base command when called without any subcommands.
 func NewRootCMD() *cobra.Command {
-	multilineOption := iniv1.LoadOptions{AllowPythonMultilineValues: true}
-	iniCodec := viperini.Codec{LoadOptions: multilineOption}
-
-	codecRegistry := viper.NewCodecRegistry()
-	if err := codecRegistry.RegisterCodec("ini", iniCodec); err != nil {
-		log.Fatalf("failed to register ini codec: %s", err)
+	v, err := vipertools.New()
+	if err != nil {
+		log.Fatalf("failed to create viper instance: %s", err)
 	}
-
-	v := viper.NewWithOptions(viper.WithCodecRegistry(codecRegistry))
 
 	cmd := &cobra.Command{
 		Use:   "wakatime-cli",

--- a/pkg/vipertools/vipertools.go
+++ b/pkg/vipertools/vipertools.go
@@ -1,11 +1,67 @@
 package vipertools
 
 import (
+	"fmt"
+	"slices"
 	"strings"
 
+	viperini "github.com/go-viper/encoding/ini"
 	"github.com/spf13/cast"
 	"github.com/spf13/viper"
+	iniv1 "gopkg.in/ini.v1"
 )
+
+// New creates a new viper instance with the ini codec registered.
+func New() (*viper.Viper, error) {
+	multilineOption := iniv1.LoadOptions{AllowPythonMultilineValues: true}
+	iniCodec := viperini.Codec{LoadOptions: multilineOption}
+
+	codecRegistry := viper.NewCodecRegistry()
+	if err := codecRegistry.RegisterCodec("ini", iniCodec); err != nil {
+		return nil, fmt.Errorf("failed to register ini codec: %w", err)
+	}
+
+	return viper.NewWithOptions(viper.WithCodecRegistry(codecRegistry)), nil
+}
+
+// CopyOnlySettings copies only the settings from one viper.Viper instance to another.
+// It skips all settings that are loaded from command line arguments.
+func CopyOnlySettings(vsrc, vdest *viper.Viper) {
+	skip := []string{
+		"key",
+		"api-url",
+		"apiurl",
+		"hostname",
+		"proxy",
+		"ssl-certs-file",
+		"timeout",
+		"no-ssl-verify",
+		"guess-language",
+		"exclude",
+		"include",
+		"exclude-unknown-project",
+		"include-only-with-project-file",
+		"hide-branch-names",
+		"hide-dependencies",
+		"hide-project-names",
+		"hide-file-names",
+		"hide-filenames",
+		"hidefilenames",
+		"hide-project-folder",
+		"disable-offline",
+		"disableoffline",
+		"heartbeat-rate-limit-seconds",
+		"today-hide-categories",
+	}
+
+	for _, key := range vsrc.AllKeys() {
+		if slices.Contains(skip, key) {
+			continue
+		}
+
+		vdest.Set(key, vsrc.Get(key))
+	}
+}
 
 // FirstNonEmptyBool accepts multiple keys and returns the first non-empty bool value
 // from viper.Viper via these keys. Non-empty meaning key not set will not be accepted.

--- a/pkg/vipertools/vipertools_test.go
+++ b/pkg/vipertools/vipertools_test.go
@@ -10,6 +10,50 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestCopyOnlySettings(t *testing.T) {
+	v := viper.New()
+	v.Set("key", "00000000-0000-4000-8000-000000000000")
+	v.Set("api-url", "http://localhost:8080/api/v1")
+	v.Set("apiurl", "http://localhost:8080/api/v2")
+	v.Set("hostname", "localhost")
+	v.Set("proxy", "http://localhost:8080")
+	v.Set("ssl-certs-file", "/path/to/cert.pem")
+	v.Set("timeout", 30)
+	v.Set("no-ssl-verify", true)
+	v.Set("guess-language", true)
+	v.Set("exclude", []string{"node_modules", "vendor"})
+	v.Set("include", []string{"src", "lib"})
+	v.Set("exclude-unknown-project", true)
+	v.Set("include-only-with-project-file", true)
+	v.Set("hide-branch-names", true)
+	v.Set("hide-dependencies", true)
+	v.Set("hide-project-names", true)
+	v.Set("hide-file-names", true)
+	v.Set("hide-filenames", true)
+	v.Set("hidefilenames", true)
+	v.Set("hide-project-folder", true)
+	v.Set("disable-offline", false)
+	v.Set("disableoffline", false)
+	v.Set("heartbeat-rate-limit-seconds", 60)
+	v.Set("today-hide-categories", []string{"coding", "debugging"})
+
+	vdest := viper.New()
+	vipertools.CopyOnlySettings(v, vdest)
+
+	assert.Zero(t, len(vdest.AllKeys()))
+}
+
+func TestCopyOnlySettings_KeepSettings(t *testing.T) {
+	v := viper.New()
+	v.Set("key", "00000000-0000-4000-8000-000000000000")
+	v.Set("settings.api_key", "00000000-0000-4000-8000-000000000002")
+
+	vdest := viper.New()
+	vipertools.CopyOnlySettings(v, vdest)
+
+	assert.Equal(t, 1, len(vdest.AllKeys()))
+}
+
 func TestFirstNonEmptyBool(t *testing.T) {
 	v := viper.New()
 	v.Set("second", false)


### PR DESCRIPTION
This PR moves viper initialization to `vipertools` package as a preparation for the next PR. The idea is to share the logic of creating viper to a centralized function.