### PR TITLE
Upgrade wsl to wsl_v5

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,7 +19,7 @@ linters:
     - usestdlibvars
     - usetesting
     - whitespace
-    - wsl
+    - wsl_v5
   settings:
     revive:
       rules:
@@ -58,6 +58,10 @@ linters:
     usetesting:
       os-setenv: true
       os-temp-dir: true
+    wsl_v5:
+      allow-first-in-block: true
+      allow-whole-block: false
+      branch-max-lines: 2
   exclusions:
     generated: lax
     rules:

--- a/cmd/fileexperts/fileexperts_test.go
+++ b/cmd/fileexperts/fileexperts_test.go
@@ -74,6 +74,7 @@ func TestFileExperts(t *testing.T) {
 
 		f, err := os.Open("testdata/api_file_experts_response.json")
 		require.NoError(t, err)
+
 		defer f.Close()
 
 		_, err = io.Copy(w, f)

--- a/cmd/offlinecount/offlinecount_test.go
+++ b/cmd/offlinecount/offlinecount_test.go
@@ -49,8 +49,10 @@ func TestOfflineCount_Empty(t *testing.T) {
 	// copy the output in a separate goroutine so printing can't block indefinitely
 	go func() {
 		var buf bytes.Buffer
+
 		_, err = io.Copy(&buf, r)
 		require.NoError(t, err)
+
 		outC <- buf.String()
 	}()
 
@@ -109,8 +111,10 @@ func TestOfflineCount(t *testing.T) {
 	// copy the output in a separate goroutine so printing can't block indefinitely
 	go func() {
 		var buf bytes.Buffer
+
 		_, err = io.Copy(&buf, r)
 		require.NoError(t, err)
+
 		outC <- buf.String()
 	}()
 

--- a/cmd/offlineprint/offlineprint_test.go
+++ b/cmd/offlineprint/offlineprint_test.go
@@ -62,8 +62,10 @@ func TestPrintOfflineHeartbeats(t *testing.T) {
 	// copy the output in a separate goroutine so printing can't block indefinitely
 	go func() {
 		var buf bytes.Buffer
+
 		_, err = io.Copy(&buf, r)
 		require.NoError(t, err)
+
 		outC <- buf.String()
 	}()
 
@@ -102,8 +104,10 @@ func TestPrintOfflineHeartbeats_Empty(t *testing.T) {
 	// copy the output in a separate goroutine so printing can't block indefinitely
 	go func() {
 		var buf bytes.Buffer
+
 		_, err = io.Copy(&buf, r)
 		require.NoError(t, err)
+
 		outC <- buf.String()
 	}()
 

--- a/cmd/offlinesync/offlinesync_internal_test.go
+++ b/cmd/offlinesync/offlinesync_internal_test.go
@@ -52,6 +52,7 @@ func TestSyncOfflineActivityLegacy(t *testing.T) {
 
 		f, err := os.Open("testdata/api_heartbeats_response.json")
 		require.NoError(t, err)
+
 		defer f.Close()
 
 		_, err = io.Copy(w, f)

--- a/cmd/offlinesync/offlinesync_test.go
+++ b/cmd/offlinesync/offlinesync_test.go
@@ -61,6 +61,7 @@ func TestRunWithRateLimiting(t *testing.T) {
 
 		f, err := os.Open("testdata/api_heartbeats_response.json")
 		require.NoError(t, err)
+
 		defer f.Close()
 
 		_, err = io.Copy(w, f)
@@ -153,6 +154,7 @@ func TestRunWithoutRateLimiting(t *testing.T) {
 
 		f, err := os.Open("testdata/api_heartbeats_response.json")
 		require.NoError(t, err)
+
 		defer f.Close()
 
 		_, err = io.Copy(w, f)
@@ -259,6 +261,7 @@ func TestSyncOfflineActivity(t *testing.T) {
 
 		f, err := os.Open("testdata/api_heartbeats_response.json")
 		require.NoError(t, err)
+
 		defer f.Close()
 
 		_, err = io.Copy(w, f)
@@ -336,6 +339,7 @@ func TestSyncOfflineActivity_MultipleApiKey(t *testing.T) {
 		// send response
 		f, err := os.Open("testdata/api_heartbeats_response.json")
 		require.NoError(t, err)
+
 		defer f.Close()
 
 		w.WriteHeader(http.StatusCreated)

--- a/cmd/today/today_test.go
+++ b/cmd/today/today_test.go
@@ -47,6 +47,7 @@ func TestToday(t *testing.T) {
 
 		f, err := os.Open("testdata/api_statusbar_today_response.json")
 		require.NoError(t, err)
+
 		defer f.Close()
 
 		_, err = io.Copy(w, f)

--- a/cmd/todaygoal/todaygoal_test.go
+++ b/cmd/todaygoal/todaygoal_test.go
@@ -48,6 +48,7 @@ func TestGoal(t *testing.T) {
 
 			f, err := os.Open("testdata/api_goals_id_response.json")
 			require.NoError(t, err)
+
 			defer f.Close()
 
 			_, err = io.Copy(w, f)

--- a/main_test.go
+++ b/main_test.go
@@ -1412,9 +1412,11 @@ func runCmd(cmd *exec.Cmd, buffer *bytes.Buffer) string {
 	cmd.Stdin = buffer
 
 	var stdout bytes.Buffer
+
 	cmd.Stdout = &stdout
 
 	var stderr bytes.Buffer
+
 	cmd.Stderr = &stderr
 
 	err := cmd.Run()
@@ -1433,9 +1435,11 @@ func runCmdExpectErr(cmd *exec.Cmd) (string, int) {
 	fmt.Println(cmd.String())
 
 	var stdout bytes.Buffer
+
 	cmd.Stdout = &stdout
 
 	var stderr bytes.Buffer
+
 	cmd.Stderr = &stderr
 
 	err := cmd.Run()

--- a/pkg/api/goal_test.go
+++ b/pkg/api/goal_test.go
@@ -61,6 +61,7 @@ func TestClient_GoalWithTimeout(t *testing.T) {
 	router.HandleFunc(
 		"/users/current/goals/00000000-0000-4000-8000-000000000000", func(_ http.ResponseWriter, _ *http.Request) {
 			<-block
+
 			called <- struct{}{}
 		})
 
@@ -75,6 +76,7 @@ func TestClient_GoalWithTimeout(t *testing.T) {
 	assert.True(t, strings.Contains(err.Error(), "Timeout"), errMsg)
 
 	close(block)
+
 	select {
 	case <-called:
 		break

--- a/pkg/api/statusbar_test.go
+++ b/pkg/api/statusbar_test.go
@@ -60,6 +60,7 @@ func TestClient_StatusBarWithTimeout(t *testing.T) {
 
 	router.HandleFunc("/users/current/statusbar/today", func(_ http.ResponseWriter, _ *http.Request) {
 		<-block
+
 		called <- struct{}{}
 	})
 
@@ -73,6 +74,7 @@ func TestClient_StatusBarWithTimeout(t *testing.T) {
 	assert.True(t, strings.Contains(err.Error(), "Timeout"), errMsg)
 
 	close(block)
+
 	select {
 	case <-called:
 		break

--- a/pkg/heartbeat/category_test.go
+++ b/pkg/heartbeat/category_test.go
@@ -82,6 +82,7 @@ func TestCategory_MarshalJSON(t *testing.T) {
 
 func TestCategory_MarshalJSON_DefaultCategory(t *testing.T) {
 	var c heartbeat.Category
+
 	data, err := json.Marshal(c)
 	require.NoError(t, err)
 	assert.JSONEq(t, `null`, string(data))

--- a/pkg/lexer/ecl.go
+++ b/pkg/lexer/ecl.go
@@ -30,7 +30,6 @@ func (l ECL) Lexer() chroma.Lexer {
 	lexer.SetAnalyser(func(text string) float32 { // nolint:wsl
 		// This is very difficult to guess relative to other business languages.
 		// -> in conjunction with BEGIN/END seems relatively rare though.
-
 		var result float32
 
 		if strings.Contains(text, "->") {

--- a/pkg/log/writer.go
+++ b/pkg/log/writer.go
@@ -32,6 +32,7 @@ func (d *DynamicWriteSyncer) Sync() error {
 func (d *DynamicWriteSyncer) SetWriter(newWriter zapcore.WriteSyncer) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
+
 	d.writer = newWriter
 }
 

--- a/pkg/project/subversion.go
+++ b/pkg/project/subversion.go
@@ -62,8 +62,8 @@ func svnInfo(fp string, binary string) (map[string]string, bool, error) {
 	}
 
 	cmd := exec.Command(binary, "info", fp)
-	out, err := cmd.Output()
 
+	out, err := cmd.Output()
 	if err != nil {
 		return nil, false, fmt.Errorf("error getting svn info: %s", err)
 	}

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -242,6 +242,7 @@ func (c Client) DownloadFileFallback(ctx context.Context, localFile string) erro
 	cmd := exec.CommandContext(ctx, "scp", "-B", fmt.Sprintf("%s:%s", c.OriginalHost, c.Path), localFile) // nolint:gosec
 
 	var stderr bytes.Buffer
+
 	cmd.Stderr = &stderr
 
 	if err := cmd.Run(); err != nil {


### PR DESCRIPTION
```
WARN The linter 'wsl' is deprecated (since v2.2.0) due to: new major version. Replaced by wsl_v5.
WARN [linter] `allow-multiline-assign` is deprecated and always allowed in wsl >= v5
WARN Suggested new configuration:
linters:
  enable:
    - wsl_v5
  settings:
    wsl_v5:
      allow-first-in-block: true
      allow-whole-block: false
      branch-max-lines: 2
```

I updated `wsl` to `wsl_v5` and added the suggested configuration.

Some new lines were added automatically by wsl_v5.