### PR TITLE
Fix panic for splitDrive

### DIFF
--- a/pkg/windows/windows.go
+++ b/pkg/windows/windows.go
@@ -259,7 +259,7 @@ func parseNetUseColumns(line string) (netUseColumns, error) {
 
 // splitDrive splits a filepath into the drive letter and the path.
 func splitDrive(fp string) (string, string) {
-	if fp[1:2] != ":" || !unicode.IsLetter(rune(fp[0])) {
+	if len(fp) < 2 || fp[1:2] != ":" || !unicode.IsLetter(rune(fp[0])) {
 		return "", fp
 	}
 

--- a/pkg/windows/windows_internal_test.go
+++ b/pkg/windows/windows_internal_test.go
@@ -182,6 +182,11 @@ func TestSplitDrive(t *testing.T) {
 			ExpectedDriveLetter: ``,
 			ExpectedPath:        `_:\\remotepc\share`,
 		},
+		"one character drive": {
+			Filepath:            `A`,
+			ExpectedDriveLetter: "",
+			ExpectedPath:        `A`,
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
This PR fixes a panic when filepath is less than 2 characters for `splitDrive()` in Windows.

```
runtime error: slice bounds out of range [:2] with length 1

goroutine 1 [running]:
runtime/debug.Stack()
C:/hostedtoolcache/windows/go/1.24.4/x64/src/runtime/debug/stack.go:26 +0x5e
github.com/wakatime/wakatime-cli/cmd.runCmd.func1()
D:/a/wakatime-cli/wakatime-cli/cmd/run.go:298 +0x12a
panic({0x7093a0?, 0xc000516858?})
C:/hostedtoolcache/windows/go/1.24.4/x64/src/runtime/panic.go:792 +0x132
github.com/wakatime/wakatime-cli/pkg/windows.splitDrive({0xa1c178?, 0x335060?})
D:/a/wakatime-cli/wakatime-cli/pkg/windows/windows.go:262 +0x90
github.com/wakatime/wakatime-cli/pkg/windows.toUncPath({0xa1c178, 0x1})
D:/a/wakatime-cli/wakatime-cli/pkg/windows/windows.go:111 +0x25
github.com/wakatime/wakatime-cli/pkg/windows.FormatLocalFilePath({0x0, 0x0}, {0xa1c178, 0x1})
D:/a/wakatime-cli/wakatime-cli/pkg/windows/windows.go:100 +0x85
github.com/wakatime/wakatime-cli/pkg/heartbeat.formatWindowsFilePath({0xa05b28?, 0xc00069ab40?}, 0xc00012d448)
D:/a/wakatime-cli/wakatime-cli/pkg/heartbeat/format.go:111 +0x188
github.com/wakatime/wakatime-cli/pkg/heartbeat.Format(...)
D:/a/wakatime-cli/wakatime-cli/pkg/heartbeat/format.go:46
github.com/wakatime/wakatime-cli/pkg/heartbeat.WithFormatting.func1.1({0xa05b28, 0xc00069ab40}, {0xc00052e3c0, 0x1, 0x1})
D:/a/wakatime-cli/wakatime-cli/pkg/heartbeat/format.go:31 +0x232
github.com/wakatime/wakatime-cli/cmd/offline.SaveHeartbeats.SaveHeartbeats.New.func3.func4(...)
D:/a/wakatime-cli/wakatime-cli/cmd/handler/handler.go:61
github.com/wakatime/wakatime-cli/cmd/offline.SaveHeartbeats({0xa05b28, 0xc00069ab40}, 0xc0000ba480, {0x0, 0x0, 0xc00000b4f8?}, {0xc000034480, 0x30})
D:/a/wakatime-cli/wakatime-cli/cmd/offline/offline.go:50 +0x843
github.com/wakatime/wakatime-cli/cmd/heartbeat.SendHeartbeats({0xa05b28, 0xc00069ab40}, 0xc0000ba480, {0xc000034480, 0x30})
D:/a/wakatime-cli/wakatime-cli/cmd/heartbeat/heartbeat.go:83 +0x2bc
github.com/wakatime/wakatime-cli/cmd/heartbeat.Run({0xa05b28, 0xc00069ab40}, 0xc0000ba480)
D:/a/wakatime-cli/wakatime-cli/cmd/heartbeat/heartbeat.go:35 +0xd2
github.com/wakatime/wakatime-cli/cmd.runCmd({0xa05b28, 0xc00069ab40}, 0xc0000ba480, 0x0, 0x0, 0x951460)
D:/a/wakatime-cli/wakatime-cli/cmd/run.go:316 +0x167
github.com/wakatime/wakatime-cli/cmd.RunCmdWithOfflineSync({0xa05b28, 0xc00069ab40}, 0xc0000ba480, 0x0, 0x0, 0x0?)
D:/a/wakatime-cli/wakatime-cli/cmd/run.go:271 +0x2c
github.com/wakatime/wakatime-cli/cmd.RunE(0xc0006fe008, 0xc0000ba480)
D:/a/wakatime-cli/wakatime-cli/cmd/run.go:140 +0x85a
github.com/wakatime/wakatime-cli/cmd.NewRootCMD.func1(0xc0000a1a00?, {0x743d5a?, 0x4?, 0x743d5e?})
D:/a/wakatime-cli/wakatime-cli/cmd/root.go:32 +0x17
github.com/spf13/cobra.(*Command).execute(0xc0006fe008, {0xc0000a0010, 0xf, 0xf})
C:/Users/runneradmin/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1015 +0xaaa
github.com/spf13/cobra.(*Command).ExecuteC(0xc0006fe008)
C:/Users/runneradmin/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1148 +0x46f
github.com/spf13/cobra.(*Command).Execute(...)
C:/Users/runneradmin/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1071
github.com/wakatime/wakatime-cli/cmd.Execute()
D:/a/wakatime-cli/wakatime-cli/cmd/root.go:301 +0x18
main.main()
D:/a/wakatime-cli/wakatime-cli/main.go:6 +0xf
```