### PR TITLE
Fix flakey test

### DIFF
--- a/pkg/ratelimit/ratelimit_test.go
+++ b/pkg/ratelimit/ratelimit_test.go
@@ -90,5 +90,5 @@ func TestRateLimitReset(t *testing.T) {
 	lastSentAt, err := writer.File.Section("internal").Key("heartbeats_last_sent_at").TimeFormat(ini.DateFormat)
 	require.NoError(t, err)
 
-	assert.WithinDuration(t, time.Now(), lastSentAt, 1*time.Second)
+	assert.WithinDuration(t, time.Now(), lastSentAt, 2*time.Second)
 }


### PR DESCRIPTION
Changes the buffer from 1 second to 2 seconds when comparing the timestamp.