### PR TITLE
Add handler package

### DIFF
--- a/cmd/handler/handler.go
+++ b/cmd/handler/handler.go
@@ -1,0 +1,131 @@
+package handler
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"github.com/wakatime/wakatime-cli/pkg/file"
+	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
+	"github.com/wakatime/wakatime-cli/pkg/ini"
+	"github.com/wakatime/wakatime-cli/pkg/log"
+	paramspkg "github.com/wakatime/wakatime-cli/pkg/params"
+	"github.com/wakatime/wakatime-cli/pkg/vipertools"
+
+	"github.com/spf13/viper"
+)
+
+const projectConfigFileName = ".wakatime"
+
+// Config contains the configuration for the heartbeat handler.
+type Config struct {
+	Params       paramspkg.Params
+	ParamsLoader func(context.Context, *viper.Viper) (paramspkg.Params, error)
+	Opts         []Preprocessor
+}
+
+// New creates a new heartbeat.HandleOption that processes heartbeats
+// with project-level configuration files and applies the provided options.
+func New(
+	v *viper.Viper,
+	cfg Config,
+) heartbeat.HandleOption {
+	return func(next heartbeat.Handle) heartbeat.Handle {
+		return func(ctx context.Context, hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+			var heartbeats []heartbeat.Heartbeat
+			logger := *log.Extract(ctx) // make it a shallow copy to avoid modifying the original logger
+
+			for _, h := range hh {
+				// shallow copy the params to avoid modifying the original
+				effectiveParams := cfg.Params
+
+				p, ok, err := findProjectConfigFile(ctx, v, h.Entity, h.EntityType, h.IsUnsavedEntity, cfg.ParamsLoader)
+				if err != nil {
+					return nil, fmt.Errorf("failed to find project configuration file: %w", err)
+				}
+
+				if ok {
+					// if project-level configuration file is found, use it
+					logger.Debugf("found project-level configuration file %s for entity %q", projectConfigFileName, h.Entity)
+					logger.Debugf("project-level params: %s", p)
+
+					effectiveParams = p
+				}
+
+				chain := heartbeat.NewHandle(noop{})
+
+				for i := len(cfg.Opts) - 1; i >= 0; i-- {
+					chain = cfg.Opts[i](effectiveParams)(chain)
+				}
+
+				res, err := chain(ctx, []heartbeat.Heartbeat{h})
+				if err != nil {
+					return nil, fmt.Errorf("failed to process heartbeat: %w", err)
+				}
+
+				for _, r := range res {
+					heartbeats = append(heartbeats, r.Heartbeat)
+				}
+			}
+
+			if len(heartbeats) == 0 {
+				return []heartbeat.Result{}, nil
+			}
+
+			return next(ctx, heartbeats)
+		}
+	}
+}
+
+func findProjectConfigFile(
+	ctx context.Context,
+	v *viper.Viper,
+	entity string,
+	entityType heartbeat.EntityType,
+	isUnsavedEntity bool,
+	paramsLoader func(context.Context, *viper.Viper) (paramspkg.Params, error),
+) (paramspkg.Params, bool, error) {
+	if entityType != heartbeat.FileType || isUnsavedEntity {
+		return paramspkg.Params{}, false, nil
+	}
+
+	fp, ok := file.Find(ctx, filepath.Dir(entity), projectConfigFileName)
+	if !ok {
+		return paramspkg.Params{}, false, nil
+	}
+
+	vproj, err := vipertools.New()
+	if err != nil {
+		return paramspkg.Params{}, false, fmt.Errorf("failed to create viper instance: %w", err)
+	}
+
+	// copy only settings from the main viper instance to the project-level viper instance
+	vipertools.CopyOnlySettings(v, vproj)
+
+	// load project-level configuration file into viper instance
+	if err := ini.ReadInConfig(vproj, fp); err != nil {
+		return paramspkg.Params{}, false, fmt.Errorf("failed to load project-level configuration file: %s", err)
+	}
+
+	// load parameters from viper instance
+	params, err := paramsLoader(ctx, vproj)
+	if err != nil {
+		return paramspkg.Params{}, false, fmt.Errorf("failed to load project-level parameters: %w", err)
+	}
+
+	return params, true, nil
+}
+
+// noop is a noop api client, used to format heartbeats without sending them.
+type noop struct{}
+
+// SendHeartbeats always returns results containing formatted heartbeats and no error.
+func (noop) SendHeartbeats(_ context.Context, hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+	results := make([]heartbeat.Result, len(hh))
+
+	for i := range hh {
+		results[i] = heartbeat.Result{Heartbeat: hh[i]}
+	}
+
+	return results, nil
+}

--- a/cmd/handler/handler_internal_test.go
+++ b/cmd/handler/handler_internal_test.go
@@ -1,0 +1,172 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
+	paramspkg "github.com/wakatime/wakatime-cli/pkg/params"
+
+	viperini "github.com/go-viper/encoding/ini"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	iniv1 "gopkg.in/ini.v1"
+)
+
+func TestNoopSendHeartbeats(t *testing.T) {
+	noop := noop{}
+
+	res, err := noop.SendHeartbeats(t.Context(), []heartbeat.Heartbeat{
+		{APIKey: "test-api-key", Entity: "test-entity", EntityType: heartbeat.FileType, IsUnsavedEntity: false},
+		{APIKey: "test-api-key-2", Entity: "test-entity-2", EntityType: heartbeat.AppType, IsUnsavedEntity: true},
+	})
+	require.NoError(t, err)
+
+	require.Len(t, res, 2)
+	assert.EqualValues(
+		t,
+		heartbeat.Heartbeat{
+			APIKey:          "test-api-key",
+			Entity:          "test-entity",
+			EntityType:      heartbeat.FileType,
+			IsUnsavedEntity: false,
+		},
+		res[0].Heartbeat,
+	)
+	assert.EqualValues(
+		t,
+		heartbeat.Heartbeat{
+			APIKey:          "test-api-key-2",
+			Entity:          "test-entity-2",
+			EntityType:      heartbeat.AppType,
+			IsUnsavedEntity: true,
+		},
+		res[1].Heartbeat,
+	)
+}
+
+func TestFindProjectConfigFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	dir := filepath.Join(tmpDir, "src", "folder-1", "folder-2", "folder-3")
+
+	err := os.MkdirAll(dir, os.FileMode(int(0700)))
+	require.NoError(t, err)
+
+	tmpFile, err := os.OpenFile(filepath.Join(dir, "some-entity.go"), os.O_RDONLY|os.O_CREATE, 0700)
+	require.NoError(t, err)
+
+	tmpProjectFile, err := os.OpenFile(filepath.Join(tmpDir, "src", ".wakatime"), os.O_RDONLY|os.O_CREATE, 0700)
+	require.NoError(t, err)
+
+	defer func() {
+		tmpFile.Close()
+		tmpProjectFile.Close()
+	}()
+
+	v := setupViper(t)
+
+	params, ok, err := findProjectConfigFile(
+		t.Context(), v, dir, heartbeat.FileType, false,
+		func(_ context.Context, _ *viper.Viper) (paramspkg.Params, error) {
+			return paramspkg.Params{}, nil
+		},
+	)
+	require.NoError(t, err)
+
+	assert.True(t, ok)
+	assert.Equal(t, paramspkg.Params{}, params)
+}
+
+func TestFindProjectConfigFile_NotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	dir := filepath.Join(tmpDir, "src", "folder-1", "folder-2", "folder-3")
+
+	err := os.MkdirAll(dir, os.FileMode(int(0700)))
+	require.NoError(t, err)
+
+	tmpFile, err := os.OpenFile(filepath.Join(dir, "some-entity.go"), os.O_RDONLY|os.O_CREATE, 0700)
+	require.NoError(t, err)
+
+	defer tmpFile.Close()
+
+	v := setupViper(t)
+
+	params, ok, err := findProjectConfigFile(
+		t.Context(), v, dir, heartbeat.FileType, false,
+		func(_ context.Context, _ *viper.Viper) (paramspkg.Params, error) {
+			return paramspkg.Params{}, nil
+		},
+	)
+	require.NoError(t, err)
+
+	assert.False(t, ok)
+	assert.Equal(t, paramspkg.Params{}, params)
+}
+
+func TestFindProjectConfigFile_NotFileType(t *testing.T) {
+	params, ok, err := findProjectConfigFile(t.Context(), nil, "", heartbeat.AppType, false, nil)
+	require.NoError(t, err)
+
+	assert.False(t, ok)
+	assert.Equal(t, paramspkg.Params{}, params)
+}
+
+func TestFindProjectConfigFile_IsUnsavedEntity(t *testing.T) {
+	params, ok, err := findProjectConfigFile(t.Context(), nil, "", heartbeat.FileType, true, nil)
+	require.NoError(t, err)
+
+	assert.False(t, ok)
+	assert.Equal(t, paramspkg.Params{}, params)
+}
+
+func TestFindProjectConfigFile_ParamsLoader_Err(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	dir := filepath.Join(tmpDir, "src", "folder-1", "folder-2", "folder-3")
+
+	err := os.MkdirAll(dir, os.FileMode(int(0700)))
+	require.NoError(t, err)
+
+	tmpFile, err := os.OpenFile(filepath.Join(dir, "some-entity.go"), os.O_RDONLY|os.O_CREATE, 0700)
+	require.NoError(t, err)
+
+	tmpProjectFile, err := os.OpenFile(filepath.Join(tmpDir, "src", ".wakatime"), os.O_RDONLY|os.O_CREATE, 0700)
+	require.NoError(t, err)
+
+	defer func() {
+		tmpFile.Close()
+		tmpProjectFile.Close()
+	}()
+
+	v := setupViper(t)
+
+	params, ok, err := findProjectConfigFile(
+		t.Context(), v, dir, heartbeat.FileType, false,
+		func(_ context.Context, _ *viper.Viper) (paramspkg.Params, error) {
+			return paramspkg.Params{}, errors.New("fail")
+		},
+	)
+	require.EqualError(t, err, "failed to load project-level parameters: fail")
+
+	assert.False(t, ok)
+	assert.Equal(t, paramspkg.Params{}, params)
+}
+
+func setupViper(t *testing.T) *viper.Viper {
+	multilineOption := iniv1.LoadOptions{AllowPythonMultilineValues: true}
+	iniCodec := viperini.Codec{LoadOptions: multilineOption}
+
+	codecRegistry := viper.NewCodecRegistry()
+	err := codecRegistry.RegisterCodec("ini", iniCodec)
+	require.NoError(t, err)
+
+	v := viper.NewWithOptions(viper.WithCodecRegistry(codecRegistry))
+
+	return v
+}

--- a/cmd/handler/handler_test.go
+++ b/cmd/handler/handler_test.go
@@ -1,0 +1,97 @@
+package handler_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/wakatime/wakatime-cli/cmd/handler"
+	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
+	"github.com/wakatime/wakatime-cli/pkg/params"
+
+	viperini "github.com/go-viper/encoding/ini"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	iniv1 "gopkg.in/ini.v1"
+)
+
+func TestHandlerNew(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	dir := filepath.Join(tmpDir, "src", "folder-1", "folder-2", "folder-3")
+
+	err := os.MkdirAll(dir, os.FileMode(int(0700)))
+	require.NoError(t, err)
+
+	_, err = os.OpenFile(filepath.Join(dir, "some-entity.go"), os.O_RDONLY|os.O_CREATE, 0700)
+	require.NoError(t, err)
+
+	_, err = os.OpenFile(filepath.Join(tmpDir, "src", ".wakatime"), os.O_RDONLY|os.O_CREATE, 0700)
+	require.NoError(t, err)
+
+	v := setupViper(t)
+
+	sender := newHandle(noopMock{})
+	hdl := handler.New(v, handler.Config{
+		Params: params.Params{},
+		ParamsLoader: func(_ context.Context, _ *viper.Viper) (params.Params, error) {
+			return params.Params{
+				// this simulates the project-level parameters loaded from the .wakatime file.
+				API: params.API{Key: "00000000-0000-4000-8000-000000000002"},
+			}, nil
+		},
+		Opts: []handler.Preprocessor{
+			// we're only testing the API key replacement, so we need to add this option.
+			handler.WithAPIKeyReplacing(),
+		},
+	})(sender)
+
+	res, err := hdl(t.Context(), []heartbeat.Heartbeat{
+		{
+			APIKey:          "00000000-0000-4000-8000-000000000001",
+			Entity:          filepath.Join(dir, "some-entity.go"),
+			EntityType:      heartbeat.FileType,
+			IsUnsavedEntity: false,
+		},
+	})
+	require.NoError(t, err)
+
+	assert.Len(t, res, 1)
+	assert.Equal(t, res[0].Heartbeat.APIKey, "00000000-0000-4000-8000-000000000002")
+}
+
+func setupViper(t *testing.T) *viper.Viper {
+	multilineOption := iniv1.LoadOptions{AllowPythonMultilineValues: true}
+	iniCodec := viperini.Codec{LoadOptions: multilineOption}
+
+	codecRegistry := viper.NewCodecRegistry()
+	err := codecRegistry.RegisterCodec("ini", iniCodec)
+	require.NoError(t, err)
+
+	v := viper.NewWithOptions(viper.WithCodecRegistry(codecRegistry))
+
+	return v
+}
+
+func newHandle(sender heartbeat.Sender) heartbeat.Handle {
+	return func(ctx context.Context, hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+		var handle heartbeat.Handle = sender.SendHeartbeats
+		return handle(ctx, hh)
+	}
+}
+
+type noopMock struct{}
+
+// SendHeartbeats always returns results containing formatted heartbeats and no error.
+func (noopMock) SendHeartbeats(_ context.Context, hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+	res := make([]heartbeat.Result, len(hh))
+	for i, h := range hh {
+		res[i] = heartbeat.Result{
+			Heartbeat: h,
+		}
+	}
+
+	return res, nil
+}

--- a/cmd/handler/option.go
+++ b/cmd/handler/option.go
@@ -1,0 +1,143 @@
+package handler
+
+import (
+	"github.com/wakatime/wakatime-cli/pkg/apikey"
+	"github.com/wakatime/wakatime-cli/pkg/deps"
+	"github.com/wakatime/wakatime-cli/pkg/fileexperts"
+	"github.com/wakatime/wakatime-cli/pkg/filestats"
+	"github.com/wakatime/wakatime-cli/pkg/filter"
+	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
+	"github.com/wakatime/wakatime-cli/pkg/language"
+	"github.com/wakatime/wakatime-cli/pkg/params"
+	"github.com/wakatime/wakatime-cli/pkg/project"
+	"github.com/wakatime/wakatime-cli/pkg/remote"
+)
+
+// Preprocessor is a function used to preprocess heartbeat parameters.
+// It takes params.Params as input and returns a heartbeat.HandleOption.
+type Preprocessor func(params params.Params) heartbeat.HandleOption
+
+// WithFormatting returns a Preprocessor that applies heartbeat formatting.
+func WithFormatting() Preprocessor {
+	return func(_ params.Params) heartbeat.HandleOption {
+		return heartbeat.WithFormatting()
+	}
+}
+
+// WithEntityModifier returns a Preprocessor that applies entity modification to heartbeats.
+func WithEntityModifier() Preprocessor {
+	return func(_ params.Params) heartbeat.HandleOption {
+		return heartbeat.WithEntityModifier()
+	}
+}
+
+// WithHeartbeatFiltering returns a Preprocessor that applies filtering to heartbeats.
+func WithHeartbeatFiltering() Preprocessor {
+	return func(params params.Params) heartbeat.HandleOption {
+		return filter.WithFiltering(filter.Config{
+			Exclude:                    params.Heartbeat.Filter.Exclude,
+			Include:                    params.Heartbeat.Filter.Include,
+			IncludeOnlyWithProjectFile: params.Heartbeat.Filter.IncludeOnlyWithProjectFile,
+		})
+	}
+}
+
+// WithRemoteDetection returns a Preprocessor that applies remote detection to heartbeats.
+func WithRemoteDetection() Preprocessor {
+	return func(_ params.Params) heartbeat.HandleOption {
+		return remote.WithDetection()
+	}
+}
+
+// WithAPIKeyReplacing returns a Preprocessor that replaces API keys in heartbeats.
+func WithAPIKeyReplacing() Preprocessor {
+	return func(params params.Params) heartbeat.HandleOption {
+		return apikey.WithReplacing(apikey.Config{
+			DefaultAPIKey: params.API.Key,
+			MapPatterns:   params.API.KeyPatterns,
+		})
+	}
+}
+
+// WithFileStatsDetection returns a Preprocessor that applies file statistics detection to heartbeats.
+func WithFileStatsDetection() Preprocessor {
+	return func(_ params.Params) heartbeat.HandleOption {
+		return filestats.WithDetection()
+	}
+}
+
+// WithLanguageDetection returns a Preprocessor that applies language detection to heartbeats.
+func WithLanguageDetection() Preprocessor {
+	return func(params params.Params) heartbeat.HandleOption {
+		return language.WithDetection(language.Config{
+			GuessLanguage: params.Heartbeat.GuessLanguage,
+		})
+	}
+}
+
+// WithDependencyDetection returns a Preprocessor that applies dependency detection to heartbeats.
+func WithDependencyDetection() Preprocessor {
+	return func(params params.Params) heartbeat.HandleOption {
+		return deps.WithDetection(deps.Config{
+			FilePatterns: params.Heartbeat.Sanitize.HideFileNames,
+		})
+	}
+}
+
+// WithProjectDetection returns a Preprocessor that applies project detection to heartbeats.
+func WithProjectDetection() Preprocessor {
+	return func(params params.Params) heartbeat.HandleOption {
+		return project.WithDetection(project.Config{
+			HideProjectNames:     params.Heartbeat.Sanitize.HideProjectNames,
+			MapPatterns:          params.Heartbeat.Project.MapPatterns,
+			ProjectFromGitRemote: params.Heartbeat.Project.ProjectFromGitRemote,
+			Submodule: project.Submodule{
+				DisabledPatterns: params.Heartbeat.Project.SubmodulesDisabled,
+				MapPatterns:      params.Heartbeat.Project.SubmoduleMapPatterns,
+			},
+		})
+	}
+}
+
+// WithProjectFiltering returns a Preprocessor that applies project filtering to heartbeats.
+func WithProjectFiltering() Preprocessor {
+	return func(params params.Params) heartbeat.HandleOption {
+		return project.WithFiltering(project.FilterConfig{
+			ExcludeUnknownProject: params.Heartbeat.Filter.ExcludeUnknownProject,
+		})
+	}
+}
+
+// WithHeartbeatSanitization returns a Preprocessor that applies sanitization to heartbeats.
+func WithHeartbeatSanitization() Preprocessor {
+	return func(params params.Params) heartbeat.HandleOption {
+		return heartbeat.WithSanitization(heartbeat.SanitizeConfig{
+			BranchPatterns:     params.Heartbeat.Sanitize.HideBranchNames,
+			DependencyPatterns: params.Heartbeat.Sanitize.HideDependencies,
+			FilePatterns:       params.Heartbeat.Sanitize.HideFileNames,
+			HideProjectFolder:  params.Heartbeat.Sanitize.HideProjectFolder,
+			ProjectPatterns:    params.Heartbeat.Sanitize.HideProjectNames,
+		})
+	}
+}
+
+// WithFileExpertsValidation returns a Preprocessor that applies validation for file experts.
+func WithFileExpertsValidation() Preprocessor {
+	return func(_ params.Params) heartbeat.HandleOption {
+		return fileexperts.WithValidation()
+	}
+}
+
+// WithRemoteCleanup returns a Preprocessor that applies cleanup for remote heartbeats.
+func WithRemoteCleanup() Preprocessor {
+	return func(_ params.Params) heartbeat.HandleOption {
+		return remote.WithCleanup()
+	}
+}
+
+// WithLengthValidator returns a Preprocessor that applies length validation to heartbeats.
+func WithLengthValidator() Preprocessor {
+	return func(_ params.Params) heartbeat.HandleOption {
+		return filter.WithLengthValidator()
+	}
+}

--- a/cmd/handler/option_test.go
+++ b/cmd/handler/option_test.go
@@ -1,0 +1,181 @@
+package handler_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/wakatime/wakatime-cli/cmd/handler"
+	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
+	"github.com/wakatime/wakatime-cli/pkg/params"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithFormatting(t *testing.T) {
+	opt := handler.WithFormatting()
+
+	chain := heartbeat.NewHandle(noopMock{})
+	hdl := opt(params.Params{})(chain)
+
+	res, err := hdl(context.Background(), nil)
+	require.NoError(t, err)
+
+	assert.Len(t, res, 0)
+}
+
+func TestWithEntityModifier(t *testing.T) {
+	opt := handler.WithEntityModifier()
+
+	chain := heartbeat.NewHandle(noopMock{})
+	hdl := opt(params.Params{})(chain)
+
+	res, err := hdl(context.Background(), nil)
+	require.NoError(t, err)
+
+	assert.Len(t, res, 0)
+}
+
+func TestWithHeartbeatFiltering(t *testing.T) {
+	opt := handler.WithHeartbeatFiltering()
+
+	chain := heartbeat.NewHandle(noopMock{})
+	hdl := opt(params.Params{})(chain)
+
+	res, err := hdl(context.Background(), nil)
+	require.NoError(t, err)
+
+	assert.Len(t, res, 0)
+}
+
+func TestWithRemoteDetection(t *testing.T) {
+	opt := handler.WithRemoteDetection()
+
+	chain := heartbeat.NewHandle(noopMock{})
+	hdl := opt(params.Params{})(chain)
+
+	res, err := hdl(context.Background(), nil)
+	require.NoError(t, err)
+
+	assert.Len(t, res, 0)
+}
+
+func TestWithAPIKeyReplacing(t *testing.T) {
+	opt := handler.WithAPIKeyReplacing()
+
+	chain := heartbeat.NewHandle(noopMock{})
+	hdl := opt(params.Params{})(chain)
+
+	res, err := hdl(context.Background(), nil)
+	require.NoError(t, err)
+
+	assert.Len(t, res, 0)
+}
+
+func TestWithFileStatsDetection(t *testing.T) {
+	opt := handler.WithFileStatsDetection()
+
+	chain := heartbeat.NewHandle(noopMock{})
+	hdl := opt(params.Params{})(chain)
+
+	res, err := hdl(context.Background(), nil)
+	require.NoError(t, err)
+
+	assert.Len(t, res, 0)
+}
+
+func TestWithLanguageDetection(t *testing.T) {
+	opt := handler.WithLanguageDetection()
+
+	chain := heartbeat.NewHandle(noopMock{})
+	hdl := opt(params.Params{})(chain)
+
+	res, err := hdl(context.Background(), nil)
+	require.NoError(t, err)
+
+	assert.Len(t, res, 0)
+}
+
+func TestWithDependencyDetection(t *testing.T) {
+	opt := handler.WithDependencyDetection()
+
+	chain := heartbeat.NewHandle(noopMock{})
+	hdl := opt(params.Params{})(chain)
+
+	res, err := hdl(context.Background(), nil)
+	require.NoError(t, err)
+
+	assert.Len(t, res, 0)
+}
+
+func TestWithProjectDetection(t *testing.T) {
+	opt := handler.WithProjectDetection()
+
+	chain := heartbeat.NewHandle(noopMock{})
+	hdl := opt(params.Params{})(chain)
+
+	res, err := hdl(context.Background(), nil)
+	require.NoError(t, err)
+
+	assert.Len(t, res, 0)
+}
+
+func TestWithProjectFiltering(t *testing.T) {
+	opt := handler.WithProjectFiltering()
+
+	chain := heartbeat.NewHandle(noopMock{})
+	hdl := opt(params.Params{})(chain)
+
+	res, err := hdl(context.Background(), nil)
+	require.NoError(t, err)
+
+	assert.Len(t, res, 0)
+}
+
+func TestWithHeartbeatSanitization(t *testing.T) {
+	opt := handler.WithHeartbeatSanitization()
+
+	chain := heartbeat.NewHandle(noopMock{})
+	hdl := opt(params.Params{})(chain)
+
+	res, err := hdl(context.Background(), nil)
+	require.NoError(t, err)
+
+	assert.Len(t, res, 0)
+}
+
+func TestWithFileExpertsValidation(t *testing.T) {
+	opt := handler.WithFileExpertsValidation()
+
+	chain := heartbeat.NewHandle(noopMock{})
+	hdl := opt(params.Params{})(chain)
+
+	res, err := hdl(context.Background(), nil)
+	require.NoError(t, err)
+
+	assert.Len(t, res, 0)
+}
+
+func TestWithRemoteCleanup(t *testing.T) {
+	opt := handler.WithRemoteCleanup()
+
+	chain := heartbeat.NewHandle(noopMock{})
+	hdl := opt(params.Params{})(chain)
+
+	res, err := hdl(context.Background(), nil)
+	require.NoError(t, err)
+
+	assert.Len(t, res, 0)
+}
+
+func TestWithLengthValidator(t *testing.T) {
+	opt := handler.WithLengthValidator()
+
+	chain := heartbeat.NewHandle(noopMock{})
+	hdl := opt(params.Params{})(chain)
+
+	res, err := hdl(context.Background(), nil)
+	require.NoError(t, err)
+
+	assert.Len(t, res, 0)
+}

--- a/go.sum
+++ b/go.sum
@@ -145,8 +145,6 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/wakatime/bbolt v1.5.0 h1:FO4qSyKAKbkW6aS+2Svqt6kD6H/sfkv4izWXGjUvdHc=
-github.com/wakatime/bbolt v1.5.0/go.mod h1:nXZdfwGRl+8hFb3aoD2M2pnYwqfpahyK11Vlr5IM5Eg=
 github.com/yookoala/realpath v1.0.0 h1:7OA9pj4FZd+oZDsyvXWQvjn5oBdcHRTV44PpdMSuImQ=
 github.com/yookoala/realpath v1.0.0/go.mod h1:gJJMA9wuX7AcqLy1+ffPatSCySA1FQ2S8Ya9AIoYBpE=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=


### PR DESCRIPTION
This PR creates a new package `handler` in cmd to handle the preprocessing options which includes all filters applied in a heartbeat before actually calling the API.