### PR TITLE
Add flag read order to params

### DIFF
--- a/cmd/fileexperts/fileexperts.go
+++ b/cmd/fileexperts/fileexperts.go
@@ -40,7 +40,7 @@ func Run(ctx context.Context, v *viper.Viper) (int, error) {
 
 // FileExperts returns a rendered file experts of todays coding activity.
 func FileExperts(ctx context.Context, v *viper.Viper) (string, error) {
-	params, err := LoadParams(ctx, v)
+	params, err := LoadParams(ctx, v, params.FlagReadOrderFlagPrecedence)
 	if err != nil {
 		return "", fmt.Errorf("failed to load command parameters: %w", err)
 	}
@@ -86,22 +86,22 @@ func FileExperts(ctx context.Context, v *viper.Viper) (string, error) {
 
 // LoadParams loads file-expert config params from viper.Viper instance. Returns ErrAuth
 // if failed to retrieve api key.
-func LoadParams(ctx context.Context, v *viper.Viper) (params.Params, error) {
+func LoadParams(ctx context.Context, v *viper.Viper, order params.FlagReadOrder) (params.Params, error) {
 	if v == nil {
 		return params.Params{}, fmt.Errorf("viper instance unset")
 	}
 
-	heartbeatParams, err := params.LoadHeartbeatParams(ctx, v)
+	heartbeatParams, err := params.LoadHeartbeatParams(ctx, v, order)
 	if err != nil {
 		return params.Params{}, fmt.Errorf("failed to load heartbeat params: %s", err)
 	}
 
-	apiParams, err := params.LoadAPIParams(ctx, v)
+	apiParams, err := params.LoadAPIParams(ctx, v, order)
 	if err != nil {
 		return params.Params{}, fmt.Errorf("failed to load API parameters: %w", err)
 	}
 
-	statusBarParams, err := params.LoadStatusBarParams(v)
+	statusBarParams, err := params.LoadStatusBarParams(v, order)
 	if err != nil {
 		return params.Params{}, fmt.Errorf("failed to load status bar params: %w", err)
 	}

--- a/cmd/handler/handler.go
+++ b/cmd/handler/handler.go
@@ -9,8 +9,7 @@ import (
 	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 	"github.com/wakatime/wakatime-cli/pkg/ini"
 	"github.com/wakatime/wakatime-cli/pkg/log"
-	paramspkg "github.com/wakatime/wakatime-cli/pkg/params"
-	"github.com/wakatime/wakatime-cli/pkg/vipertools"
+	"github.com/wakatime/wakatime-cli/pkg/params"
 
 	"github.com/spf13/viper"
 )
@@ -19,8 +18,8 @@ const projectConfigFileName = ".wakatime"
 
 // Config contains the configuration for the heartbeat handler.
 type Config struct {
-	Params       paramspkg.Params
-	ParamsLoader func(context.Context, *viper.Viper) (paramspkg.Params, error)
+	Params       params.Params
+	ParamsLoader func(context.Context, *viper.Viper, params.FlagReadOrder) (params.Params, error)
 	Opts         []Preprocessor
 }
 
@@ -83,37 +82,29 @@ func findProjectConfigFile(
 	entity string,
 	entityType heartbeat.EntityType,
 	isUnsavedEntity bool,
-	paramsLoader func(context.Context, *viper.Viper) (paramspkg.Params, error),
-) (paramspkg.Params, bool, error) {
+	paramsLoader func(context.Context, *viper.Viper, params.FlagReadOrder) (params.Params, error),
+) (params.Params, bool, error) {
 	if entityType != heartbeat.FileType || isUnsavedEntity {
-		return paramspkg.Params{}, false, nil
+		return params.Params{}, false, nil
 	}
 
 	fp, ok := file.Find(ctx, filepath.Dir(entity), projectConfigFileName)
 	if !ok {
-		return paramspkg.Params{}, false, nil
+		return params.Params{}, false, nil
 	}
-
-	vproj, err := vipertools.New()
-	if err != nil {
-		return paramspkg.Params{}, false, fmt.Errorf("failed to create viper instance: %w", err)
-	}
-
-	// copy only settings from the main viper instance to the project-level viper instance
-	vipertools.CopyOnlySettings(v, vproj)
 
 	// load project-level configuration file into viper instance
-	if err := ini.ReadInConfig(vproj, fp); err != nil {
-		return paramspkg.Params{}, false, fmt.Errorf("failed to load project-level configuration file: %s", err)
+	if err := ini.ReadInConfig(v, fp); err != nil {
+		return params.Params{}, false, fmt.Errorf("failed to load project-level configuration file: %s", err)
 	}
 
 	// load parameters from viper instance
-	params, err := paramsLoader(ctx, vproj)
+	p, err := paramsLoader(ctx, v, params.FlagReadOrderProjectConfigPrecedence)
 	if err != nil {
-		return paramspkg.Params{}, false, fmt.Errorf("failed to load project-level parameters: %w", err)
+		return params.Params{}, false, fmt.Errorf("failed to load project-level parameters: %w", err)
 	}
 
-	return params, true, nil
+	return p, true, nil
 }
 
 // noop is a noop api client, used to format heartbeats without sending them.

--- a/cmd/handler/handler_internal_test.go
+++ b/cmd/handler/handler_internal_test.go
@@ -9,12 +9,11 @@ import (
 
 	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 	paramspkg "github.com/wakatime/wakatime-cli/pkg/params"
+	"github.com/wakatime/wakatime-cli/pkg/vipertools"
 
-	viperini "github.com/go-viper/encoding/ini"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	iniv1 "gopkg.in/ini.v1"
 )
 
 func TestNoopSendHeartbeats(t *testing.T) {
@@ -68,11 +67,11 @@ func TestFindProjectConfigFile(t *testing.T) {
 		tmpProjectFile.Close()
 	}()
 
-	v := setupViper(t)
+	v := vipertools.MustNew()
 
 	params, ok, err := findProjectConfigFile(
 		t.Context(), v, dir, heartbeat.FileType, false,
-		func(_ context.Context, _ *viper.Viper) (paramspkg.Params, error) {
+		func(_ context.Context, _ *viper.Viper, _ paramspkg.FlagReadOrder) (paramspkg.Params, error) {
 			return paramspkg.Params{}, nil
 		},
 	)
@@ -95,11 +94,11 @@ func TestFindProjectConfigFile_NotFound(t *testing.T) {
 
 	defer tmpFile.Close()
 
-	v := setupViper(t)
+	v := vipertools.MustNew()
 
 	params, ok, err := findProjectConfigFile(
 		t.Context(), v, dir, heartbeat.FileType, false,
-		func(_ context.Context, _ *viper.Viper) (paramspkg.Params, error) {
+		func(_ context.Context, _ *viper.Viper, _ paramspkg.FlagReadOrder) (paramspkg.Params, error) {
 			return paramspkg.Params{}, nil
 		},
 	)
@@ -144,11 +143,11 @@ func TestFindProjectConfigFile_ParamsLoader_Err(t *testing.T) {
 		tmpProjectFile.Close()
 	}()
 
-	v := setupViper(t)
+	v := vipertools.MustNew()
 
 	params, ok, err := findProjectConfigFile(
 		t.Context(), v, dir, heartbeat.FileType, false,
-		func(_ context.Context, _ *viper.Viper) (paramspkg.Params, error) {
+		func(_ context.Context, _ *viper.Viper, _ paramspkg.FlagReadOrder) (paramspkg.Params, error) {
 			return paramspkg.Params{}, errors.New("fail")
 		},
 	)
@@ -156,17 +155,4 @@ func TestFindProjectConfigFile_ParamsLoader_Err(t *testing.T) {
 
 	assert.False(t, ok)
 	assert.Equal(t, paramspkg.Params{}, params)
-}
-
-func setupViper(t *testing.T) *viper.Viper {
-	multilineOption := iniv1.LoadOptions{AllowPythonMultilineValues: true}
-	iniCodec := viperini.Codec{LoadOptions: multilineOption}
-
-	codecRegistry := viper.NewCodecRegistry()
-	err := codecRegistry.RegisterCodec("ini", iniCodec)
-	require.NoError(t, err)
-
-	v := viper.NewWithOptions(viper.WithCodecRegistry(codecRegistry))
-
-	return v
 }

--- a/cmd/handler/handler_test.go
+++ b/cmd/handler/handler_test.go
@@ -9,12 +9,11 @@ import (
 	"github.com/wakatime/wakatime-cli/cmd/handler"
 	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 	"github.com/wakatime/wakatime-cli/pkg/params"
+	"github.com/wakatime/wakatime-cli/pkg/vipertools"
 
-	viperini "github.com/go-viper/encoding/ini"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	iniv1 "gopkg.in/ini.v1"
 )
 
 func TestHandlerNew(t *testing.T) {
@@ -37,12 +36,12 @@ func TestHandlerNew(t *testing.T) {
 	err = wakatimeProjectFile.Close()
 	require.NoError(t, err)
 
-	v := setupViper(t)
+	v := vipertools.MustNew()
 
 	sender := newHandle(noopMock{})
 	hdl := handler.New(v, handler.Config{
 		Params: params.Params{},
-		ParamsLoader: func(_ context.Context, _ *viper.Viper) (params.Params, error) {
+		ParamsLoader: func(_ context.Context, _ *viper.Viper, _ params.FlagReadOrder) (params.Params, error) {
 			return params.Params{
 				// this simulates the project-level parameters loaded from the .wakatime file.
 				API: params.API{Key: "00000000-0000-4000-8000-000000000002"},
@@ -66,19 +65,6 @@ func TestHandlerNew(t *testing.T) {
 
 	assert.Len(t, res, 1)
 	assert.Equal(t, res[0].Heartbeat.APIKey, "00000000-0000-4000-8000-000000000002")
-}
-
-func setupViper(t *testing.T) *viper.Viper {
-	multilineOption := iniv1.LoadOptions{AllowPythonMultilineValues: true}
-	iniCodec := viperini.Codec{LoadOptions: multilineOption}
-
-	codecRegistry := viper.NewCodecRegistry()
-	err := codecRegistry.RegisterCodec("ini", iniCodec)
-	require.NoError(t, err)
-
-	v := viper.NewWithOptions(viper.WithCodecRegistry(codecRegistry))
-
-	return v
 }
 
 func newHandle(sender heartbeat.Sender) heartbeat.Handle {

--- a/cmd/heartbeat/heartbeat.go
+++ b/cmd/heartbeat/heartbeat.go
@@ -65,7 +65,7 @@ func Run(ctx context.Context, v *viper.Viper) (int, error) {
 // heartbeats from the offline queue, if available and offline sync is not
 // explicitly disabled.
 func SendHeartbeats(ctx context.Context, v *viper.Viper, queueFilepath string) error {
-	params, err := LoadParams(ctx, v)
+	params, err := LoadParams(ctx, v, params.FlagReadOrderFlagPrecedence)
 	if err != nil {
 		return fmt.Errorf("failed to load command parameters: %w", err)
 	}
@@ -175,17 +175,17 @@ func buildHandle(ctx context.Context, v *viper.Viper, params params.Params, queu
 
 // LoadParams loads params from viper.Viper instance. Returns ErrAuth
 // if failed to retrieve api key.
-func LoadParams(ctx context.Context, v *viper.Viper) (params.Params, error) {
+func LoadParams(ctx context.Context, v *viper.Viper, order params.FlagReadOrder) (params.Params, error) {
 	if v == nil {
 		return params.Params{}, errors.New("viper instance unset")
 	}
 
-	apiParams, err := params.LoadAPIParams(ctx, v)
+	apiParams, err := params.LoadAPIParams(ctx, v, order)
 	if err != nil {
 		return params.Params{}, fmt.Errorf("failed to load API parameters: %w", err)
 	}
 
-	heartbeatParams, err := params.LoadHeartbeatParams(ctx, v)
+	heartbeatParams, err := params.LoadHeartbeatParams(ctx, v, order)
 	if err != nil {
 		return params.Params{}, fmt.Errorf("failed to load heartbeat params: %s", err)
 	}
@@ -193,7 +193,7 @@ func LoadParams(ctx context.Context, v *viper.Viper) (params.Params, error) {
 	return params.Params{
 		API:       apiParams,
 		Heartbeat: heartbeatParams,
-		Offline:   params.LoadOfflineParams(ctx, v),
+		Offline:   params.LoadOfflineParams(ctx, v, order),
 	}, nil
 }
 

--- a/cmd/heartbeat/heartbeat_test.go
+++ b/cmd/heartbeat/heartbeat_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/wakatime/wakatime-cli/pkg/ini"
 	"github.com/wakatime/wakatime-cli/pkg/log"
 	"github.com/wakatime/wakatime-cli/pkg/offline"
-	paramspkg "github.com/wakatime/wakatime-cli/pkg/params"
+	"github.com/wakatime/wakatime-cli/pkg/params"
 	"github.com/wakatime/wakatime-cli/pkg/project"
 	"github.com/wakatime/wakatime-cli/pkg/version"
 	"github.com/wakatime/wakatime-cli/pkg/windows"
@@ -98,6 +98,7 @@ func TestSendHeartbeats(t *testing.T) {
 
 		f, err := os.Open("testdata/api_heartbeats_response.json")
 		require.NoError(t, err)
+
 		defer f.Close()
 
 		_, err = io.Copy(w, f)
@@ -351,6 +352,7 @@ func TestSendHeartbeats_ExtraHeartbeats(t *testing.T) {
 
 		f, err := os.Open("testdata/api_heartbeats_response_extra_heartbeats.json")
 		require.NoError(t, err)
+
 		defer f.Close()
 
 		_, err = io.Copy(w, f)
@@ -437,6 +439,7 @@ func TestSendHeartbeats_ExtraHeartbeats_Sanitize(t *testing.T) {
 
 		f, err := os.Open("testdata/api_heartbeats_response_extra_heartbeats.json")
 		require.NoError(t, err)
+
 		defer f.Close()
 
 		_, err = io.Copy(w, f)
@@ -651,6 +654,7 @@ func TestSendHeartbeats_ExtraHeartbeatsIsUnsavedEntity(t *testing.T) {
 
 		f, err := os.Open("testdata/api_heartbeats_response_is_unsaved_entity.json")
 		require.NoError(t, err)
+
 		defer f.Close()
 
 		_, err = io.Copy(w, f)
@@ -783,6 +787,7 @@ func TestSendHeartbeats_NonExistingExtraHeartbeatsEntity(t *testing.T) {
 
 		f, err := os.Open("testdata/api_heartbeats_response_extra_heartbeats_filtered.json")
 		require.NoError(t, err)
+
 		defer f.Close()
 
 		_, err = io.Copy(w, f)
@@ -1076,6 +1081,7 @@ func TestSendHeartbeats_ObfuscateProject(t *testing.T) {
 
 		f, err := os.Open("testdata/api_heartbeats_response.json")
 		require.NoError(t, err)
+
 		defer f.Close()
 
 		_, err = io.Copy(w, f)
@@ -1166,6 +1172,7 @@ func TestSendHeartbeats_ObfuscateProjectNotBranch(t *testing.T) {
 
 		f, err := os.Open("testdata/api_heartbeats_response.json")
 		require.NoError(t, err)
+
 		defer f.Close()
 
 		_, err = io.Copy(w, f)
@@ -1249,5 +1256,5 @@ func copyFile(t *testing.T, source, destination string) {
 func resetSingleton(t *testing.T) {
 	t.Helper()
 
-	paramspkg.Once = sync.Once{}
+	params.Once = sync.Once{}
 }

--- a/cmd/offline/offline.go
+++ b/cmd/offline/offline.go
@@ -19,7 +19,7 @@ import (
 // Used when we have more heartbeats than `offline.SendLimit`, when we couldn't send
 // heartbeats to the API, or the API returned an auth error.
 func SaveHeartbeats(ctx context.Context, v *viper.Viper, heartbeats []heartbeat.Heartbeat, queueFilepath string) error {
-	params, err := LoadParams(ctx, v)
+	params, err := LoadParams(ctx, v, params.FlagReadOrderFlagPrecedence)
 	if err != nil {
 		return fmt.Errorf("failed to load command parameters: %w", err)
 	}
@@ -54,15 +54,15 @@ func SaveHeartbeats(ctx context.Context, v *viper.Viper, heartbeats []heartbeat.
 
 // LoadParams loads params from viper.Viper instance. Returns ErrAuth
 // if failed to retrieve api key.
-func LoadParams(ctx context.Context, v *viper.Viper) (params.Params, error) {
+func LoadParams(ctx context.Context, v *viper.Viper, order params.FlagReadOrder) (params.Params, error) {
 	logger := log.Extract(ctx)
 
-	paramAPI, err := params.LoadAPIParams(ctx, v)
+	paramAPI, err := params.LoadAPIParams(ctx, v, order)
 	if err != nil {
 		logger.Warnf("failed to load API parameters: %s", err)
 	}
 
-	paramHeartbeat, err := params.LoadHeartbeatParams(ctx, v)
+	paramHeartbeat, err := params.LoadHeartbeatParams(ctx, v, order)
 	if err != nil {
 		return params.Params{}, fmt.Errorf("failed to load heartbeat parameters: %s", err)
 	}
@@ -70,7 +70,7 @@ func LoadParams(ctx context.Context, v *viper.Viper) (params.Params, error) {
 	return params.Params{
 		API:       paramAPI,
 		Heartbeat: paramHeartbeat,
-		Offline:   params.LoadOfflineParams(ctx, v),
+		Offline:   params.LoadOfflineParams(ctx, v, order),
 	}, nil
 }
 

--- a/cmd/offlineprint/offlineprint.go
+++ b/cmd/offlineprint/offlineprint.go
@@ -24,7 +24,7 @@ func Run(ctx context.Context, v *viper.Viper) (int, error) {
 		)
 	}
 
-	p := params.LoadOfflineParams(ctx, v)
+	p := params.LoadOfflineParams(ctx, v, params.FlagReadOrderFlagPrecedence)
 
 	hh, err := offline.ReadHeartbeats(ctx, queueFilepath, p.PrintMax)
 	if err != nil {

--- a/cmd/offlinesync/offlinesync.go
+++ b/cmd/offlinesync/offlinesync.go
@@ -25,7 +25,7 @@ func RunWithoutRateLimiting(ctx context.Context, v *viper.Viper) (int, error) {
 
 // RunWithRateLimiting executes sync-offline-activity command with rate limiting enabled.
 func RunWithRateLimiting(ctx context.Context, v *viper.Viper) (int, error) {
-	offlineParams := params.LoadOfflineParams(ctx, v)
+	offlineParams := params.LoadOfflineParams(ctx, v, params.FlagReadOrderFlagPrecedence)
 
 	logger := log.Extract(ctx)
 
@@ -43,7 +43,7 @@ func RunWithRateLimiting(ctx context.Context, v *viper.Viper) (int, error) {
 }
 
 func run(ctx context.Context, v *viper.Viper) (int, error) {
-	offlineParams := params.LoadOfflineParams(ctx, v)
+	offlineParams := params.LoadOfflineParams(ctx, v, params.FlagReadOrderFlagPrecedence)
 	if offlineParams.Disabled {
 		return exitcode.Success, nil
 	}
@@ -101,9 +101,9 @@ func syncOfflineActivityLegacy(ctx context.Context, v *viper.Viper, queueFilepat
 		}
 	}()
 
-	offlineParams := params.LoadOfflineParams(ctx, v)
+	offlineParams := params.LoadOfflineParams(ctx, v, params.FlagReadOrderFlagPrecedence)
 
-	apiParams, err := params.LoadAPIParams(ctx, v)
+	apiParams, err := params.LoadAPIParams(ctx, v, params.FlagReadOrderFlagPrecedence)
 	if err != nil {
 		return fmt.Errorf("failed to load API parameters: %w", err)
 	}
@@ -138,9 +138,9 @@ func syncOfflineActivityLegacy(ctx context.Context, v *viper.Viper, queueFilepat
 // SyncOfflineActivity syncs offline activity by sending heartbeats
 // from the offline queue to the WakaTime API.
 func SyncOfflineActivity(ctx context.Context, v *viper.Viper, queueFilepath string) error {
-	offlineParams := params.LoadOfflineParams(ctx, v)
+	offlineParams := params.LoadOfflineParams(ctx, v, params.FlagReadOrderFlagPrecedence)
 
-	apiParams, err := params.LoadAPIParams(ctx, v)
+	apiParams, err := params.LoadAPIParams(ctx, v, params.FlagReadOrderFlagPrecedence)
 	if err != nil {
 		return fmt.Errorf("failed to load API parameters: %w", err)
 	}

--- a/cmd/offlinesync/offlinesync_test.go
+++ b/cmd/offlinesync/offlinesync_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/wakatime/wakatime-cli/cmd/offlinesync"
 	"github.com/wakatime/wakatime-cli/pkg/exitcode"
 	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
-	paramspkg "github.com/wakatime/wakatime-cli/pkg/params"
+	"github.com/wakatime/wakatime-cli/pkg/params"
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
@@ -442,5 +442,5 @@ func insertHeartbeatRecord(t *testing.T, db *bolt.DB, bucket string, h heartbeat
 func resetSingleton(t *testing.T) {
 	t.Helper()
 
-	paramspkg.Once = sync.Once{}
+	params.Once = sync.Once{}
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -369,7 +369,7 @@ func saveHeartbeats(ctx context.Context, v *viper.Viper) int {
 }
 
 func sendDiagnostics(ctx context.Context, v *viper.Viper, d diagnostics) error {
-	paramAPI, err := params.LoadAPIParams(ctx, v)
+	paramAPI, err := params.LoadAPIParams(ctx, v, params.FlagReadOrderFlagPrecedence)
 	if err != nil {
 		return fmt.Errorf("failed to load API parameters: %s", err)
 	}

--- a/cmd/run_internal_test.go
+++ b/cmd/run_internal_test.go
@@ -17,16 +17,15 @@ import (
 	"github.com/wakatime/wakatime-cli/pkg/ini"
 	"github.com/wakatime/wakatime-cli/pkg/log"
 	"github.com/wakatime/wakatime-cli/pkg/version"
+	"github.com/wakatime/wakatime-cli/pkg/vipertools"
 
-	viperini "github.com/go-viper/encoding/ini"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	iniv1 "gopkg.in/ini.v1"
 )
 
 func TestRunCmd(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 
 	err := runCmd(t.Context(), v, false, false, func(_ context.Context, _ *viper.Viper) (int, error) {
 		return exitcode.Success, nil
@@ -36,7 +35,7 @@ func TestRunCmd(t *testing.T) {
 }
 
 func TestRunCmd_Err(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 
 	err := runCmd(t.Context(), v, false, false, func(_ context.Context, _ *viper.Viper) (int, error) {
 		return exitcode.ErrGeneric, errors.New("fail")
@@ -102,7 +101,7 @@ func TestRunCmd_Panic(t *testing.T) {
 
 	ctx := t.Context()
 
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("api-url", testServerURL)
 	v.Set("log-file", logFile.Name())
 
@@ -182,7 +181,7 @@ func TestRunCmd_Panic_Verbose(t *testing.T) {
 
 	ctx := t.Context()
 
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("api-url", testServerURL)
 	v.Set("log-file", logFile.Name())
 
@@ -255,7 +254,7 @@ func TestRunCmd_ErrOfflineEnqueue(t *testing.T) {
 		w.WriteHeader(http.StatusCreated)
 	})
 
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("api-url", testServerURL)
 	v.Set("entity", "/path/to/file")
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
@@ -305,7 +304,7 @@ func TestRunCmd_BackoffLoggedWithVerbose(t *testing.T) {
 
 	defer entity.Close()
 
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("api-url", testServerURL)
 	v.Set("entity", entity.Name())
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
@@ -369,7 +368,7 @@ func TestRunCmd_BackoffNotLogged(t *testing.T) {
 
 	defer entity.Close()
 
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("api-url", testServerURL)
 	v.Set("entity", entity.Name())
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
@@ -401,7 +400,7 @@ func TestRunCmd_BackoffNotLogged(t *testing.T) {
 }
 
 func TestParseConfigFiles(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("config", "testdata/.wakatime.cfg")
 	v.Set("internal-config", "testdata/.wakatime-internal.cfg")
 
@@ -424,7 +423,7 @@ func TestParseConfigFiles(t *testing.T) {
 }
 
 func TestParseConfigFiles_MissingAPIKey(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("config", "testdata/.wakatime-empty.cfg")
 	v.Set("internal-config", "testdata/.wakatime-internal.cfg")
 
@@ -434,7 +433,7 @@ func TestParseConfigFiles_MissingAPIKey(t *testing.T) {
 }
 
 func TestParseConfigFiles_APIKey_FlagTakesPrecedence(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("config", "testdata/.wakatime-empty.cfg")
 	v.Set("settings.import_cfg", "")
@@ -462,17 +461,4 @@ func setupTestServer() (string, *http.ServeMux, func()) {
 	srv := httptest.NewServer(router)
 
 	return srv.URL, router, func() { srv.Close() }
-}
-
-func setupViper(t *testing.T) *viper.Viper {
-	multilineOption := iniv1.LoadOptions{AllowPythonMultilineValues: true}
-	iniCodec := viperini.Codec{LoadOptions: multilineOption}
-
-	codecRegistry := viper.NewCodecRegistry()
-	err := codecRegistry.RegisterCodec("ini", iniCodec)
-	require.NoError(t, err)
-
-	v := viper.NewWithOptions(viper.WithCodecRegistry(codecRegistry))
-
-	return v
 }

--- a/cmd/today/today.go
+++ b/cmd/today/today.go
@@ -38,12 +38,12 @@ func Run(ctx context.Context, v *viper.Viper) (int, error) {
 
 // Today returns a rendered summary of today's coding activity.
 func Today(ctx context.Context, v *viper.Viper) (string, error) {
-	paramAPI, err := params.LoadAPIParams(ctx, v)
+	paramAPI, err := params.LoadAPIParams(ctx, v, params.FlagReadOrderFlagPrecedence)
 	if err != nil {
 		return "", fmt.Errorf("failed to load API parameters: %w", err)
 	}
 
-	paramStatusBar, err := params.LoadStatusBarParams(v)
+	paramStatusBar, err := params.LoadStatusBarParams(v, params.FlagReadOrderFlagPrecedence)
 	if err != nil {
 		return "", fmt.Errorf("failed to load status bar parameters: %w", err)
 	}

--- a/cmd/todaygoal/todaygoal.go
+++ b/cmd/todaygoal/todaygoal.go
@@ -76,12 +76,12 @@ func Goal(ctx context.Context, v *viper.Viper) (string, error) {
 // LoadParams loads todaygoal config params from viper.Viper instance. Returns ErrAuth
 // if failed to retrieve api key.
 func LoadParams(ctx context.Context, v *viper.Viper) (Params, error) {
-	paramAPI, err := params.LoadAPIParams(ctx, v)
+	paramAPI, err := params.LoadAPIParams(ctx, v, params.FlagReadOrderFlagPrecedence)
 	if err != nil {
 		return Params{}, fmt.Errorf("failed to load API parameters: %w", err)
 	}
 
-	paramStatusBar, err := params.LoadStatusBarParams(v)
+	paramStatusBar, err := params.LoadStatusBarParams(v, params.FlagReadOrderFlagPrecedence)
 	if err != nil {
 		return Params{}, fmt.Errorf("failed to load status bar parameters: %w", err)
 	}

--- a/pkg/backoff/backoff_test.go
+++ b/pkg/backoff/backoff_test.go
@@ -11,12 +11,10 @@ import (
 	"github.com/wakatime/wakatime-cli/pkg/backoff"
 	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 	"github.com/wakatime/wakatime-cli/pkg/ini"
+	"github.com/wakatime/wakatime-cli/pkg/vipertools"
 
-	viperini "github.com/go-viper/encoding/ini"
-	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	iniv1 "gopkg.in/ini.v1"
 )
 
 func TestWithBackoff(t *testing.T) {
@@ -25,7 +23,7 @@ func TestWithBackoff(t *testing.T) {
 
 	defer tmpFile.Close()
 
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("internal-config", tmpFile.Name())
 
 	opt := backoff.WithBackoff(backoff.Config{
@@ -59,7 +57,7 @@ func TestWithBackoff_BeforeNextBackoff(t *testing.T) {
 
 	ctx := t.Context()
 
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("internal-config", tmpFile.Name())
 
 	at := time.Now()
@@ -139,7 +137,7 @@ func TestWithBackoff_BeforeNextBackoffWithProxy(t *testing.T) {
 }
 
 func TestWithBackoff_ApiError(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 
 	tmpFile, err := os.CreateTemp(t.TempDir(), "wakatime")
 	require.NoError(t, err)
@@ -175,7 +173,7 @@ func TestWithBackoff_BackoffAndNotReset(t *testing.T) {
 
 	defer tmpFile.Close()
 
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("internal-config", tmpFile.Name())
 
 	opt := backoff.WithBackoff(backoff.Config{
@@ -215,7 +213,7 @@ func TestWithBackoff_BackoffMaxReached(t *testing.T) {
 
 	ctx := t.Context()
 
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("internal-config", tmpFile.Name())
 
 	// first, cause backoff to be set
@@ -271,7 +269,7 @@ func TestWithBackoff_BackoffMaxReachedWithZeroRetries(t *testing.T) {
 
 	ctx := t.Context()
 
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("internal-config", tmpFile.Name())
 
 	// first, cause backoff to be set
@@ -327,7 +325,7 @@ func TestWithBackoff_ShouldRetry(t *testing.T) {
 
 	ctx := t.Context()
 
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("internal-config", tmpFile.Name())
 
 	opt := backoff.WithBackoff(backoff.Config{
@@ -376,17 +374,4 @@ func TestWithBackoff_ShouldRetry(t *testing.T) {
 	// make sure backoff settings reset
 	assert.Empty(t, v.GetString("internal.backoff_at"))
 	assert.Equal(t, "0", v.GetString("internal.backoff_retries"))
-}
-
-func setupViper(t *testing.T) *viper.Viper {
-	multilineOption := iniv1.LoadOptions{AllowPythonMultilineValues: true}
-	iniCodec := viperini.Codec{LoadOptions: multilineOption}
-
-	codecRegistry := viper.NewCodecRegistry()
-	err := codecRegistry.RegisterCodec("ini", iniCodec)
-	require.NoError(t, err)
-
-	v := viper.NewWithOptions(viper.WithCodecRegistry(codecRegistry))
-
-	return v
 }

--- a/pkg/ini/ini_test.go
+++ b/pkg/ini/ini_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/wakatime/wakatime-cli/pkg/ini"
 	"github.com/wakatime/wakatime-cli/pkg/vipertools"
 
-	viperini "github.com/go-viper/encoding/ini"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -19,7 +18,7 @@ import (
 )
 
 func TestReadInConfig(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("config", "testdata/wakatime.cfg")
 
 	filePath, err := ini.FilePath(t.Context(), v)
@@ -37,7 +36,7 @@ func TestReadInConfig(t *testing.T) {
 }
 
 func TestReadInConfig_Multiline(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("config", "testdata/wakatime-multiline.cfg")
 
 	filePath, err := ini.FilePath(t.Context(), v)
@@ -54,7 +53,7 @@ func TestReadInConfig_Multiline(t *testing.T) {
 }
 
 func TestReadInConfig_Multiple(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("config", "testdata/wakatime.cfg")
 	v.Set("internal-config", "testdata/wakatime-internal.cfg")
 
@@ -80,7 +79,7 @@ func TestReadInConfig_Multiple(t *testing.T) {
 }
 
 func TestReadInConfig_Corrupted(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("config", "testdata/corrupted.cfg")
 
 	filePath, err := ini.FilePath(t.Context(), v)
@@ -96,7 +95,7 @@ func TestReadInConfig_Corrupted(t *testing.T) {
 }
 
 func TestReadInConfig_Missing(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 
 	err := ini.ReadInConfig(v, "not-exists")
 
@@ -104,7 +103,7 @@ func TestReadInConfig_Missing(t *testing.T) {
 }
 
 func TestReadInConfig_Malformed(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("config", "testdata/malformed.cfg")
 
 	filePath, err := ini.FilePath(t.Context(), v)
@@ -148,7 +147,7 @@ func TestFilePath(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			v := setupViper(t)
+			v := vipertools.MustNew()
 			v.Set("config", test.ViperValue)
 
 			t.Setenv("WAKATIME_HOME", test.EnvVar)
@@ -187,7 +186,7 @@ func TestInternalFilePath(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			v := setupViper(t)
+			v := vipertools.MustNew()
 			v.Set("internal-config", test.ViperValue)
 
 			t.Setenv("WAKATIME_HOME", test.EnvVar)
@@ -201,7 +200,7 @@ func TestInternalFilePath(t *testing.T) {
 }
 
 func TestNewWriter(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 
 	w, err := ini.NewWriter(t.Context(), v, func(_ context.Context, vp *viper.Viper) (string, error) {
 		assert.Equal(t, v, vp)
@@ -214,7 +213,7 @@ func TestNewWriter(t *testing.T) {
 }
 
 func TestNewWriterErr(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 
 	_, err := ini.NewWriter(t.Context(), v, func(_ context.Context, vp *viper.Viper) (string, error) {
 		assert.Equal(t, v, vp)
@@ -226,7 +225,7 @@ func TestNewWriterErr(t *testing.T) {
 }
 
 func TestNewWriter_MissingFile(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 
 	tmpDir := t.TempDir()
 
@@ -243,7 +242,7 @@ func TestNewWriter_MissingFile(t *testing.T) {
 }
 
 func TestNewWriter_CorruptedFile(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 
 	w, err := ini.NewWriter(t.Context(), v, func(_ context.Context, vp *viper.Viper) (string, error) {
 		assert.Equal(t, v, vp)
@@ -304,7 +303,7 @@ func TestWrite_NoMultilineSideEffects(t *testing.T) {
 
 	ctx := t.Context()
 
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("config", tmpFile.Name())
 
 	copyFile(t, "testdata/wakatime-multiline.cfg", tmpFile.Name())
@@ -337,7 +336,7 @@ func TestWrite_NullsRemoved(t *testing.T) {
 
 	ctx := t.Context()
 
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("config", tmpFile.Name())
 
 	copyFile(t, "testdata/wakatime-nulls.cfg", tmpFile.Name())
@@ -377,17 +376,4 @@ func copyFile(t *testing.T, source, destination string) {
 
 	err = os.WriteFile(destination, input, 0600)
 	require.NoError(t, err)
-}
-
-func setupViper(t *testing.T) *viper.Viper {
-	multilineOption := iniv1.LoadOptions{AllowPythonMultilineValues: true}
-	iniCodec := viperini.Codec{LoadOptions: multilineOption}
-
-	codecRegistry := viper.NewCodecRegistry()
-	err := codecRegistry.RegisterCodec("ini", iniCodec)
-	require.NoError(t, err)
-
-	v := viper.NewWithOptions(viper.WithCodecRegistry(codecRegistry))
-
-	return v
 }

--- a/pkg/params/params.go
+++ b/pkg/params/params.go
@@ -54,6 +54,103 @@ var (
 	proxyRegex = regexp.MustCompile(`^((https?|socks5)://)?([^:@]+(:([^:@])+)?@)?([^:]+|(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])))(:\d+)?$`)
 )
 
+// FlagReadOrder defines the order in which flags are read when loading parameters.
+type FlagReadOrder uint8
+
+const (
+	// FlagReadOrderFlagPrecedence defines the order where command line flags take precedence.
+	FlagReadOrderFlagPrecedence FlagReadOrder = iota
+	// FlagReadOrderProjectConfigPrecedence defines the order where project config takes precedence over command line flags.
+	FlagReadOrderProjectConfigPrecedence
+)
+
+// These variables are used to define the order in which parameters are read from the viper instance.
+// It's needed when a project config file is used, so we can read the parameters in the correct order.
+// nolint:gochecknoglobals
+var (
+	apiKeyOrder = map[FlagReadOrder][]string{
+		FlagReadOrderFlagPrecedence:          {"key", "settings.api_key", "settings.apikey"},
+		FlagReadOrderProjectConfigPrecedence: {"settings.api_key", "key", "settings.apikey"},
+	}
+	guessLanguageOrder = map[FlagReadOrder][]string{
+		FlagReadOrderFlagPrecedence:          {"guess-language", "settings.guess_language"},
+		FlagReadOrderProjectConfigPrecedence: {"settings.guess_language", "guess-language"},
+	}
+	excludeUnknownProjectOrder = map[FlagReadOrder][]string{
+		FlagReadOrderFlagPrecedence:          {"exclude-unknown-project", "settings.exclude_unknown_project"},
+		FlagReadOrderProjectConfigPrecedence: {"settings.exclude_unknown_project", "exclude-unknown-project"},
+	}
+	includeOnlyWithProjectFileOrder = map[FlagReadOrder][]string{
+		FlagReadOrderFlagPrecedence:          {"include-only-with-project-file", "settings.include_only_with_project_file"},
+		FlagReadOrderProjectConfigPrecedence: {"settings.include_only_with_project_file", "include-only-with-project-file"},
+	}
+	hideBranchNamesOrder = map[FlagReadOrder][]string{
+		FlagReadOrderFlagPrecedence: {
+			"hide-branch-names",
+			"settings.hide_branch_names",
+			"settings.hide_branchnames",
+			"settings.hidebranchnames",
+		},
+		FlagReadOrderProjectConfigPrecedence: {
+			"settings.hide_branch_names",
+			"settings.hide_branchnames",
+			"settings.hidebranchnames",
+			"hide-branch-names",
+		},
+	}
+	hideDependenciesOrder = map[FlagReadOrder][]string{
+		FlagReadOrderFlagPrecedence:          {"hide-dependencies", "settings.hide_dependencies"},
+		FlagReadOrderProjectConfigPrecedence: {"settings.hide_dependencies", "hide-dependencies"},
+	}
+	hideProjectNamesOrder = map[FlagReadOrder][]string{
+		FlagReadOrderFlagPrecedence: {
+			"hide-project-names",
+			"settings.hide_project_names",
+			"settings.hide_projectnames",
+			"settings.hideprojectnames"},
+		FlagReadOrderProjectConfigPrecedence: {
+			"settings.hide_project_names",
+			"settings.hide_projectnames",
+			"settings.hideprojectnames",
+			"hide-project-names",
+		},
+	}
+	hideFileNamesOrder = map[FlagReadOrder][]string{
+		FlagReadOrderFlagPrecedence: {
+			"hide-file-names",
+			"hide-filenames",
+			"hidefilenames",
+			"settings.hide_file_names",
+			"settings.hide_filenames",
+			"settings.hidefilenames",
+		},
+		FlagReadOrderProjectConfigPrecedence: {
+			"settings.hide_file_names",
+			"settings.hide_filenames",
+			"settings.hidefilenames",
+			"hide-file-names",
+			"hide-filenames",
+			"hidefilenames",
+		},
+	}
+	hideProjectFolderOrder = map[FlagReadOrder][]string{
+		FlagReadOrderFlagPrecedence:          {"hide-project-folder", "settings.hide_project_folder"},
+		FlagReadOrderProjectConfigPrecedence: {"settings.hide_project_folder", "hide-project-folder"},
+	}
+	disableOfflineOrder = map[FlagReadOrder][]string{
+		FlagReadOrderFlagPrecedence:          {"disable-offline", "disableoffline", "settings.offline"},
+		FlagReadOrderProjectConfigPrecedence: {"settings.offline", "disable-offline", "disableoffline"},
+	}
+	heartbeatRateLimitOrder = map[FlagReadOrder][]string{
+		FlagReadOrderFlagPrecedence:          {"heartbeat-rate-limit-seconds", "settings.heartbeat_rate_limit_seconds"},
+		FlagReadOrderProjectConfigPrecedence: {"settings.heartbeat_rate_limit_seconds", "heartbeat-rate-limit-seconds"},
+	}
+	todayHideCategoriesOrder = map[FlagReadOrder][]string{
+		FlagReadOrderFlagPrecedence:          {"today-hide-categories", "settings.status_bar_hide_categories"},
+		FlagReadOrderProjectConfigPrecedence: {"settings.status_bar_hide_categories", "today-hide-categories"},
+	}
+)
+
 type (
 	// Params contains params.
 	Params struct {
@@ -170,8 +267,8 @@ type (
 
 // LoadAPIParams loads API params from viper.Viper instance. Returns ErrAuth
 // if failed to retrieve api key.
-func LoadAPIParams(ctx context.Context, v *viper.Viper) (API, error) {
-	apiKey, err := LoadAPIKey(ctx, v)
+func LoadAPIParams(ctx context.Context, v *viper.Viper, order FlagReadOrder) (API, error) {
+	apiKey, err := loadAPIKey(ctx, v, order)
 	if err != nil {
 		return API{}, err
 	}
@@ -319,9 +416,9 @@ func LoadAPIParams(ctx context.Context, v *viper.Viper) (API, error) {
 	}, nil
 }
 
-// LoadAPIKey loads a valid default WakaTime API Key or returns an error.
-func LoadAPIKey(ctx context.Context, v *viper.Viper) (string, error) {
-	apiKey := vipertools.FirstNonEmptyString(v, "key", "settings.api_key", "settings.apikey")
+// loadAPIKey loads a valid default WakaTime API Key or returns an error.
+func loadAPIKey(ctx context.Context, v *viper.Viper, order FlagReadOrder) (string, error) {
+	apiKey := vipertools.FirstNonEmptyString(v, apiKeyOrder[order]...)
 	if apiKey != "" {
 		if !apiKeyRegex.MatchString(apiKey) {
 			return "", api.ErrAuth{Err: errors.New("invalid api key format")}
@@ -366,7 +463,7 @@ func LoadAPIKey(ctx context.Context, v *viper.Viper) (string, error) {
 }
 
 // LoadHeartbeatParams loads heartbeats params from viper.Viper instance.
-func LoadHeartbeatParams(ctx context.Context, v *viper.Viper) (Heartbeat, error) {
+func LoadHeartbeatParams(ctx context.Context, v *viper.Viper, order FlagReadOrder) (Heartbeat, error) {
 	var category heartbeat.Category
 
 	if categoryStr := vipertools.GetString(v, "category"); categoryStr != "" {
@@ -440,7 +537,7 @@ func LoadHeartbeatParams(ctx context.Context, v *viper.Viper) (Heartbeat, error)
 		timeSecs = float64(time.Now().UnixNano()) / 1000000000
 	}
 
-	filterParams, err := loadFilterParams(ctx, v)
+	filterParams, err := loadFilterParams(ctx, v, order)
 	if err != nil {
 		return Heartbeat{}, fmt.Errorf("failed to load filter params: %s", err)
 	}
@@ -450,7 +547,7 @@ func LoadHeartbeatParams(ctx context.Context, v *viper.Viper) (Heartbeat, error)
 		return Heartbeat{}, fmt.Errorf("failed to parse project params: %s", err)
 	}
 
-	sanitizeParams, err := loadSanitizeParams(ctx, v)
+	sanitizeParams, err := loadSanitizeParams(ctx, v, order)
 	if err != nil {
 		return Heartbeat{}, fmt.Errorf("failed to load sanitize params: %s", err)
 	}
@@ -466,7 +563,7 @@ func LoadHeartbeatParams(ctx context.Context, v *viper.Viper) (Heartbeat, error)
 		Entity:            entity,
 		ExtraHeartbeats:   extraHeartbeats,
 		EntityType:        entityType,
-		GuessLanguage:     vipertools.FirstNonEmptyBool(v, "guess-language", "settings.guess_language"),
+		GuessLanguage:     vipertools.FirstNonEmptyBool(v, guessLanguageOrder[order]...),
 		IsUnsavedEntity:   v.GetBool("is-unsaved-entity"),
 		IsWrite:           isWrite,
 		Language:          language,
@@ -483,7 +580,7 @@ func LoadHeartbeatParams(ctx context.Context, v *viper.Viper) (Heartbeat, error)
 	}, nil
 }
 
-func loadFilterParams(ctx context.Context, v *viper.Viper) (FilterParams, error) {
+func loadFilterParams(ctx context.Context, v *viper.Viper, order FlagReadOrder) (FilterParams, error) {
 	exclude := v.GetStringSlice("exclude")
 	exclude = append(exclude, v.GetStringSlice("settings.exclude")...)
 	exclude = append(exclude, v.GetStringSlice("settings.ignore")...)
@@ -522,30 +619,16 @@ func loadFilterParams(ctx context.Context, v *viper.Viper) (FilterParams, error)
 	}
 
 	return FilterParams{
-		Exclude: excludePatterns,
-		ExcludeUnknownProject: vipertools.FirstNonEmptyBool(
-			v,
-			"exclude-unknown-project",
-			"settings.exclude_unknown_project",
-		),
-		Include: includePatterns,
-		IncludeOnlyWithProjectFile: vipertools.FirstNonEmptyBool(
-			v,
-			"include-only-with-project-file",
-			"settings.include_only_with_project_file",
-		),
+		Exclude:                    excludePatterns,
+		ExcludeUnknownProject:      vipertools.FirstNonEmptyBool(v, excludeUnknownProjectOrder[order]...),
+		Include:                    includePatterns,
+		IncludeOnlyWithProjectFile: vipertools.FirstNonEmptyBool(v, includeOnlyWithProjectFileOrder[order]...),
 	}, nil
 }
 
-func loadSanitizeParams(ctx context.Context, v *viper.Viper) (SanitizeParams, error) {
+func loadSanitizeParams(ctx context.Context, v *viper.Viper, order FlagReadOrder) (SanitizeParams, error) {
 	// hide branch names
-	hideBranchNamesStr := vipertools.FirstNonEmptyString(
-		v,
-		"hide-branch-names",
-		"settings.hide_branch_names",
-		"settings.hide_branchnames",
-		"settings.hidebranchnames",
-	)
+	hideBranchNamesStr := vipertools.FirstNonEmptyString(v, hideBranchNamesOrder[order]...)
 
 	hideBranchNamesPatterns, err := parseBoolOrRegexList(ctx, hideBranchNamesStr)
 	if err != nil {
@@ -557,11 +640,7 @@ func loadSanitizeParams(ctx context.Context, v *viper.Viper) (SanitizeParams, er
 	}
 
 	// hide dependencies
-	hideDependenciesStr := vipertools.FirstNonEmptyString(
-		v,
-		"hide-dependencies",
-		"settings.hide_dependencies",
-	)
+	hideDependenciesStr := vipertools.FirstNonEmptyString(v, hideDependenciesOrder[order]...)
 
 	hideDependenciesPatterns, err := parseBoolOrRegexList(ctx, hideDependenciesStr)
 	if err != nil {
@@ -573,13 +652,7 @@ func loadSanitizeParams(ctx context.Context, v *viper.Viper) (SanitizeParams, er
 	}
 
 	// hide project names
-	hideProjectNamesStr := vipertools.FirstNonEmptyString(
-		v,
-		"hide-project-names",
-		"settings.hide_project_names",
-		"settings.hide_projectnames",
-		"settings.hideprojectnames",
-	)
+	hideProjectNamesStr := vipertools.FirstNonEmptyString(v, hideProjectNamesOrder[order]...)
 
 	hideProjectNamesPatterns, err := parseBoolOrRegexList(ctx, hideProjectNamesStr)
 	if err != nil {
@@ -591,15 +664,7 @@ func loadSanitizeParams(ctx context.Context, v *viper.Viper) (SanitizeParams, er
 	}
 
 	// hide file names
-	hideFileNamesStr := vipertools.FirstNonEmptyString(
-		v,
-		"hide-file-names",
-		"hide-filenames",
-		"hidefilenames",
-		"settings.hide_file_names",
-		"settings.hide_filenames",
-		"settings.hidefilenames",
-	)
+	hideFileNamesStr := vipertools.FirstNonEmptyString(v, hideFileNamesOrder[order]...)
 
 	hideFileNamesPatterns, err := parseBoolOrRegexList(ctx, hideFileNamesStr)
 	if err != nil {
@@ -614,7 +679,7 @@ func loadSanitizeParams(ctx context.Context, v *viper.Viper) (SanitizeParams, er
 		HideBranchNames:     hideBranchNamesPatterns,
 		HideDependencies:    hideDependenciesPatterns,
 		HideFileNames:       hideFileNamesPatterns,
-		HideProjectFolder:   vipertools.FirstNonEmptyBool(v, "hide-project-folder", "settings.hide_project_folder"),
+		HideProjectFolder:   vipertools.FirstNonEmptyBool(v, hideProjectFolderOrder[order]...),
 		HideProjectNames:    hideProjectNamesPatterns,
 		ProjectPathOverride: vipertools.GetString(v, "project-folder"),
 	}, nil
@@ -669,19 +734,18 @@ func loadProjectMapPatterns(ctx context.Context, v *viper.Viper, prefix string) 
 }
 
 // LoadOfflineParams loads offline params from viper.Viper instance.
-func LoadOfflineParams(ctx context.Context, v *viper.Viper) Offline {
-	disabled := vipertools.FirstNonEmptyBool(v, "disable-offline", "disableoffline")
-	if b := v.GetBool("settings.offline"); v.IsSet("settings.offline") {
-		disabled = !b
+func LoadOfflineParams(ctx context.Context, v *viper.Viper, order FlagReadOrder) Offline {
+	disabled := vipertools.FirstNonEmptyBool(v, disableOfflineOrder[order]...)
+	// if disable-offline or disableoffline is not set, negate settings.offline if set
+	if v.IsSet("settings.offline") && !v.IsSet("disable-offline") && !v.IsSet("disableoffline") {
+		disabled = !v.GetBool("settings.offline")
 	}
 
 	logger := log.Extract(ctx)
 
 	rateLimit := offline.RateLimitDefaultSeconds
 
-	if rateLimitSecs, ok := vipertools.FirstNonEmptyInt(v,
-		"heartbeat-rate-limit-seconds",
-		"settings.heartbeat_rate_limit_seconds"); ok {
+	if rateLimitSecs, ok := vipertools.FirstNonEmptyInt(v, heartbeatRateLimitOrder[order]...); ok {
 		rateLimit = rateLimitSecs
 
 		if rateLimit < 0 {
@@ -725,14 +789,10 @@ func LoadOfflineParams(ctx context.Context, v *viper.Viper) Offline {
 }
 
 // LoadStatusBarParams loads status bar params from viper.Viper instance.
-func LoadStatusBarParams(v *viper.Viper) (StatusBar, error) {
+func LoadStatusBarParams(v *viper.Viper, order FlagReadOrder) (StatusBar, error) {
 	var hideCategories bool
 
-	if hideCategoriesStr := vipertools.FirstNonEmptyString(
-		v,
-		"today-hide-categories",
-		"settings.status_bar_hide_categories",
-	); hideCategoriesStr != "" {
+	if hideCategoriesStr := vipertools.FirstNonEmptyString(v, todayHideCategoriesOrder[order]...); hideCategoriesStr != "" {
 		val, err := strconv.ParseBool(hideCategoriesStr)
 		if err != nil {
 			return StatusBar{}, fmt.Errorf("failed to parse today-hide-categories: %s", err)
@@ -1187,6 +1247,18 @@ func (p StatusBar) String() string {
 		p.HideCategories,
 		p.Output,
 	)
+}
+
+// String implements fmt.Stringer interface.
+func (order FlagReadOrder) String() string {
+	switch order {
+	case FlagReadOrderFlagPrecedence:
+		return "flag-precedence"
+	case FlagReadOrderProjectConfigPrecedence:
+		return "project-config-precedence"
+	default:
+		return "unknown"
+	}
 }
 
 func parseBoolOrRegexList(ctx context.Context, s string) ([]regex.Regex, error) {

--- a/pkg/params/params_test.go
+++ b/pkg/params/params_test.go
@@ -23,6 +23,7 @@ import (
 	paramspkg "github.com/wakatime/wakatime-cli/pkg/params"
 	"github.com/wakatime/wakatime-cli/pkg/project"
 	"github.com/wakatime/wakatime-cli/pkg/regex"
+	"github.com/wakatime/wakatime-cli/pkg/vipertools"
 
 	viperini "github.com/go-viper/encoding/ini"
 	"github.com/spf13/viper"
@@ -31,22 +32,88 @@ import (
 	iniv1 "gopkg.in/ini.v1"
 )
 
+func TestLoadHeartbeatParams_FlagTakesPrecedence(t *testing.T) {
+	v := vipertools.MustNew()
+	v.Set("entity", "/path/to/file")
+	v.Set("exclude-unknown-project", true)
+	v.Set("settings.exclude_unknown_project", false)
+	v.Set("include-only-with-project-file", true)
+	v.Set("settings.include_only_with_project_file", false)
+	v.Set("hide-branch-names", true)
+	v.Set("settings.hide_branch_names", false)
+	v.Set("hide-dependencies", true)
+	v.Set("settings.hide_dependencies", false)
+	v.Set("hide-project-names", true)
+	v.Set("settings.hide_project_names", false)
+	v.Set("hide-file-names", true)
+	v.Set("settings.hide_file_names", false)
+	v.Set("hide-project-folder", true)
+	v.Set("settings.hide_project_folder", false)
+	v.Set("guess-language", true)
+	v.Set("settings.guess_language", false)
+
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
+	require.NoError(t, err)
+
+	assert.True(t, params.Filter.ExcludeUnknownProject)
+	assert.True(t, params.Filter.IncludeOnlyWithProjectFile)
+	assert.Equal(t, []regex.Regex{regex.NewRegexpWrap(regexp.MustCompile(".*"))}, params.Sanitize.HideBranchNames)
+	assert.Equal(t, []regex.Regex{regex.NewRegexpWrap(regexp.MustCompile(".*"))}, params.Sanitize.HideDependencies)
+	assert.Equal(t, []regex.Regex{regex.NewRegexpWrap(regexp.MustCompile(".*"))}, params.Sanitize.HideProjectNames)
+	assert.Equal(t, []regex.Regex{regex.NewRegexpWrap(regexp.MustCompile(".*"))}, params.Sanitize.HideFileNames)
+	assert.True(t, params.Sanitize.HideProjectFolder)
+	assert.True(t, params.GuessLanguage)
+}
+
+func TestLoadHeartbeatParams_ProjectConfigTakesPrecedence(t *testing.T) {
+	v := vipertools.MustNew()
+	v.Set("entity", "/path/to/file")
+	v.Set("exclude-unknown-project", true)
+	v.Set("settings.exclude_unknown_project", false)
+	v.Set("include-only-with-project-file", true)
+	v.Set("settings.include_only_with_project_file", false)
+	v.Set("hide-branch-names", true)
+	v.Set("settings.hide_branch_names", false)
+	v.Set("hide-dependencies", true)
+	v.Set("settings.hide_dependencies", false)
+	v.Set("hide-project-names", true)
+	v.Set("settings.hide_project_names", false)
+	v.Set("hide-file-names", true)
+	v.Set("settings.hide_file_names", false)
+	v.Set("hide-project-folder", true)
+	v.Set("settings.hide_project_folder", false)
+	v.Set("guess-language", true)
+	v.Set("settings.guess_language", false)
+
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderProjectConfigPrecedence)
+	require.NoError(t, err)
+
+	assert.False(t, params.Filter.ExcludeUnknownProject)
+	assert.False(t, params.Filter.IncludeOnlyWithProjectFile)
+	assert.Equal(t, []regex.Regex{regex.NewRegexpWrap(regexp.MustCompile("a^"))}, params.Sanitize.HideBranchNames)
+	assert.Equal(t, []regex.Regex{regex.NewRegexpWrap(regexp.MustCompile("a^"))}, params.Sanitize.HideDependencies)
+	assert.Equal(t, []regex.Regex{regex.NewRegexpWrap(regexp.MustCompile("a^"))}, params.Sanitize.HideProjectNames)
+	assert.Equal(t, []regex.Regex{regex.NewRegexpWrap(regexp.MustCompile("a^"))}, params.Sanitize.HideFileNames)
+	assert.False(t, params.Sanitize.HideProjectFolder)
+	assert.False(t, params.GuessLanguage)
+}
+
 func TestLoadHeartbeatParams_AlternateProject(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 	v.Set("alternate-project", "web")
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, "web", params.Project.Alternate)
 }
 
 func TestLoadHeartbeatParams_AlternateProject_Unset(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Empty(t, params.Project.Alternate)
@@ -79,11 +146,11 @@ func TestLoadHeartbeatParams_Category(t *testing.T) {
 
 	for name, category := range tests {
 		t.Run(name, func(t *testing.T) {
-			v := setupViper(t)
+			v := vipertools.MustNew()
 			v.Set("entity", "/path/to/file")
 			v.Set("category", name)
 
-			params, err := paramspkg.LoadHeartbeatParams(ctx, v)
+			params, err := paramspkg.LoadHeartbeatParams(ctx, v, paramspkg.FlagReadOrderFlagPrecedence)
 			require.NoError(t, err)
 
 			assert.Equal(t, category, params.Category)
@@ -92,87 +159,87 @@ func TestLoadHeartbeatParams_Category(t *testing.T) {
 }
 
 func TestLoadHeartbeatParams_Category_Default(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, heartbeat.CodingCategory, params.Category)
 }
 
 func TestLoadHeartbeatParams_Category_Invalid(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("category", "invalid")
 
-	_, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	_, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.Error(t, err)
 
 	assert.Equal(t, "failed to parse category: invalid category \"invalid\"", err.Error())
 }
 
 func TestLoadHeartbeatParams_CursorPosition(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 	v.Set("cursorpos", 42)
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, 42, *params.CursorPosition)
 }
 
 func TestLoadHeartbeatParams_CursorPosition_Zero(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 	v.Set("cursorpos", 0)
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Zero(t, *params.CursorPosition)
 }
 
 func TestLoadHeartbeatParams_CursorPosition_Unset(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Nil(t, params.CursorPosition)
 }
 
 func TestLoadHeartbeatParams_Entity_FlagTakesPrecedence(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 	v.Set("file", "ignored")
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, "/path/to/file", params.Entity)
 }
 
 func TestLoadHeartbeatParams_Entity_FileFlag(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("file", "~/path/to/file")
 
 	home, err := os.UserHomeDir()
 	require.NoError(t, err)
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, filepath.Join(home, "/path/to/file"), params.Entity)
 }
 
 func TestLoadHeartbeatParams_Entity_Unset(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 
-	_, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	_, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.Error(t, err)
 
 	assert.Equal(t, "failed to retrieve entity", err.Error())
@@ -189,11 +256,11 @@ func TestLoadHeartbeatParams_EntityType(t *testing.T) {
 
 	for name, entityType := range tests {
 		t.Run(name, func(t *testing.T) {
-			v := setupViper(t)
+			v := vipertools.MustNew()
 			v.Set("entity", "/path/to/file")
 			v.Set("entity-type", name)
 
-			params, err := paramspkg.LoadHeartbeatParams(ctx, v)
+			params, err := paramspkg.LoadHeartbeatParams(ctx, v, paramspkg.FlagReadOrderFlagPrecedence)
 			require.NoError(t, err)
 
 			assert.Equal(t, entityType, params.EntityType)
@@ -202,21 +269,21 @@ func TestLoadHeartbeatParams_EntityType(t *testing.T) {
 }
 
 func TestLoadHeartbeatParams_EntityType_Default(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, heartbeat.FileType, params.EntityType)
 }
 
 func TestLoadHeartbeatParams_EntityType_Invalid(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 	v.Set("entity-type", "invalid")
 
-	_, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	_, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.Error(t, err)
 
 	assert.Equal(
@@ -252,11 +319,11 @@ func TestLoadHeartbeatParams_ExtraHeartbeats(t *testing.T) {
 		w.Close()
 	}()
 
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 	v.Set("extra-heartbeats", true)
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Len(t, params.ExtraHeartbeats, 2)
@@ -326,11 +393,11 @@ func TestLoadHeartbeatParams_ExtraHeartbeats_WithStringValues(t *testing.T) {
 		w.Close()
 	}()
 
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 	v.Set("extra-heartbeats", true)
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Len(t, params.ExtraHeartbeats, 2)
@@ -396,11 +463,11 @@ func TestLoadHeartbeatParams_ExtraHeartbeats_WithEOF(t *testing.T) {
 		w.Close()
 	}()
 
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 	v.Set("extra-heartbeats", true)
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Len(t, params.ExtraHeartbeats, 2)
@@ -474,7 +541,7 @@ func TestLoadHeartbeatParams_ExtraHeartbeats_NoData(t *testing.T) {
 
 	defer logFile.Close()
 
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 	v.Set("extra-heartbeats", true)
 	v.Set("log-file", logFile.Name())
@@ -487,7 +554,7 @@ func TestLoadHeartbeatParams_ExtraHeartbeats_NoData(t *testing.T) {
 
 	ctx = log.ToContext(ctx, logger)
 
-	params, err := paramspkg.LoadHeartbeatParams(ctx, v)
+	params, err := paramspkg.LoadHeartbeatParams(ctx, v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Empty(t, params.ExtraHeartbeats)
@@ -500,44 +567,44 @@ func TestLoadHeartbeatParams_ExtraHeartbeats_NoData(t *testing.T) {
 }
 
 func TestLoadHeartbeat_GuessLanguage_FlagTakesPrecedence(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 	v.Set("guess-language", false)
 	v.Set("settings.guess_language", true)
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.False(t, params.GuessLanguage)
 }
 
 func TestLoadHeartbeat_GuessLanguage_FromConfig(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 	v.Set("settings.guess_language", true)
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.True(t, params.GuessLanguage)
 }
 
 func TestLoadHeartbeat_GuessLanguage_Default(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.False(t, params.GuessLanguage)
 }
 
 func TestLoadHeartbeatParams_IsUnsavedEntity(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 	v.Set("is-unsaved-entity", true)
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.True(t, params.IsUnsavedEntity)
@@ -553,11 +620,11 @@ func TestLoadHeartbeatParams_IsWrite(t *testing.T) {
 
 	for name, isWrite := range tests {
 		t.Run(name, func(t *testing.T) {
-			v := setupViper(t)
+			v := vipertools.MustNew()
 			v.Set("entity", "/path/to/file")
 			v.Set("write", isWrite)
 
-			params, err := paramspkg.LoadHeartbeatParams(ctx, v)
+			params, err := paramspkg.LoadHeartbeatParams(ctx, v, paramspkg.FlagReadOrderFlagPrecedence)
 			require.NoError(t, err)
 
 			assert.Equal(t, isWrite, *params.IsWrite)
@@ -566,32 +633,32 @@ func TestLoadHeartbeatParams_IsWrite(t *testing.T) {
 }
 
 func TestLoadHeartbeatParams_IsWrite_Unset(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Nil(t, params.IsWrite)
 }
 
 func TestLoadHeartbeatParams_Language(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 	v.Set("language", "Go")
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, heartbeat.LanguageGo.String(), *params.Language)
 }
 
 func TestLoadHeartbeatParams_LanguageAlternate(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 	v.Set("alternate-language", "Go")
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, heartbeat.LanguageGo.String(), params.LanguageAlternate)
@@ -599,64 +666,64 @@ func TestLoadHeartbeatParams_LanguageAlternate(t *testing.T) {
 }
 
 func TestLoadHeartbeatParams_LineNumber(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 	v.Set("lineno", 42)
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, 42, *params.LineNumber)
 }
 
 func TestLoadHeartbeatParams_LineNumber_Zero(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 	v.Set("lineno", 0)
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Zero(t, *params.LineNumber)
 }
 
 func TestLoadHeartbeatParams_LineNumber_Unset(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Nil(t, params.LineNumber)
 }
 
 func TestLoadHeartbeatParams_LocalFile(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 	v.Set("local-file", "/path/to/file")
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, "/path/to/file", params.LocalFile)
 }
 
 func TestLoadHeartbeatParams_Project(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 	v.Set("project", "billing")
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, "billing", params.Project.Override)
 }
 
 func TestLoadHeartbeatParams_Project_Unset(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Empty(t, params.Project.Override)
@@ -697,11 +764,11 @@ func TestLoadHeartbeatParams_ProjectMap(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			v := setupViper(t)
+			v := vipertools.MustNew()
 			v.Set("entity", test.Entity)
 			v.Set(fmt.Sprintf("projectmap.%s", test.Regex.String()), test.Project)
 
-			params, err := paramspkg.LoadHeartbeatParams(ctx, v)
+			params, err := paramspkg.LoadHeartbeatParams(ctx, v, paramspkg.FlagReadOrderFlagPrecedence)
 			require.NoError(t, err)
 
 			assert.Equal(t, test.Expected, params.Project.MapPatterns)
@@ -757,11 +824,11 @@ func TestLoadAPIParams_ProjectApiKey(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			v := setupViper(t)
+			v := vipertools.MustNew()
 			v.Set("key", "00000000-0000-4000-8000-000000000000")
 			v.Set(fmt.Sprintf("project_api_key.%s", test.Regex.String()), test.APIKey)
 
-			params, err := paramspkg.LoadAPIParams(ctx, v)
+			params, err := paramspkg.LoadAPIParams(ctx, v, paramspkg.FlagReadOrderFlagPrecedence)
 			require.NoError(t, err)
 
 			assert.Equal(t, test.Expected, params.KeyPatterns)
@@ -772,7 +839,7 @@ func TestLoadAPIParams_ProjectApiKey(t *testing.T) {
 func TestLoadAPIParams_ProjectApiKey_ParseConfig(t *testing.T) {
 	ctx := t.Context()
 
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("config", "testdata/.wakatime.cfg")
 	v.Set("entity", "testdata/heartbeat_go.json")
 
@@ -782,7 +849,7 @@ func TestLoadAPIParams_ProjectApiKey_ParseConfig(t *testing.T) {
 	err = inipkg.ReadInConfig(v, configFile)
 	require.NoError(t, err)
 
-	params, err := paramspkg.LoadAPIParams(ctx, v)
+	params, err := paramspkg.LoadAPIParams(ctx, v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	expected := []apikey.MapPattern{
@@ -796,29 +863,29 @@ func TestLoadAPIParams_ProjectApiKey_ParseConfig(t *testing.T) {
 }
 
 func TestLoadAPIParams_APIKeyPrefixSupported(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("key", "waka_00000000-0000-4000-8000-000000000000")
 
-	_, err := paramspkg.LoadAPIParams(t.Context(), v)
+	_, err := paramspkg.LoadAPIParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 }
 
 func TestLoadHeartbeatParams_Time(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 	v.Set("time", 1590609206.1)
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, 1590609206.1, params.Time)
 }
 
 func TestLoadHeartbeatParams_Time_Default(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	now := float64(time.Now().UnixNano()) / 1000000000
@@ -827,13 +894,13 @@ func TestLoadHeartbeatParams_Time_Default(t *testing.T) {
 }
 
 func TestLoadHeartbeatParams_Filter_Exclude(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 	v.Set("exclude", []string{".*", "wakatime.*"})
 	v.Set("settings.exclude", []string{".+", "wakatime.+"})
 	v.Set("settings.ignore", []string{".?", "wakatime.?"})
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	require.Len(t, params.Filter.Exclude, 6)
@@ -846,11 +913,11 @@ func TestLoadHeartbeatParams_Filter_Exclude(t *testing.T) {
 }
 
 func TestLoadHeartbeatParams_Filter_Exclude_All(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 	v.Set("exclude", []string{"true"})
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	require.Len(t, params.Filter.Exclude, 1)
@@ -858,11 +925,11 @@ func TestLoadHeartbeatParams_Filter_Exclude_All(t *testing.T) {
 }
 
 func TestLoadHeartbeatParams_Filter_Exclude_Multiline(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 	v.Set("settings.ignore", "\t.?\n\twakatime.? \t\n")
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	require.Len(t, params.Filter.Exclude, 2)
@@ -871,11 +938,11 @@ func TestLoadHeartbeatParams_Filter_Exclude_Multiline(t *testing.T) {
 }
 
 func TestLoadHeartbeatParams_Filter_Exclude_IgnoresInvalidRegex(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 	v.Set("exclude", []string{".*", "["})
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	require.Len(t, params.Filter.Exclude, 1)
@@ -890,11 +957,11 @@ func TestLoadHeartbeatParams_Filter_Exclude_PerlRegexPatterns(t *testing.T) {
 
 	for name, pattern := range tests {
 		t.Run(name, func(t *testing.T) {
-			v := setupViper(t)
+			v := vipertools.MustNew()
 			v.Set("entity", "/path/to/file")
 			v.Set("exclude", []string{pattern})
 
-			params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+			params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 			require.NoError(t, err)
 
 			require.Len(t, params.Filter.Exclude, 1)
@@ -904,46 +971,46 @@ func TestLoadHeartbeatParams_Filter_Exclude_PerlRegexPatterns(t *testing.T) {
 }
 
 func TestLoadHeartbeatParams_Filter_ExcludeUnknownProject(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 	v.Set("exclude-unknown-project", true)
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.True(t, params.Filter.ExcludeUnknownProject)
 }
 
 func TestLoadHeartbeatParams_Filter_ExcludeUnknownProject_FromConfig(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 	v.Set("settings.exclude_unknown_project", true)
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.True(t, params.Filter.ExcludeUnknownProject)
 }
 
 func TestLoadHeartbeatParams_Filter_ExcludeUnknownProject_FlagTakesPrecedence(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 	v.Set("exclude-unknown-project", false)
 	v.Set("settings.exclude_unknown_project", true)
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.False(t, params.Filter.ExcludeUnknownProject)
 }
 
 func TestLoadHeartbeatParams_Filter_Include(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 	v.Set("include", []string{".*", "wakatime.*"})
 	v.Set("settings.include", []string{".+", "wakatime.+"})
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	require.Len(t, params.Filter.Include, 4)
@@ -954,11 +1021,11 @@ func TestLoadHeartbeatParams_Filter_Include(t *testing.T) {
 }
 
 func TestLoadHeartbeatParams_Filter_Include_All(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 	v.Set("include", []string{"true"})
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	require.Len(t, params.Filter.Include, 1)
@@ -966,11 +1033,11 @@ func TestLoadHeartbeatParams_Filter_Include_All(t *testing.T) {
 }
 
 func TestLoadHeartbeatParams_Filter_Include_IgnoresInvalidRegex(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 	v.Set("include", []string{".*", "["})
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	require.Len(t, params.Filter.Include, 1)
@@ -987,11 +1054,11 @@ func TestLoadHeartbeatParams_Filter_Include_PerlRegexPatterns(t *testing.T) {
 
 	for name, pattern := range tests {
 		t.Run(name, func(t *testing.T) {
-			v := setupViper(t)
+			v := vipertools.MustNew()
 			v.Set("entity", "/path/to/file")
 			v.Set("include", []string{pattern})
 
-			params, err := paramspkg.LoadHeartbeatParams(ctx, v)
+			params, err := paramspkg.LoadHeartbeatParams(ctx, v, paramspkg.FlagReadOrderFlagPrecedence)
 			require.NoError(t, err)
 
 			require.Len(t, params.Filter.Include, 1)
@@ -1001,22 +1068,22 @@ func TestLoadHeartbeatParams_Filter_Include_PerlRegexPatterns(t *testing.T) {
 }
 
 func TestLoadHeartbeatParams_Filter_IncludeOnlyWithProjectFile(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 	v.Set("include-only-with-project-file", true)
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.True(t, params.Filter.IncludeOnlyWithProjectFile)
 }
 
 func TestLoadHeartbeatParams_Filter_IncludeOnlyWithProjectFile_FromConfig(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 	v.Set("settings.include_only_with_project_file", true)
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.True(t, params.Filter.IncludeOnlyWithProjectFile)
@@ -1025,19 +1092,20 @@ func TestLoadHeartbeatParams_Filter_IncludeOnlyWithProjectFile_FromConfig(t *tes
 func TestLoadHeartbeatParams_SanitizeParams_HideBranchNames_True(t *testing.T) {
 	ctx := t.Context()
 
-	tests := map[string]string{
+	tests := map[string]any{
 		"lowercase":       "true",
 		"uppercase":       "TRUE",
 		"first uppercase": "True",
+		"boolean":         true,
 	}
 
 	for name, viperValue := range tests {
 		t.Run(name, func(t *testing.T) {
-			v := setupViper(t)
+			v := vipertools.MustNew()
 			v.Set("entity", "/path/to/file")
 			v.Set("hide-branch-names", viperValue)
 
-			params, err := paramspkg.LoadHeartbeatParams(ctx, v)
+			params, err := paramspkg.LoadHeartbeatParams(ctx, v, paramspkg.FlagReadOrderFlagPrecedence)
 			require.NoError(t, err)
 
 			assert.Equal(t, paramspkg.SanitizeParams{
@@ -1058,11 +1126,11 @@ func TestLoadHeartbeatParams_SanitizeParams_HideBranchNames_False(t *testing.T) 
 
 	for name, viperValue := range tests {
 		t.Run(name, func(t *testing.T) {
-			v := setupViper(t)
+			v := vipertools.MustNew()
 			v.Set("entity", "/path/to/file")
 			v.Set("hide-branch-names", viperValue)
 
-			params, err := paramspkg.LoadHeartbeatParams(ctx, v)
+			params, err := paramspkg.LoadHeartbeatParams(ctx, v, paramspkg.FlagReadOrderFlagPrecedence)
 			require.NoError(t, err)
 
 			assert.Equal(t, paramspkg.SanitizeParams{
@@ -1096,11 +1164,11 @@ func TestLoadHeartbeatParams_SanitizeParams_HideBranchNames_List(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			v := setupViper(t)
+			v := vipertools.MustNew()
 			v.Set("entity", "/path/to/file")
 			v.Set("hide-branch-names", test.ViperValue)
 
-			params, err := paramspkg.LoadHeartbeatParams(ctx, v)
+			params, err := paramspkg.LoadHeartbeatParams(ctx, v, paramspkg.FlagReadOrderFlagPrecedence)
 			require.NoError(t, err)
 
 			assert.Equal(t, paramspkg.SanitizeParams{
@@ -1111,14 +1179,14 @@ func TestLoadHeartbeatParams_SanitizeParams_HideBranchNames_List(t *testing.T) {
 }
 
 func TestLoadHeartbeatParams_SanitizeParams_HideBranchNames_FlagTakesPrecedence(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 	v.Set("hide-branch-names", true)
 	v.Set("settings.hide_branch_names", "ignored")
 	v.Set("settings.hide_branchnames", "ignored")
 	v.Set("settings.hidebranchnames", "ignored")
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, paramspkg.SanitizeParams{
@@ -1127,13 +1195,13 @@ func TestLoadHeartbeatParams_SanitizeParams_HideBranchNames_FlagTakesPrecedence(
 }
 
 func TestLoadHeartbeatParams_SanitizeParams_HideBranchNames_ConfigTakesPrecedence(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 	v.Set("settings.hide_branch_names", true)
 	v.Set("settings.hide_branchnames", "ignored")
 	v.Set("settings.hidebranchnames", "ignored")
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, paramspkg.SanitizeParams{
@@ -1142,12 +1210,12 @@ func TestLoadHeartbeatParams_SanitizeParams_HideBranchNames_ConfigTakesPrecedenc
 }
 
 func TestLoadHeartbeatParams_SanitizeParams_HideBranchNames_ConfigDeprecatedOneTakesPrecedence(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 	v.Set("settings.hide_branchnames", true)
 	v.Set("settings.hidebranchnames", "ignored")
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, paramspkg.SanitizeParams{
@@ -1156,11 +1224,11 @@ func TestLoadHeartbeatParams_SanitizeParams_HideBranchNames_ConfigDeprecatedOneT
 }
 
 func TestLoadHeartbeatParams_SanitizeParams_HideBranchNames_ConfigDeprecatedTwo(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 	v.Set("settings.hidebranchnames", true)
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, paramspkg.SanitizeParams{
@@ -1176,7 +1244,7 @@ func TestLoadHeartbeatParams_SanitizeParams_HideBranchNames_InvalidRegex(t *test
 
 	ctx := t.Context()
 
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 	v.Set("hide-branch-names", ".*secret.*\n[0-9+")
 	v.Set("log-file", logFile.Name())
@@ -1188,7 +1256,7 @@ func TestLoadHeartbeatParams_SanitizeParams_HideBranchNames_InvalidRegex(t *test
 
 	ctx = log.ToContext(ctx, logger)
 
-	_, err = paramspkg.LoadHeartbeatParams(ctx, v)
+	_, err = paramspkg.LoadHeartbeatParams(ctx, v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	output, err := io.ReadAll(logFile)
@@ -1198,11 +1266,11 @@ func TestLoadHeartbeatParams_SanitizeParams_HideBranchNames_InvalidRegex(t *test
 }
 
 func TestLoadHeartbeatParams_SanitizeParams_HideDependencies_Flag(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 	v.Set("settings.hide_dependencies", true)
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, paramspkg.SanitizeParams{
@@ -1221,11 +1289,11 @@ func TestLoadHeartbeatParams_SanitizeParams_HideDependencies_True(t *testing.T) 
 
 	for name, viperValue := range tests {
 		t.Run(name, func(t *testing.T) {
-			v := setupViper(t)
+			v := vipertools.MustNew()
 			v.Set("entity", "/path/to/file")
 			v.Set("hide-dependencies", viperValue)
 
-			params, err := paramspkg.LoadHeartbeatParams(ctx, v)
+			params, err := paramspkg.LoadHeartbeatParams(ctx, v, paramspkg.FlagReadOrderFlagPrecedence)
 			require.NoError(t, err)
 
 			assert.Equal(t, paramspkg.SanitizeParams{
@@ -1246,11 +1314,11 @@ func TestLoadHeartbeatParams_SanitizeParams_HideDependencies_False(t *testing.T)
 
 	for name, viperValue := range tests {
 		t.Run(name, func(t *testing.T) {
-			v := setupViper(t)
+			v := vipertools.MustNew()
 			v.Set("entity", "/path/to/file")
 			v.Set("hide-dependencies", viperValue)
 
-			params, err := paramspkg.LoadHeartbeatParams(ctx, v)
+			params, err := paramspkg.LoadHeartbeatParams(ctx, v, paramspkg.FlagReadOrderFlagPrecedence)
 			require.NoError(t, err)
 
 			assert.Equal(t, paramspkg.SanitizeParams{
@@ -1284,11 +1352,11 @@ func TestLoadHeartbeatParams_SanitizeParams_HideDependencies_List(t *testing.T) 
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			v := setupViper(t)
+			v := vipertools.MustNew()
 			v.Set("entity", "/path/to/file")
 			v.Set("hide-dependencies", test.ViperValue)
 
-			params, err := paramspkg.LoadHeartbeatParams(ctx, v)
+			params, err := paramspkg.LoadHeartbeatParams(ctx, v, paramspkg.FlagReadOrderFlagPrecedence)
 			require.NoError(t, err)
 
 			assert.Equal(t, paramspkg.SanitizeParams{
@@ -1299,12 +1367,12 @@ func TestLoadHeartbeatParams_SanitizeParams_HideDependencies_List(t *testing.T) 
 }
 
 func TestLoadHeartbeatParams_SanitizeParams_HideDependencies_FlagTakesPrecedence(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 	v.Set("hide-dependencies", true)
 	v.Set("settings.hide_dependencies", "ignored")
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, paramspkg.SanitizeParams{
@@ -1313,11 +1381,11 @@ func TestLoadHeartbeatParams_SanitizeParams_HideDependencies_FlagTakesPrecedence
 }
 
 func TestLoadHeartbeatParams_SanitizeParams_HideDependencies_FromConfig(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 	v.Set("settings.hide_dependencies", true)
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, paramspkg.SanitizeParams{
@@ -1333,7 +1401,7 @@ func TestLoadHeartbeatParams_SanitizeParams_HideDependencies_InvalidRegex(t *tes
 
 	ctx := t.Context()
 
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 	v.Set("hide-dependencies", ".*secret.*\n[0-9+")
 	v.Set("log-file", logFile.Name())
@@ -1345,7 +1413,7 @@ func TestLoadHeartbeatParams_SanitizeParams_HideDependencies_InvalidRegex(t *tes
 
 	ctx = log.ToContext(ctx, logger)
 
-	_, err = paramspkg.LoadHeartbeatParams(ctx, v)
+	_, err = paramspkg.LoadHeartbeatParams(ctx, v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	output, err := io.ReadAll(logFile)
@@ -1365,11 +1433,11 @@ func TestLoadHeartbeatParams_SanitizeParams_HideProjectNames_True(t *testing.T) 
 
 	for name, viperValue := range tests {
 		t.Run(name, func(t *testing.T) {
-			v := setupViper(t)
+			v := vipertools.MustNew()
 			v.Set("entity", "/path/to/file")
 			v.Set("hide-project-names", viperValue)
 
-			params, err := paramspkg.LoadHeartbeatParams(ctx, v)
+			params, err := paramspkg.LoadHeartbeatParams(ctx, v, paramspkg.FlagReadOrderFlagPrecedence)
 			require.NoError(t, err)
 
 			assert.Equal(t, paramspkg.SanitizeParams{
@@ -1390,11 +1458,11 @@ func TestLoadHeartbeatParams_SanitizeParams_HideProjectNames_False(t *testing.T)
 
 	for name, viperValue := range tests {
 		t.Run(name, func(t *testing.T) {
-			v := setupViper(t)
+			v := vipertools.MustNew()
 			v.Set("entity", "/path/to/file")
 			v.Set("hide-project-names", viperValue)
 
-			params, err := paramspkg.LoadHeartbeatParams(ctx, v)
+			params, err := paramspkg.LoadHeartbeatParams(ctx, v, paramspkg.FlagReadOrderFlagPrecedence)
 			require.NoError(t, err)
 
 			assert.Equal(t, paramspkg.SanitizeParams{
@@ -1428,11 +1496,11 @@ func TestLoadHeartbeatParams_SanitizeParams_HideProjecthNames_List(t *testing.T)
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			v := setupViper(t)
+			v := vipertools.MustNew()
 			v.Set("entity", "/path/to/file")
 			v.Set("hide-project-names", test.ViperValue)
 
-			params, err := paramspkg.LoadHeartbeatParams(ctx, v)
+			params, err := paramspkg.LoadHeartbeatParams(ctx, v, paramspkg.FlagReadOrderFlagPrecedence)
 			require.NoError(t, err)
 
 			assert.Equal(t, paramspkg.SanitizeParams{
@@ -1443,14 +1511,14 @@ func TestLoadHeartbeatParams_SanitizeParams_HideProjecthNames_List(t *testing.T)
 }
 
 func TestLoadHeartbeatParams_SanitizeParams_HideProjectNames_FlagTakesPrecedence(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 	v.Set("hide-project-names", true)
 	v.Set("settings.hide_project_names", "ignored")
 	v.Set("settings.hide_projectnames", "ignored")
 	v.Set("settings.hideprojectnames", "ignored")
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, paramspkg.SanitizeParams{
@@ -1459,13 +1527,13 @@ func TestLoadHeartbeatParams_SanitizeParams_HideProjectNames_FlagTakesPrecedence
 }
 
 func TestLoadHeartbeatParams_SanitizeParams_HideProjectNames_ConfigTakesPrecedence(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 	v.Set("settings.hide_project_names", true)
 	v.Set("settings.hide_projectnames", "ignored")
 	v.Set("settings.hideprojectnames", "ignored")
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, paramspkg.SanitizeParams{
@@ -1474,12 +1542,12 @@ func TestLoadHeartbeatParams_SanitizeParams_HideProjectNames_ConfigTakesPreceden
 }
 
 func TestLoadHeartbeatParams_SanitizeParams_HideProjectNames_ConfigDeprecatedOneTakesPrecedence(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 	v.Set("settings.hide_projectnames", true)
 	v.Set("settings.hideprojectnames", "ignored")
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, paramspkg.SanitizeParams{
@@ -1488,11 +1556,11 @@ func TestLoadHeartbeatParams_SanitizeParams_HideProjectNames_ConfigDeprecatedOne
 }
 
 func TestLoadHeartbeatParams_SanitizeParams_HideProjectNames_ConfigDeprecatedTwo(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 	v.Set("settings.hideprojectnames", "true")
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, paramspkg.SanitizeParams{
@@ -1508,7 +1576,7 @@ func TestLoadHeartbeatParams_SanitizeParams_HideProjectNames_InvalidRegex(t *tes
 
 	ctx := t.Context()
 
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 	v.Set("hide-project-names", ".*secret.*\n[0-9+")
 	v.Set("log-file", logFile.Name())
@@ -1520,7 +1588,7 @@ func TestLoadHeartbeatParams_SanitizeParams_HideProjectNames_InvalidRegex(t *tes
 
 	ctx = log.ToContext(ctx, logger)
 
-	_, err = paramspkg.LoadHeartbeatParams(ctx, v)
+	_, err = paramspkg.LoadHeartbeatParams(ctx, v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	output, err := io.ReadAll(logFile)
@@ -1540,11 +1608,11 @@ func TestLoadHeartbeatParams_SanitizeParams_HideFileNames_True(t *testing.T) {
 
 	for name, viperValue := range tests {
 		t.Run(name, func(t *testing.T) {
-			v := setupViper(t)
+			v := vipertools.MustNew()
 			v.Set("entity", "/path/to/file")
 			v.Set("hide-file-names", viperValue)
 
-			params, err := paramspkg.LoadHeartbeatParams(ctx, v)
+			params, err := paramspkg.LoadHeartbeatParams(ctx, v, paramspkg.FlagReadOrderFlagPrecedence)
 			require.NoError(t, err)
 
 			assert.Equal(t, paramspkg.SanitizeParams{
@@ -1565,11 +1633,11 @@ func TestLoadHeartbeatParams_SanitizeParams_HideFileNames_False(t *testing.T) {
 
 	for name, viperValue := range tests {
 		t.Run(name, func(t *testing.T) {
-			v := setupViper(t)
+			v := vipertools.MustNew()
 			v.Set("entity", "/path/to/file")
 			v.Set("hide-file-names", viperValue)
 
-			params, err := paramspkg.LoadHeartbeatParams(ctx, v)
+			params, err := paramspkg.LoadHeartbeatParams(ctx, v, paramspkg.FlagReadOrderFlagPrecedence)
 			require.NoError(t, err)
 
 			assert.Equal(t, paramspkg.SanitizeParams{
@@ -1603,11 +1671,11 @@ func TestLoadHeartbeatParams_SanitizeParams_HideFileNames_List(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			v := setupViper(t)
+			v := vipertools.MustNew()
 			v.Set("entity", "/path/to/file")
 			v.Set("hide-file-names", test.ViperValue)
 
-			params, err := paramspkg.LoadHeartbeatParams(ctx, v)
+			params, err := paramspkg.LoadHeartbeatParams(ctx, v, paramspkg.FlagReadOrderFlagPrecedence)
 			require.NoError(t, err)
 
 			assert.Equal(t, paramspkg.SanitizeParams{
@@ -1618,7 +1686,7 @@ func TestLoadHeartbeatParams_SanitizeParams_HideFileNames_List(t *testing.T) {
 }
 
 func TestLoadheartbeatParams_SanitizeParams_HideFileNames_FlagTakesPrecedence(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 	v.Set("hide-file-names", true)
 	v.Set("hide-filenames", "ignored")
@@ -1627,7 +1695,7 @@ func TestLoadheartbeatParams_SanitizeParams_HideFileNames_FlagTakesPrecedence(t 
 	v.Set("settings.hide_filenames", "ignored")
 	v.Set("settings.hidefilenames", "ignored")
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, paramspkg.SanitizeParams{
@@ -1636,7 +1704,7 @@ func TestLoadheartbeatParams_SanitizeParams_HideFileNames_FlagTakesPrecedence(t 
 }
 
 func TestLoadHeartbeatParams_SanitizeParams_HideFileNames_FlagDeprecatedOneTakesPrecedence(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 	v.Set("hide-filenames", true)
 	v.Set("hidefilenames", "ignored")
@@ -1644,7 +1712,7 @@ func TestLoadHeartbeatParams_SanitizeParams_HideFileNames_FlagDeprecatedOneTakes
 	v.Set("settings.hide_filenames", "ignored")
 	v.Set("settings.hidefilenames", "ignored")
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, paramspkg.SanitizeParams{
@@ -1653,14 +1721,14 @@ func TestLoadHeartbeatParams_SanitizeParams_HideFileNames_FlagDeprecatedOneTakes
 }
 
 func TestLoadHeartbeatParams_SanitizeParams_HideFileNames_FlagDeprecatedTwoTakesPrecedence(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 	v.Set("hidefilenames", true)
 	v.Set("settings.hide_file_names", "ignored")
 	v.Set("settings.hide_filenames", "ignored")
 	v.Set("settings.hidefilenames", "ignored")
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, paramspkg.SanitizeParams{
@@ -1669,13 +1737,13 @@ func TestLoadHeartbeatParams_SanitizeParams_HideFileNames_FlagDeprecatedTwoTakes
 }
 
 func TestLoadHeartbeatParams_SanitizeParams_HideFileNames_ConfigTakesPrecedence(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 	v.Set("settings.hide_file_names", true)
 	v.Set("settings.hide_filenames", "ignored")
 	v.Set("settings.hidefilenames", "ignored")
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, paramspkg.SanitizeParams{
@@ -1684,12 +1752,12 @@ func TestLoadHeartbeatParams_SanitizeParams_HideFileNames_ConfigTakesPrecedence(
 }
 
 func TestLoadHeartbeatParams_SanitizeParams_HideFileNames_ConfigDeprecatedOneTakesPrecedence(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 	v.Set("settings.hide_filenames", true)
 	v.Set("settings.hidefilenames", "ignored")
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, paramspkg.SanitizeParams{
@@ -1698,11 +1766,11 @@ func TestLoadHeartbeatParams_SanitizeParams_HideFileNames_ConfigDeprecatedOneTak
 }
 
 func TestLoadHeartbeatParams_SanitizeParams_HideFileNames_ConfigDeprecatedTwo(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 	v.Set("settings.hidefilenames", "true")
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, paramspkg.SanitizeParams{
@@ -1718,7 +1786,7 @@ func TestLoadHeartbeatParams_SanitizeParams_HideFileNames_InvalidRegex(t *testin
 
 	ctx := t.Context()
 
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 	v.Set("hide-file-names", ".*secret.*\n[0-9+")
 	v.Set("log-file", logFile.Name())
@@ -1730,7 +1798,7 @@ func TestLoadHeartbeatParams_SanitizeParams_HideFileNames_InvalidRegex(t *testin
 
 	ctx = log.ToContext(ctx, logger)
 
-	_, err = paramspkg.LoadHeartbeatParams(ctx, v)
+	_, err = paramspkg.LoadHeartbeatParams(ctx, v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	output, err := io.ReadAll(logFile)
@@ -1740,11 +1808,11 @@ func TestLoadHeartbeatParams_SanitizeParams_HideFileNames_InvalidRegex(t *testin
 }
 
 func TestLoadHeartbeatParams_SanitizeParams_HideProjectFolder(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 	v.Set("hide-project-folder", true)
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, paramspkg.SanitizeParams{
@@ -1753,11 +1821,11 @@ func TestLoadHeartbeatParams_SanitizeParams_HideProjectFolder(t *testing.T) {
 }
 
 func TestLoadHeartbeatParams_SanitizeParams_HideProjectFolder_ConfigTakesPrecedence(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 	v.Set("settings.hide_project_folder", true)
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, paramspkg.SanitizeParams{
@@ -1766,11 +1834,11 @@ func TestLoadHeartbeatParams_SanitizeParams_HideProjectFolder_ConfigTakesPrecede
 }
 
 func TestLoadHeartbeatParams_SanitizeParams_OverrideProjectPath(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")
 	v.Set("project-folder", "/custom-path")
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, paramspkg.SanitizeParams{
@@ -1787,11 +1855,11 @@ func TestLoadHeartbeatParams_SubmodulesDisabled_True(t *testing.T) {
 
 	for name, viperValue := range tests {
 		t.Run(name, func(t *testing.T) {
-			v := setupViper(t)
+			v := vipertools.MustNew()
 			v.Set("entity", "/path/to/file")
 			v.Set("git.submodules_disabled", viperValue)
 
-			params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+			params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 			require.NoError(t, err)
 
 			assert.Equal(t, []regex.Regex{regex.NewRegexpWrap(regexp.MustCompile(".*"))}, params.Project.SubmodulesDisabled)
@@ -1810,11 +1878,11 @@ func TestLoadHeartbeatParams_SubmodulesDisabled_False(t *testing.T) {
 
 	for name, viperValue := range tests {
 		t.Run(name, func(t *testing.T) {
-			v := setupViper(t)
+			v := vipertools.MustNew()
 			v.Set("entity", "/path/to/file")
 			v.Set("git.submodules_disabled", viperValue)
 
-			params, err := paramspkg.LoadHeartbeatParams(ctx, v)
+			params, err := paramspkg.LoadHeartbeatParams(ctx, v, paramspkg.FlagReadOrderFlagPrecedence)
 			require.NoError(t, err)
 
 			assert.Equal(t, params.Project.SubmodulesDisabled, []regex.Regex{regex.NewRegexpWrap(regexp.MustCompile("a^"))})
@@ -1857,7 +1925,7 @@ func TestLoadHeartbeatsParams_SubmodulesDisabled_List(t *testing.T) {
 			v.Set("entity", "/path/to/file")
 			v.Set("git.submodules_disabled", test.ViperValue)
 
-			params, err := paramspkg.LoadHeartbeatParams(ctx, v)
+			params, err := paramspkg.LoadHeartbeatParams(ctx, v, paramspkg.FlagReadOrderFlagPrecedence)
 			require.NoError(t, err)
 
 			assert.Equal(t, test.Expected, params.Project.SubmodulesDisabled)
@@ -1900,11 +1968,11 @@ func TestLoadHeartbeatsParams_SubmoduleProjectMap(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			v := setupViper(t)
+			v := vipertools.MustNew()
 			v.Set("entity", test.Entity)
 			v.Set(fmt.Sprintf("git_submodule_projectmap.%s", test.Regex.String()), test.Project)
 
-			params, err := paramspkg.LoadHeartbeatParams(ctx, v)
+			params, err := paramspkg.LoadHeartbeatParams(ctx, v, paramspkg.FlagReadOrderFlagPrecedence)
 			require.NoError(t, err)
 
 			assert.Equal(t, test.Expected, params.Project.SubmoduleMapPatterns)
@@ -1913,194 +1981,192 @@ func TestLoadHeartbeatsParams_SubmoduleProjectMap(t *testing.T) {
 }
 
 func TestLoadAPIParams_Plugin(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("plugin", "plugin/10.0.0")
 
-	params, err := paramspkg.LoadAPIParams(t.Context(), v)
+	params, err := paramspkg.LoadAPIParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, "plugin/10.0.0", params.Plugin)
 }
 
 func TestLoadAPIParams_Plugin_Unset(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 
-	params, err := paramspkg.LoadAPIParams(t.Context(), v)
+	params, err := paramspkg.LoadAPIParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Empty(t, params.Plugin)
 }
 
 func TestLoadAPIParams_Timeout_FlagTakesPrecedence(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("timeout", 5)
 	v.Set("settings.timeout", 10)
 
-	params, err := paramspkg.LoadAPIParams(t.Context(), v)
+	params, err := paramspkg.LoadAPIParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, 5*time.Second, params.Timeout)
 }
 
 func TestLoadAPIParams_Timeout_ConfigTakesPrecedence(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("settings.timeout", 10)
 
-	params, err := paramspkg.LoadAPIParams(t.Context(), v)
+	params, err := paramspkg.LoadAPIParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, 10*time.Second, params.Timeout)
 }
 
 func TestLoadAPIParams_Timeout_FromConfig(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("settings.timeout", 10)
 
-	params, err := paramspkg.LoadAPIParams(t.Context(), v)
+	params, err := paramspkg.LoadAPIParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, 10*time.Second, params.Timeout)
 }
 
 func TestLoadAPIParams_Timeout_Zero(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("timeout", 0)
 
-	params, err := paramspkg.LoadAPIParams(t.Context(), v)
+	params, err := paramspkg.LoadAPIParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Zero(t, params.Timeout)
 }
 
 func TestLoadAPIParams_Timeout_Default(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.SetDefault("timeout", api.DefaultTimeoutSecs)
 
-	params, err := paramspkg.LoadAPIParams(t.Context(), v)
+	params, err := paramspkg.LoadAPIParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, time.Duration(api.DefaultTimeoutSecs)*time.Second, params.Timeout)
 }
 
 func TestLoadAPIParams_Timeout_NegativeNumber(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("timeout", 0)
 
-	params, err := paramspkg.LoadAPIParams(t.Context(), v)
+	params, err := paramspkg.LoadAPIParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Zero(t, params.Timeout)
 }
 
 func TestLoadAPIParams_Timeout_NonIntegerValue(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("timeout", "invalid")
 
-	params, err := paramspkg.LoadAPIParams(t.Context(), v)
+	params, err := paramspkg.LoadAPIParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, time.Duration(api.DefaultTimeoutSecs)*time.Second, params.Timeout)
 }
 
 func TestLoadOfflineParams_Disabled_ConfigTakesPrecedence(t *testing.T) {
-	v := setupViper(t)
-	v.Set("disable-offline", false)
-	v.Set("disableoffline", false)
+	v := vipertools.MustNew()
 	v.Set("settings.offline", false)
 
-	params := paramspkg.LoadOfflineParams(t.Context(), v)
+	params := paramspkg.LoadOfflineParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 
 	assert.True(t, params.Disabled)
 }
 
 func TestLoadOfflineParams_Disabled_FlagDeprecatedTakesPrecedence(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("disable-offline", false)
 	v.Set("disableoffline", true)
 
-	params := paramspkg.LoadOfflineParams(t.Context(), v)
+	params := paramspkg.LoadOfflineParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 
 	assert.False(t, params.Disabled)
 }
 
 func TestLoadOfflineParams_Disabled_FromFlag(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("disable-offline", true)
 
-	params := paramspkg.LoadOfflineParams(t.Context(), v)
+	params := paramspkg.LoadOfflineParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 
 	assert.True(t, params.Disabled)
 }
 
 func TestLoadOfflineParams_RateLimit_FlagTakesPrecedence(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("heartbeat-rate-limit-seconds", 5)
 	v.Set("settings.heartbeat_rate_limit_seconds", 10)
 
-	params := paramspkg.LoadOfflineParams(t.Context(), v)
+	params := paramspkg.LoadOfflineParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 
 	assert.Equal(t, time.Duration(5)*time.Second, params.RateLimit)
 }
 
 func TestLoadOfflineParams_RateLimit_FromConfig(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("settings.heartbeat_rate_limit_seconds", 10)
 
-	params := paramspkg.LoadOfflineParams(t.Context(), v)
+	params := paramspkg.LoadOfflineParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 
 	assert.Equal(t, time.Duration(10)*time.Second, params.RateLimit)
 }
 
 func TestLoadOfflineParams_RateLimit_Zero(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("heartbeat-rate-limit-seconds", 0)
 
-	params := paramspkg.LoadOfflineParams(t.Context(), v)
+	params := paramspkg.LoadOfflineParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 
 	assert.Zero(t, params.RateLimit)
 }
 
 func TestLoadOfflineParams_RateLimit_Default(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.SetDefault("heartbeat-rate-limit-seconds", offline.RateLimitDefaultSeconds)
 
-	params := paramspkg.LoadOfflineParams(t.Context(), v)
+	params := paramspkg.LoadOfflineParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 
 	assert.Equal(t, time.Duration(offline.RateLimitDefaultSeconds)*time.Second, params.RateLimit)
 }
 
 func TestLoadOfflineParams_RateLimit_NegativeNumber(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("heartbeat-rate-limit-seconds", -1)
 
-	params := paramspkg.LoadOfflineParams(t.Context(), v)
+	params := paramspkg.LoadOfflineParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 
 	assert.Zero(t, params.RateLimit)
 }
 
 func TestLoadOfflineParams_RateLimit_NonIntegerValue(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("heartbeat-rate-limit-seconds", "invalid")
 
-	params := paramspkg.LoadOfflineParams(t.Context(), v)
+	params := paramspkg.LoadOfflineParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 
 	assert.Equal(t, time.Duration(offline.RateLimitDefaultSeconds)*time.Second, params.RateLimit)
 }
 
 func TestLoadOfflineParams_LastSentAt(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("internal.heartbeats_last_sent_at", "2021-08-30T18:50:42-03:00")
 
-	params := paramspkg.LoadOfflineParams(t.Context(), v)
+	params := paramspkg.LoadOfflineParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 
 	lastSentAt, err := time.Parse(inipkg.DateFormat, "2021-08-30T18:50:42-03:00")
 	require.NoError(t, err)
@@ -2109,65 +2175,65 @@ func TestLoadOfflineParams_LastSentAt(t *testing.T) {
 }
 
 func TestLoadOfflineParams_LastSentAt_Err(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("internal.heartbeats_last_sent_at", "2021-08-30")
 
-	params := paramspkg.LoadOfflineParams(t.Context(), v)
+	params := paramspkg.LoadOfflineParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 
 	assert.Zero(t, params.LastSentAt)
 }
 
 func TestLoadOfflineParams_LastSentAtFuture(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	lastSentAt := time.Now().Add(2 * time.Hour)
 	v.Set("internal.heartbeats_last_sent_at", lastSentAt.Format(inipkg.DateFormat))
 
-	params := paramspkg.LoadOfflineParams(t.Context(), v)
+	params := paramspkg.LoadOfflineParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 
 	assert.LessOrEqual(t, params.LastSentAt, time.Now())
 }
 
 func TestLoadOfflineParams_SyncMax(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("sync-offline-activity", 42)
 
-	params := paramspkg.LoadOfflineParams(t.Context(), v)
+	params := paramspkg.LoadOfflineParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 
 	assert.Equal(t, 42, params.SyncMax)
 }
 
 func TestLoadOfflineParams_SyncMax_Zero(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("sync-offline-activity", "0")
 
-	params := paramspkg.LoadOfflineParams(t.Context(), v)
+	params := paramspkg.LoadOfflineParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 
 	assert.Zero(t, params.SyncMax)
 }
 
 func TestLoadOfflineParams_SyncMax_Default(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.SetDefault("sync-offline-activity", 1000)
 
-	params := paramspkg.LoadOfflineParams(t.Context(), v)
+	params := paramspkg.LoadOfflineParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 
 	assert.Equal(t, 1000, params.SyncMax)
 }
 
 func TestLoadOfflineParams_SyncMax_NegativeNumber(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("sync-offline-activity", -1)
 
-	params := paramspkg.LoadOfflineParams(t.Context(), v)
+	params := paramspkg.LoadOfflineParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 
 	assert.Zero(t, params.SyncMax)
 }
 
 func TestLoadOfflineParams_SyncMax_NonIntegerValue(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("sync-offline-activity", "invalid")
 
-	params := paramspkg.LoadOfflineParams(t.Context(), v)
+	params := paramspkg.LoadOfflineParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 
 	assert.Zero(t, params.SyncMax)
 }
@@ -2175,10 +2241,10 @@ func TestLoadOfflineParams_SyncMax_NonIntegerValue(t *testing.T) {
 func TestLoadAPIParams_APIKey(t *testing.T) {
 	ctx := t.Context()
 
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 
-	params, err := paramspkg.LoadAPIParams(ctx, v)
+	params, err := paramspkg.LoadAPIParams(ctx, v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, "00000000-0000-4000-8000-000000000000", params.Key)
@@ -2187,11 +2253,11 @@ func TestLoadAPIParams_APIKey(t *testing.T) {
 func TestLoadAPIParams_APIKey_FlagTakesPrecedence(t *testing.T) {
 	ctx := t.Context()
 
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("settings.api_key", "10000000-0000-4000-8000-000000000000")
 
-	params, err := paramspkg.LoadAPIParams(ctx, v)
+	params, err := paramspkg.LoadAPIParams(ctx, v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, "00000000-0000-4000-8000-000000000000", params.Key)
@@ -2200,10 +2266,10 @@ func TestLoadAPIParams_APIKey_FlagTakesPrecedence(t *testing.T) {
 func TestLoadAPIParams_APIKey_FromConfig(t *testing.T) {
 	ctx := t.Context()
 
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("settings.api_key", "10000000-0000-4000-8000-000000000000")
 
-	params, err := paramspkg.LoadAPIParams(ctx, v)
+	params, err := paramspkg.LoadAPIParams(ctx, v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, "10000000-0000-4000-8000-000000000000", params.Key)
@@ -2212,20 +2278,20 @@ func TestLoadAPIParams_APIKey_FromConfig(t *testing.T) {
 func TestLoadAPIParams_APIKey_ConfigDeprecatedTakesPrecedence(t *testing.T) {
 	ctx := t.Context()
 
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("settings.apikey", "20000000-0000-4000-8000-000000000000")
 
-	params, err := paramspkg.LoadAPIParams(ctx, v)
+	params, err := paramspkg.LoadAPIParams(ctx, v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, "20000000-0000-4000-8000-000000000000", params.Key)
 }
 
 func TestLoadAPIParams_APIKeyUnset(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("key", "")
 
-	_, err := paramspkg.LoadAPIParams(t.Context(), v)
+	_, err := paramspkg.LoadAPIParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.Error(t, err)
 
 	var errauth api.ErrAuth
@@ -2245,10 +2311,10 @@ func TestLoadAPIParams_APIKeyInvalid(t *testing.T) {
 
 	for name, value := range tests {
 		t.Run(name, func(t *testing.T) {
-			v := setupViper(t)
+			v := vipertools.MustNew()
 			v.Set("key", value)
 
-			_, err := paramspkg.LoadAPIParams(ctx, v)
+			_, err := paramspkg.LoadAPIParams(ctx, v, paramspkg.FlagReadOrderFlagPrecedence)
 			require.Error(t, err)
 
 			var errauth api.ErrAuth
@@ -2260,7 +2326,7 @@ func TestLoadAPIParams_APIKeyInvalid(t *testing.T) {
 }
 
 func TestLoadAPIParams_APIKey_ConfigFileTakesPrecedence(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("config", "testdata/.wakatime.cfg")
 	v.Set("entity", "testdata/heartbeat_go.json")
 
@@ -2270,14 +2336,14 @@ func TestLoadAPIParams_APIKey_ConfigFileTakesPrecedence(t *testing.T) {
 	err = inipkg.ReadInConfig(v, configFile)
 	require.NoError(t, err)
 
-	params, err := paramspkg.LoadAPIParams(t.Context(), v)
+	params, err := paramspkg.LoadAPIParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, "00000000-0000-4000-8000-000000000000", params.Key)
 }
 
 func TestLoadAPIParams_APIKey_FromVault(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("config", "testdata/.wakatime-vault.cfg")
 	v.Set("entity", "testdata/heartbeat_go.json")
 
@@ -2287,7 +2353,7 @@ func TestLoadAPIParams_APIKey_FromVault(t *testing.T) {
 	err = inipkg.ReadInConfig(v, configFile)
 	require.NoError(t, err)
 
-	params, err := paramspkg.LoadAPIParams(t.Context(), v)
+	params, err := paramspkg.LoadAPIParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, "00000000-0000-4000-8000-000000000000", params.Key)
@@ -2300,7 +2366,7 @@ func TestLoadParams_APIKey_FromVault_Err_Darwin(t *testing.T) {
 
 	ctx := t.Context()
 
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("config", "testdata/.wakatime-vault-error.cfg")
 	v.Set("entity", "testdata/heartbeat_go.json")
 
@@ -2310,28 +2376,28 @@ func TestLoadParams_APIKey_FromVault_Err_Darwin(t *testing.T) {
 	err = inipkg.ReadInConfig(v, configFile)
 	require.NoError(t, err)
 
-	_, err = paramspkg.LoadAPIParams(ctx, v)
+	_, err = paramspkg.LoadAPIParams(ctx, v, paramspkg.FlagReadOrderFlagPrecedence)
 
 	assert.EqualError(t, err, "failed to read api key from vault: exit status 1")
 }
 
 func TestLoadAPIParams_APIKeyFromEnv(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 
 	t.Setenv("WAKATIME_API_KEY", "00000000-0000-4000-8000-000000000000")
 
-	params, err := paramspkg.LoadAPIParams(t.Context(), v)
+	params, err := paramspkg.LoadAPIParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, "00000000-0000-4000-8000-000000000000", params.Key)
 }
 
 func TestLoadAPIParams_APIKeyFromEnv_Invalid(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 
 	t.Setenv("WAKATIME_API_KEY", "00000000-0000-4000-0000-000000000000")
 
-	_, err := paramspkg.LoadAPIParams(t.Context(), v)
+	_, err := paramspkg.LoadAPIParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.Error(t, err)
 
 	var errauth api.ErrAuth
@@ -2341,12 +2407,12 @@ func TestLoadAPIParams_APIKeyFromEnv_Invalid(t *testing.T) {
 }
 
 func TestLoadAPIParams_APIKeyFromEnv_ConfigTakesPrecedence(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("settings.api_key", "00000000-0000-4000-8000-000000000000")
 
 	t.Setenv("WAKATIME_API_KEY", "10000000-0000-4000-8000-000000000000")
 
-	params, err := paramspkg.LoadAPIParams(t.Context(), v)
+	params, err := paramspkg.LoadAPIParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, "00000000-0000-4000-8000-000000000000", params.Key)
@@ -2379,11 +2445,11 @@ func TestLoadAPIParams_APIUrl_Sanitize(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			v := setupViper(t)
+			v := vipertools.MustNew()
 			v.Set("key", "00000000-0000-4000-8000-000000000000")
 			v.Set("api-url", test.URL)
 
-			params, err := paramspkg.LoadAPIParams(ctx, v)
+			params, err := paramspkg.LoadAPIParams(ctx, v, paramspkg.FlagReadOrderFlagPrecedence)
 			require.NoError(t, err)
 
 			assert.Equal(t, test.Expected, params.URL)
@@ -2394,12 +2460,12 @@ func TestLoadAPIParams_APIUrl_Sanitize(t *testing.T) {
 func TestLoadAPIParams_Url(t *testing.T) {
 	ctx := t.Context()
 
-	v := setupViper(t)
+	v := vipertools.MustNew()
 
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("api-url", "http://localhost:8080")
 
-	params, err := paramspkg.LoadAPIParams(ctx, v)
+	params, err := paramspkg.LoadAPIParams(ctx, v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, "http://localhost:8080", params.URL)
@@ -2408,13 +2474,13 @@ func TestLoadAPIParams_Url(t *testing.T) {
 func TestLoadAPIParams_Url_FlagTakesPrecedence(t *testing.T) {
 	ctx := t.Context()
 
-	v := setupViper(t)
+	v := vipertools.MustNew()
 
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("api-url", "http://localhost:8080")
 	v.Set("settings.api_url", "http://localhost:8081")
 
-	params, err := paramspkg.LoadAPIParams(ctx, v)
+	params, err := paramspkg.LoadAPIParams(ctx, v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, "http://localhost:8080", params.URL)
@@ -2423,13 +2489,13 @@ func TestLoadAPIParams_Url_FlagTakesPrecedence(t *testing.T) {
 func TestLoadAPIParams_Url_FlagDeprecatedTakesPrecedence(t *testing.T) {
 	ctx := t.Context()
 
-	v := setupViper(t)
+	v := vipertools.MustNew()
 
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("apiurl", "http://localhost:8080")
 	v.Set("settings.api_url", "http://localhost:8081")
 
-	params, err := paramspkg.LoadAPIParams(ctx, v)
+	params, err := paramspkg.LoadAPIParams(ctx, v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, "http://localhost:8080", params.URL)
@@ -2438,33 +2504,33 @@ func TestLoadAPIParams_Url_FlagDeprecatedTakesPrecedence(t *testing.T) {
 func TestLoadAPIParams_Url_FromConfig(t *testing.T) {
 	ctx := t.Context()
 
-	v := setupViper(t)
+	v := vipertools.MustNew()
 
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("settings.api_url", "http://localhost:8081")
 
-	params, err := paramspkg.LoadAPIParams(ctx, v)
+	params, err := paramspkg.LoadAPIParams(ctx, v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, "http://localhost:8081", params.URL)
 }
 
 func TestLoadAPIParams_Url_Default(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 
-	params, err := paramspkg.LoadAPIParams(t.Context(), v)
+	params, err := paramspkg.LoadAPIParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, api.BaseURL, params.URL)
 }
 
 func TestLoadAPIParams_Url_InvalidFormat(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("api-url", "http://in valid")
 
-	_, err := paramspkg.LoadAPIParams(t.Context(), v)
+	_, err := paramspkg.LoadAPIParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 
 	var errauth api.ErrAuth
 
@@ -2473,14 +2539,14 @@ func TestLoadAPIParams_Url_InvalidFormat(t *testing.T) {
 }
 
 func TestLoadAPIParams_BackoffAt(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("hostname", "my-computer")
 	v.Set("timeout", 0)
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("internal.backoff_at", "2021-08-30T18:50:42-03:00")
 	v.Set("internal.backoff_retries", "3")
 
-	params, err := paramspkg.LoadAPIParams(t.Context(), v)
+	params, err := paramspkg.LoadAPIParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	backoffAt, err := time.Parse(inipkg.DateFormat, "2021-08-30T18:50:42-03:00")
@@ -2496,14 +2562,14 @@ func TestLoadAPIParams_BackoffAt(t *testing.T) {
 }
 
 func TestLoadAPIParams_BackoffAtErr(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("hostname", "my-computer")
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("timeout", 0)
 	v.Set("internal.backoff_at", "2021-08-30")
 	v.Set("internal.backoff_retries", "2")
 
-	params, err := paramspkg.LoadAPIParams(t.Context(), v)
+	params, err := paramspkg.LoadAPIParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, 2, params.BackoffRetries)
@@ -2511,7 +2577,7 @@ func TestLoadAPIParams_BackoffAtErr(t *testing.T) {
 }
 
 func TestLoadAPIParams_BackoffAtFuture(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	backoff := time.Now().Add(time.Duration(2) * time.Hour)
 
 	v.Set("hostname", "my-computer")
@@ -2519,7 +2585,7 @@ func TestLoadAPIParams_BackoffAtFuture(t *testing.T) {
 	v.Set("internal.backoff_at", backoff.Format(inipkg.DateFormat))
 	v.Set("internal.backoff_retries", "3")
 
-	params, err := paramspkg.LoadAPIParams(t.Context(), v)
+	params, err := paramspkg.LoadAPIParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, 3, params.BackoffRetries)
@@ -2527,33 +2593,33 @@ func TestLoadAPIParams_BackoffAtFuture(t *testing.T) {
 }
 
 func TestLoadAPIParams_DisableSSLVerify_FlagTakesPrecedence(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("no-ssl-verify", false)
 	v.Set("settings.no_ssl_verify", true)
 
-	params, err := paramspkg.LoadAPIParams(t.Context(), v)
+	params, err := paramspkg.LoadAPIParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.False(t, params.DisableSSLVerify)
 }
 
 func TestLoadAPIParams_DisableSSLVerify_FromConfig(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("settings.no_ssl_verify", true)
 
-	params, err := paramspkg.LoadAPIParams(t.Context(), v)
+	params, err := paramspkg.LoadAPIParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.True(t, params.DisableSSLVerify)
 }
 
 func TestLoadAPIParams_DisableSSLVerify_Default(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 
-	params, err := paramspkg.LoadAPIParams(t.Context(), v)
+	params, err := paramspkg.LoadAPIParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.False(t, params.DisableSSLVerify)
@@ -2572,11 +2638,11 @@ func TestLoadAPIParams_ProxyURL(t *testing.T) {
 
 	for name, proxyURL := range tests {
 		t.Run(name, func(t *testing.T) {
-			v := setupViper(t)
+			v := vipertools.MustNew()
 			v.Set("key", "00000000-0000-4000-8000-000000000000")
 			v.Set("proxy", proxyURL)
 
-			params, err := paramspkg.LoadAPIParams(ctx, v)
+			params, err := paramspkg.LoadAPIParams(ctx, v, paramspkg.FlagReadOrderFlagPrecedence)
 			require.NoError(t, err)
 
 			assert.Equal(t, proxyURL, params.ProxyURL)
@@ -2585,71 +2651,71 @@ func TestLoadAPIParams_ProxyURL(t *testing.T) {
 }
 
 func TestLoadAPIParams_ProxyURL_FlagTakesPrecedence(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("proxy", "https://john:secret@example.org:8888")
 	v.Set("settings.proxy", "ignored")
 
-	params, err := paramspkg.LoadAPIParams(t.Context(), v)
+	params, err := paramspkg.LoadAPIParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, "https://john:secret@example.org:8888", params.ProxyURL)
 }
 
 func TestLoadAPIParams_ProxyURL_FlagTakesPrecedenceOverEnvironment(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("proxy", "https://john:secret@example.org:8888")
 
 	t.Setenv("HTTPS_PROXY", "https://papa:secret@company.org:9000")
 
-	params, err := paramspkg.LoadAPIParams(t.Context(), v)
+	params, err := paramspkg.LoadAPIParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, "https://john:secret@example.org:8888", params.ProxyURL)
 }
 
 func TestLoadAPIParams_ProxyURL_FromConfig(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("settings.proxy", "https://john:secret@example.org:8888")
 
-	params, err := paramspkg.LoadAPIParams(t.Context(), v)
+	params, err := paramspkg.LoadAPIParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, "https://john:secret@example.org:8888", params.ProxyURL)
 }
 
 func TestLoadAPIParams_ProxyURL_FromEnvironment(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 
 	t.Setenv("HTTPS_PROXY", "https://john:secret@example.org:8888")
 
-	params, err := paramspkg.LoadAPIParams(t.Context(), v)
+	params, err := paramspkg.LoadAPIParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, "https://john:secret@example.org:8888", params.ProxyURL)
 }
 
 func TestLoadAPIParams_ProxyURL_NoProxyFromEnvironment(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 
 	t.Setenv("NO_PROXY", "https://some.org,https://api.wakatime.com")
 
-	params, err := paramspkg.LoadAPIParams(t.Context(), v)
+	params, err := paramspkg.LoadAPIParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Empty(t, params.ProxyURL)
 }
 
 func TestLoadAPIParams_ProxyURL_InvalidFormat(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("proxy", "ftp://john:secret@example.org:8888")
 
-	_, err := paramspkg.LoadAPIParams(t.Context(), v)
+	_, err := paramspkg.LoadAPIParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 
 	var errauth api.ErrAuth
 
@@ -2662,83 +2728,83 @@ func TestLoadAPIParams_ProxyURL_InvalidFormat(t *testing.T) {
 }
 
 func TestLoadAPIParams_SSLCertFilepath_FlagTakesPrecedence(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("ssl-certs-file", "~/path/to/cert.pem")
 
 	home, err := os.UserHomeDir()
 	require.NoError(t, err)
 
-	params, err := paramspkg.LoadAPIParams(t.Context(), v)
+	params, err := paramspkg.LoadAPIParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, filepath.Join(home, "/path/to/cert.pem"), params.SSLCertFilepath)
 }
 
 func TestLoadAPIParams_SSLCertFilepath_FromConfig(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("settings.ssl_certs_file", "/path/to/cert.pem")
 
-	params, err := paramspkg.LoadAPIParams(t.Context(), v)
+	params, err := paramspkg.LoadAPIParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, "/path/to/cert.pem", params.SSLCertFilepath)
 }
 
 func TestLoadAPIParams_Hostname_FlagTakesPrecedence(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("hostname", "my-machine")
 	v.Set("settings.hostname", "ignored")
 
-	params, err := paramspkg.LoadAPIParams(t.Context(), v)
+	params, err := paramspkg.LoadAPIParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, "my-machine", params.Hostname)
 }
 
 func TestLoadAPIParams_Hostname_FromConfig(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("settings.hostname", "my-machine")
 
-	params, err := paramspkg.LoadAPIParams(t.Context(), v)
+	params, err := paramspkg.LoadAPIParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, "my-machine", params.Hostname)
 }
 
 func TestLoadAPIParams_Hostname_ConfigTakesPrecedence(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("settings.hostname", "my-machine")
 
 	t.Setenv("GITPOD_WORKSPACE_ID", "gitpod")
 
-	params, err := paramspkg.LoadAPIParams(t.Context(), v)
+	params, err := paramspkg.LoadAPIParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, "my-machine", params.Hostname)
 }
 
 func TestLoadAPIParams_Hostname_FromGitpodEnv(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 
 	t.Setenv("GITPOD_WORKSPACE_ID", "gitpod")
 
-	params, err := paramspkg.LoadAPIParams(t.Context(), v)
+	params, err := paramspkg.LoadAPIParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, "Gitpod", params.Hostname)
 }
 
 func TestLoadAPIParams_Hostname_DefaultFromSystem(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 
-	params, err := paramspkg.LoadAPIParams(t.Context(), v)
+	params, err := paramspkg.LoadAPIParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	expected, err := os.Hostname()
@@ -2748,21 +2814,21 @@ func TestLoadAPIParams_Hostname_DefaultFromSystem(t *testing.T) {
 }
 
 func TestLoadStatusBarParams_HideCategories_FlagTakesPrecedence(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("today-hide-categories", false)
 	v.Set("settings.status_bar_hide_categories", true)
 
-	params, err := paramspkg.LoadStatusBarParams(v)
+	params, err := paramspkg.LoadStatusBarParams(v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.False(t, params.HideCategories)
 }
 
 func TestLoadStatusBarParams_HideCategories_ConfigTakesPrecedence(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("settings.status_bar_hide_categories", true)
 
-	params, err := paramspkg.LoadStatusBarParams(v)
+	params, err := paramspkg.LoadStatusBarParams(v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.True(t, params.HideCategories)
@@ -2776,10 +2842,10 @@ func TestLoadStatusBarParams_Output(t *testing.T) {
 
 	for name, out := range tests {
 		t.Run(name, func(t *testing.T) {
-			v := setupViper(t)
+			v := vipertools.MustNew()
 			v.Set("output", name)
 
-			params, err := paramspkg.LoadStatusBarParams(v)
+			params, err := paramspkg.LoadStatusBarParams(v, paramspkg.FlagReadOrderFlagPrecedence)
 			require.NoError(t, err)
 
 			assert.Equal(t, out, params.Output)
@@ -2788,22 +2854,97 @@ func TestLoadStatusBarParams_Output(t *testing.T) {
 }
 
 func TestLoadStatusBarParams_Output_Default(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 
-	params, err := paramspkg.LoadStatusBarParams(v)
+	params, err := paramspkg.LoadStatusBarParams(v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.Equal(t, output.TextOutput, params.Output)
 }
 
 func TestLoadStatusBarParams_Output_Invalid(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("output", "invalid")
 
-	_, err := paramspkg.LoadStatusBarParams(v)
+	_, err := paramspkg.LoadStatusBarParams(v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.Error(t, err)
 
 	assert.Equal(t, "failed to parse output: invalid output \"invalid\"", err.Error())
+}
+
+func TestLoadHeartbeatParams_ExtraHeartbeats_StdinReadOnlyOnce(t *testing.T) {
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+
+	defer func() {
+		r.Close()
+		w.Close()
+	}()
+
+	origStdin := os.Stdin
+
+	defer func() { os.Stdin = origStdin }()
+
+	os.Stdin = r
+
+	paramspkg.Once = sync.Once{}
+
+	data, err := os.ReadFile("testdata/extra_heartbeats.json")
+	require.NoError(t, err)
+
+	_, err = w.Write(data)
+	require.NoError(t, err)
+
+	w.Close()
+
+	v := vipertools.MustNew()
+	v.Set("entity", "/path/to/file")
+	v.Set("extra-heartbeats", true)
+
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
+	require.NoError(t, err)
+
+	assert.Len(t, params.ExtraHeartbeats, 2)
+	assert.Equal(t, "Golang", params.ExtraHeartbeats[0].LanguageAlternate)
+
+	r.Close()
+	w.Close()
+
+	// change stdin and make sure loading params uses old stdin
+	r, w, err = os.Pipe()
+	require.NoError(t, err)
+
+	data, err = os.ReadFile("testdata/extra_heartbeats_with_string_values.json")
+	require.NoError(t, err)
+
+	_, err = w.Write(data)
+	require.NoError(t, err)
+
+	w.Close()
+
+	os.Stdin = r
+
+	v = viper.New()
+	v.Set("entity", "/path/to/file")
+	v.Set("extra-heartbeats", true)
+
+	params, err = paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
+	require.NoError(t, err)
+
+	assert.Len(t, params.ExtraHeartbeats, 2)
+	assert.Equal(t, "Golang", params.ExtraHeartbeats[0].LanguageAlternate)
+
+	v = viper.New()
+	v.Set("entity", "/path/to/file")
+	v.Set("extra-heartbeats", true)
+
+	paramspkg.Once = sync.Once{}
+
+	params, err = paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
+	require.NoError(t, err)
+
+	assert.Len(t, params.ExtraHeartbeats, 2)
+	assert.Empty(t, params.ExtraHeartbeats[0].LanguageAlternate)
 }
 
 func TestAPI_String(t *testing.T) {
@@ -2934,11 +3075,11 @@ func TestProjectParams_String(t *testing.T) {
 }
 
 func TestLoadHeartbeatParams_ProjectFromGitRemote(t *testing.T) {
-	v := setupViper(t)
+	v := vipertools.MustNew()
 	v.Set("git.project_from_git_remote", true)
 	v.Set("entity", "/path/to/file")
 
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
+	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
 	assert.True(t, params.Project.ProjectFromGitRemote)
@@ -2975,90 +3116,16 @@ func TestStatusBar_String(t *testing.T) {
 	)
 }
 
-func TestLoadHeartbeatParams_ExtraHeartbeats_StdinReadOnlyOnce(t *testing.T) {
-	r, w, err := os.Pipe()
-	require.NoError(t, err)
+func TestFlagReadOrder_String(t *testing.T) {
+	tests := map[string]paramspkg.FlagReadOrder{
+		"flag-precedence":           paramspkg.FlagReadOrderFlagPrecedence,
+		"project-config-precedence": paramspkg.FlagReadOrderProjectConfigPrecedence,
+	}
 
-	defer func() {
-		r.Close()
-		w.Close()
-	}()
-
-	origStdin := os.Stdin
-
-	defer func() { os.Stdin = origStdin }()
-
-	os.Stdin = r
-
-	paramspkg.Once = sync.Once{}
-
-	data, err := os.ReadFile("testdata/extra_heartbeats.json")
-	require.NoError(t, err)
-
-	_, err = w.Write(data)
-	require.NoError(t, err)
-
-	w.Close()
-
-	v := setupViper(t)
-	v.Set("entity", "/path/to/file")
-	v.Set("extra-heartbeats", true)
-
-	params, err := paramspkg.LoadHeartbeatParams(t.Context(), v)
-	require.NoError(t, err)
-
-	assert.Len(t, params.ExtraHeartbeats, 2)
-	assert.Equal(t, "Golang", params.ExtraHeartbeats[0].LanguageAlternate)
-
-	r.Close()
-	w.Close()
-
-	// change stdin and make sure loading params uses old stdin
-	r, w, err = os.Pipe()
-	require.NoError(t, err)
-
-	data, err = os.ReadFile("testdata/extra_heartbeats_with_string_values.json")
-	require.NoError(t, err)
-
-	_, err = w.Write(data)
-	require.NoError(t, err)
-
-	w.Close()
-
-	os.Stdin = r
-
-	v = viper.New()
-	v.Set("entity", "/path/to/file")
-	v.Set("extra-heartbeats", true)
-
-	params, err = paramspkg.LoadHeartbeatParams(t.Context(), v)
-	require.NoError(t, err)
-
-	assert.Len(t, params.ExtraHeartbeats, 2)
-	assert.Equal(t, "Golang", params.ExtraHeartbeats[0].LanguageAlternate)
-
-	v = viper.New()
-	v.Set("entity", "/path/to/file")
-	v.Set("extra-heartbeats", true)
-
-	paramspkg.Once = sync.Once{}
-
-	params, err = paramspkg.LoadHeartbeatParams(t.Context(), v)
-	require.NoError(t, err)
-
-	assert.Len(t, params.ExtraHeartbeats, 2)
-	assert.Empty(t, params.ExtraHeartbeats[0].LanguageAlternate)
-}
-
-func setupViper(t *testing.T) *viper.Viper {
-	multilineOption := iniv1.LoadOptions{AllowPythonMultilineValues: true}
-	iniCodec := viperini.Codec{LoadOptions: multilineOption}
-
-	codecRegistry := viper.NewCodecRegistry()
-	err := codecRegistry.RegisterCodec("ini", iniCodec)
-	require.NoError(t, err)
-
-	v := viper.NewWithOptions(viper.WithCodecRegistry(codecRegistry))
-
-	return v
+	for value, order := range tests {
+		t.Run(value, func(t *testing.T) {
+			s := order.String()
+			assert.Equal(t, value, s)
+		})
+	}
 }

--- a/pkg/vipertools/vipertools.go
+++ b/pkg/vipertools/vipertools.go
@@ -2,7 +2,6 @@ package vipertools
 
 import (
 	"fmt"
-	"slices"
 	"strings"
 
 	viperini "github.com/go-viper/encoding/ini"
@@ -24,47 +23,20 @@ func New() (*viper.Viper, error) {
 	return viper.NewWithOptions(viper.WithCodecRegistry(codecRegistry)), nil
 }
 
-// CopyOnlySettings copies only the settings from one viper.Viper instance to another.
-// It skips all settings that are loaded from command line arguments.
-func CopyOnlySettings(vsrc, vdest *viper.Viper) {
-	skip := []string{
-		"key",
-		"api-url",
-		"apiurl",
-		"hostname",
-		"proxy",
-		"ssl-certs-file",
-		"timeout",
-		"no-ssl-verify",
-		"guess-language",
-		"exclude",
-		"include",
-		"exclude-unknown-project",
-		"include-only-with-project-file",
-		"hide-branch-names",
-		"hide-dependencies",
-		"hide-project-names",
-		"hide-file-names",
-		"hide-filenames",
-		"hidefilenames",
-		"hide-project-folder",
-		"disable-offline",
-		"disableoffline",
-		"heartbeat-rate-limit-seconds",
-		"today-hide-categories",
+// MustNew creates a new viper instance with the ini codec registered and panics if it fails.
+// This is useful for testing.
+func MustNew() *viper.Viper {
+	v, err := New()
+	if err != nil {
+		panic(fmt.Sprintf("failed to create viper instance: %s", err))
 	}
 
-	for _, key := range vsrc.AllKeys() {
-		if slices.Contains(skip, key) {
-			continue
-		}
-
-		vdest.Set(key, vsrc.Get(key))
-	}
+	return v
 }
 
 // FirstNonEmptyBool accepts multiple keys and returns the first non-empty bool value
 // from viper.Viper via these keys. Non-empty meaning key not set will not be accepted.
+// Will return false as second parameter, if non-empty bool value could not be retrieved.
 func FirstNonEmptyBool(v *viper.Viper, keys ...string) bool {
 	if v == nil {
 		return false
@@ -136,9 +108,6 @@ func FirstNonEmptyString(v *viper.Viper, keys ...string) string {
 		}
 
 		return strings.Trim(parsed, `"'`)
-		//	if value := GetString(v, key); value != "" {
-		//		return value
-		//	}
 	}
 
 	return ""

--- a/pkg/vipertools/vipertools_test.go
+++ b/pkg/vipertools/vipertools_test.go
@@ -10,50 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCopyOnlySettings(t *testing.T) {
-	v := viper.New()
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
-	v.Set("api-url", "http://localhost:8080/api/v1")
-	v.Set("apiurl", "http://localhost:8080/api/v2")
-	v.Set("hostname", "localhost")
-	v.Set("proxy", "http://localhost:8080")
-	v.Set("ssl-certs-file", "/path/to/cert.pem")
-	v.Set("timeout", 30)
-	v.Set("no-ssl-verify", true)
-	v.Set("guess-language", true)
-	v.Set("exclude", []string{"node_modules", "vendor"})
-	v.Set("include", []string{"src", "lib"})
-	v.Set("exclude-unknown-project", true)
-	v.Set("include-only-with-project-file", true)
-	v.Set("hide-branch-names", true)
-	v.Set("hide-dependencies", true)
-	v.Set("hide-project-names", true)
-	v.Set("hide-file-names", true)
-	v.Set("hide-filenames", true)
-	v.Set("hidefilenames", true)
-	v.Set("hide-project-folder", true)
-	v.Set("disable-offline", false)
-	v.Set("disableoffline", false)
-	v.Set("heartbeat-rate-limit-seconds", 60)
-	v.Set("today-hide-categories", []string{"coding", "debugging"})
-
-	vdest := viper.New()
-	vipertools.CopyOnlySettings(v, vdest)
-
-	assert.Zero(t, len(vdest.AllKeys()))
-}
-
-func TestCopyOnlySettings_KeepSettings(t *testing.T) {
-	v := viper.New()
-	v.Set("key", "00000000-0000-4000-8000-000000000000")
-	v.Set("settings.api_key", "00000000-0000-4000-8000-000000000002")
-
-	vdest := viper.New()
-	vipertools.CopyOnlySettings(v, vdest)
-
-	assert.Equal(t, 1, len(vdest.AllKeys()))
-}
-
 func TestFirstNonEmptyBool(t *testing.T) {
 	v := viper.New()
 	v.Set("second", false)


### PR DESCRIPTION
This PR adds a new conditional when reading params that accepts the order it needs to follow. It solves the bug introduced with project-config file where settings takes precedence always.

The main change is on `params.go` with new `FlagReadOrder`. All functions that call params to load are using the default `FlagReadOrderFlagPrecedence` and there's only one place in the `handler.go` that uses `FlagReadOrderProjectConfigPrecedence`.