### PR TITLE
Detect project from project-folder arg

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -51,7 +51,7 @@ func TestSendHeartbeats_EntityFileInTempDir(t *testing.T) {
 
 	copyFile(t, "testdata/main.go", filepath.Join(tmpDir, "testdata", "main.go"))
 
-	testSendHeartbeats(t, tmpDir, filepath.Join(tmpDir, "testdata", "main.go"), "")
+	testSendHeartbeats(t, tmpDir, filepath.Join(tmpDir, "testdata", "main.go"), filepath.Base(tmpDir))
 }
 
 func testSendHeartbeats(t *testing.T, projectFolder, entity, prj string) {

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -145,7 +145,7 @@ func WithDetection(config Config) heartbeat.HandleOption {
 			for n, h := range hh {
 				logger.Debugf("execute project detection for: %s", h.Entity)
 
-				// first, use .wakatime-project or [projectmap] section with entity path.
+				// First use .wakatime-project or [projectmap] section with entity path.
 				// Then, detect with project folder. This tries to use the same project name
 				// across all IDEs instead of sometimes using alternate project when file is unsaved
 				result, detector := Detect(ctx, config.MapPatterns,
@@ -153,13 +153,13 @@ func WithDetection(config Config) heartbeat.HandleOption {
 					DetecterArg{Filepath: h.ProjectPathOverride, ShouldRun: true},
 				)
 
-				// second, use project override
+				// Project override
 				if result.Project == "" && h.ProjectOverride != "" {
 					result.Project = h.ProjectOverride
 					result.Folder = h.ProjectPathOverride
 				}
 
-				// third, autodetect with revision control with entity path.
+				// Autodetect with revision control from entity path.
 				// Then, autodetect with project folder. This tries to use the same project name
 				// across all IDEs instead of sometimes using alternate project when file is unsaved
 				if result.Project == "" || result.Branch == "" || result.Folder == "" {
@@ -177,21 +177,32 @@ func WithDetection(config Config) heartbeat.HandleOption {
 					result.Folder = firstNonEmptyString(result.Folder, revControlResult.Folder)
 				}
 
-				// fourth, use alternate project
-				if result.Project == "" && h.ProjectAlternate != "" {
-					result.Project = h.ProjectAlternate
-					result.Folder = firstNonEmptyString(h.ProjectPathOverride, result.Folder)
+				// Use project folder last part as project name
+				if result.Project == "" && h.ProjectPathOverride != "" {
+					folder := filepath.Base(h.ProjectPathOverride)
+					if runtime.GOOS == "windows" && folder != "" {
+						folder = windows.FormatFilePath(folder)
+					}
+
+					if folder != "." && folder != "/" {
+						result.Project = folder
+					}
 				}
 
-				// fifth, use alternate branch
+				// Alternate project if none auto-detected
+				if result.Project == "" && h.ProjectAlternate != "" {
+					result.Project = h.ProjectAlternate
+				}
+
+				// Alternate branch if none detected
 				if result.Branch == "" && h.BranchAlternate != "" {
 					result.Branch = h.BranchAlternate
 				}
 
-				// sixth, use project folder found or entity's path
+				// Make sure project folder is defined when not found from entity's path
 				result.Folder = firstNonEmptyString(result.Folder, h.ProjectPathOverride)
 
-				// seventh, if no folder is found, use entity's directory
+				// If no folder found, use entity's directory
 				if h.EntityType == heartbeat.FileType && result.Folder == "" {
 					result.Folder = filepath.Dir(h.Entity)
 				}
@@ -200,7 +211,7 @@ func WithDetection(config Config) heartbeat.HandleOption {
 					result.Folder = windows.FormatFilePath(result.Folder)
 				}
 
-				// finally, obfuscate project name if necessary
+				// Obfuscate project name if necessary
 				if heartbeat.ShouldSanitize(ctx, heartbeat.SanitizeCheck{
 					Entity:              h.Entity,
 					ProjectPath:         result.Folder,
@@ -212,7 +223,7 @@ func WithDetection(config Config) heartbeat.HandleOption {
 
 				result.Folder = FormatProjectFolder(ctx, result.Folder)
 
-				// count total subfolders in project's path
+				// Count total subfolders in project's path
 				if result.Folder != "" && strings.HasPrefix(h.Entity, result.Folder) {
 					subfolders := CountSlashesInProjectFolder(result.Folder)
 					if subfolders > 0 {

--- a/pkg/project/project_test.go
+++ b/pkg/project/project_test.go
@@ -88,6 +88,22 @@ func TestWithDetection_EntityNotFile(t *testing.T) {
 				ProjectOverride: "billing",
 			},
 		},
+		"entity not file project folder takes precedence": {
+			Heartbeats: []heartbeat.Heartbeat{
+				{
+					EntityType:          heartbeat.AppType,
+					ProjectAlternate:    "pci",
+					ProjectPathOverride: "/home/user/projects/proj-from-folder/",
+				},
+			},
+			Expected: heartbeat.Heartbeat{
+				Branch:              heartbeat.PointerTo(""),
+				EntityType:          heartbeat.AppType,
+				Project:             heartbeat.PointerTo("proj-from-folder"),
+				ProjectAlternate:    "pci",
+				ProjectPathOverride: "/home/user/projects/proj-from-folder/",
+			},
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
When we have a project folder, use it.

This uses the last part of `--project-folder` as the project name when one can't be auto-detected.