### PR TITLE
Upgrade wsl to wsl_v5

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,7 +19,7 @@ linters:
     - usestdlibvars
     - usetesting
     - whitespace
-    - wsl
+    - wsl_v5
   settings:
     revive:
       rules:


### PR DESCRIPTION
```
WARN The linter 'wsl' is deprecated (since v2.2.0) due to: new major version. Replaced by wsl_v5. 
WARN [linter] `allow-multiline-assign` is deprecated and always allowed in wsl >= v5 
```