### PR TITLE
Detect git project when only have project folder

### DIFF
--- a/pkg/project/git.go
+++ b/pkg/project/git.go
@@ -29,11 +29,6 @@ func (g Git) Detect(ctx context.Context) (Result, bool, error) {
 	logger := log.Extract(ctx)
 	fp := g.Filepath
 
-	// Take only the directory
-	if fileOrDirExists(fp) {
-		fp = filepath.Dir(fp)
-	}
-
 	// Find for submodule takes priority if enabled
 	gitdirSubmodule, ok, err := findSubmodule(ctx, fp, g.SubmoduleDisabledPatterns)
 	if err != nil {


### PR DESCRIPTION
When `--entity-type app` but we have `--project-folder` we should detect the project from Git, so don't assume the input path is always a file.