### PR TITLE
Add compact output option for today summaries

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -32,6 +32,7 @@ include_only_with_project_file = false
 exclude_unknown_project = false
 status_bar_enabled = true
 status_bar_coding_activity = true
+compact = false
 status_bar_hide_categories = false
 status_bar_max_categories = 0
 offline = true
@@ -100,6 +101,7 @@ Notice how you have to include the exclude patterns from your main `~/.wakatime.
 | exclude_unknown_project        | When set, any activity where the project cannot be detected will be ignored. | _bool_ | `false` |
 | status_bar_enabled             | Turns on wakatime status bar for certain editors. | _bool_ | `true` |
 | status_bar_coding_activity     | Enables displaying Today's code stats in the status bar of some editors. When false, only the WakaTime icon is displayed in the status bar. | _bool_ | `true` |
+| compact                        | When `true`, use compact output | _bool_ | `false` |
 | status_bar_hide_categories     | When `true`, --today only displays the total code stats, never displaying Categories in the output. | _bool_ | `false` |
 | status_bar_max_categories      | When greater than zero, limits the number of categories displayed in the status bar. | _int_ | `0` |
 | offline                        | Enables saving code stats locally to ~/.wakatime/offline_heartbeats.bdb when offline, and syncing to the dashboard later when back online. | _bool_ | `true` |

--- a/USAGE.md
+++ b/USAGE.md
@@ -32,7 +32,6 @@ include_only_with_project_file = false
 exclude_unknown_project = false
 status_bar_enabled = true
 status_bar_coding_activity = true
-compact = false
 status_bar_hide_categories = false
 status_bar_max_categories = 0
 offline = true
@@ -45,6 +44,7 @@ log_file =
 import_cfg = /path/to/another/wakatime.cfg
 metrics = true
 guess_language = true
+compact = false
 
 [projectmap]
 projects/foo = new project name

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -262,6 +262,7 @@ func setFlags(cmd *cobra.Command, v *viper.Viper) {
 	)
 	flags.Float64("time", 0, "Optional floating-point unix epoch timestamp. Uses current time by default.")
 	flags.Bool("today", false, "Prints dashboard time for today, then exits.")
+	flags.String("compact", "", "Enables compact output. Defaults to false.")
 	flags.String("today-hide-categories", "", "When optionally included with --today, causes output to"+
 		" show total code time today without categories. Defaults to false.")
 	flags.String(

--- a/cmd/today/today.go
+++ b/cmd/today/today.go
@@ -58,7 +58,13 @@ func Today(ctx context.Context, v *viper.Viper) (string, error) {
 		return "", fmt.Errorf("failed fetching today from api: %w", err)
 	}
 
-	output, err := summary.RenderToday(s, paramStatusBar.HideCategories, paramStatusBar.MaxCategories, paramStatusBar.Output)
+	output, err := summary.RenderToday(
+		s,
+		paramStatusBar.Compact,
+		paramStatusBar.HideCategories,
+		paramStatusBar.MaxCategories,
+		paramStatusBar.Output,
+	)
 	if err != nil {
 		return "", fmt.Errorf("failed generating today output: %s", err)
 	}

--- a/pkg/params/params.go
+++ b/pkg/params/params.go
@@ -150,6 +150,20 @@ var (
 		FlagReadOrderFlagPrecedence:          {"today-hide-categories", "settings.status_bar_hide_categories"},
 		FlagReadOrderProjectConfigPrecedence: {"settings.status_bar_hide_categories", "today-hide-categories"},
 	}
+	compactOrder = map[FlagReadOrder][]string{
+		FlagReadOrderFlagPrecedence: {
+			"compact",
+			"today-compact", // legacy alias
+			"settings.compact",
+			"settings.status_bar_compact", // legacy alias
+		},
+		FlagReadOrderProjectConfigPrecedence: {
+			"settings.compact",
+			"settings.status_bar_compact", // legacy alias
+			"compact",
+			"today-compact", // legacy alias
+		},
+	}
 	todayMaxCategoriesOrder = map[FlagReadOrder][]string{
 		FlagReadOrderFlagPrecedence:          {"today-max-categories", "settings.status_bar_max_categories"},
 		FlagReadOrderProjectConfigPrecedence: {"settings.status_bar_max_categories", "today-max-categories"},
@@ -265,6 +279,7 @@ type (
 
 	// StatusBar contains status bar related parameters.
 	StatusBar struct {
+		Compact        bool
 		HideCategories bool
 		MaxCategories  int
 		Output         output.Output
@@ -805,6 +820,17 @@ func LoadOfflineParams(ctx context.Context, v *viper.Viper, order FlagReadOrder)
 
 // LoadStatusBarParams loads status bar params from viper.Viper instance.
 func LoadStatusBarParams(v *viper.Viper, order FlagReadOrder) (StatusBar, error) {
+	var compact bool
+
+	if compactStr := vipertools.FirstNonEmptyString(v, compactOrder[order]...); compactStr != "" {
+		val, err := strconv.ParseBool(compactStr)
+		if err != nil {
+			return StatusBar{}, fmt.Errorf("failed to parse today-compact: %s", err)
+		}
+
+		compact = val
+	}
+
 	var hideCategories bool
 
 	if hideCategoriesStr := vipertools.FirstNonEmptyString(v, todayHideCategoriesOrder[order]...); hideCategoriesStr != "" {
@@ -843,6 +869,7 @@ func LoadStatusBarParams(v *viper.Viper, order FlagReadOrder) (StatusBar, error)
 	}
 
 	return StatusBar{
+		Compact:        compact,
 		HideCategories: hideCategories,
 		MaxCategories:  maxCategories,
 		Output:         out,
@@ -1269,7 +1296,8 @@ func (p SanitizeParams) String() string {
 // String implements fmt.Stringer interface.
 func (p StatusBar) String() string {
 	return fmt.Sprintf(
-		"hide categories: %t, max categories: %d, output: '%s'",
+		"compact: %t, hide categories: %t, max categories: %d, output: '%s'",
+		p.Compact,
 		p.HideCategories,
 		p.MaxCategories,
 		p.Output,

--- a/pkg/params/params.go
+++ b/pkg/params/params.go
@@ -153,15 +153,11 @@ var (
 	compactOrder = map[FlagReadOrder][]string{
 		FlagReadOrderFlagPrecedence: {
 			"compact",
-			"today-compact", // legacy alias
 			"settings.compact",
-			"settings.status_bar_compact", // legacy alias
 		},
 		FlagReadOrderProjectConfigPrecedence: {
 			"settings.compact",
-			"settings.status_bar_compact", // legacy alias
 			"compact",
-			"today-compact", // legacy alias
 		},
 	}
 	todayMaxCategoriesOrder = map[FlagReadOrder][]string{
@@ -825,7 +821,7 @@ func LoadStatusBarParams(v *viper.Viper, order FlagReadOrder) (StatusBar, error)
 	if compactStr := vipertools.FirstNonEmptyString(v, compactOrder[order]...); compactStr != "" {
 		val, err := strconv.ParseBool(compactStr)
 		if err != nil {
-			return StatusBar{}, fmt.Errorf("failed to parse today-compact: %s", err)
+			return StatusBar{}, fmt.Errorf("failed to parse compact: %s", err)
 		}
 
 		compact = val

--- a/pkg/params/params_test.go
+++ b/pkg/params/params_test.go
@@ -2881,6 +2881,27 @@ func TestLoadStatusBarParams_HideCategories_ConfigTakesPrecedence(t *testing.T) 
 	assert.True(t, params.HideCategories)
 }
 
+func TestLoadStatusBarParams_Compact_FlagTakesPrecedence(t *testing.T) {
+	v := vipertools.MustNew()
+	v.Set("compact", false)
+	v.Set("settings.compact", true)
+
+	params, err := paramspkg.LoadStatusBarParams(v, paramspkg.FlagReadOrderFlagPrecedence)
+	require.NoError(t, err)
+
+	assert.False(t, params.Compact)
+}
+
+func TestLoadStatusBarParams_Compact_ConfigTakesPrecedence(t *testing.T) {
+	v := vipertools.MustNew()
+	v.Set("settings.compact", true)
+
+	params, err := paramspkg.LoadStatusBarParams(v, paramspkg.FlagReadOrderFlagPrecedence)
+	require.NoError(t, err)
+
+	assert.True(t, params.Compact)
+}
+
 func TestLoadStatusBarParams_Output(t *testing.T) {
 	tests := map[string]output.Output{
 		"text": output.TextOutput,
@@ -3199,7 +3220,7 @@ func TestStatusBar_String(t *testing.T) {
 
 	assert.Equal(
 		t,
-		"hide categories: true, max categories: 0, output: 'json'",
+		"compact: false, hide categories: true, max categories: 0, output: 'json'",
 		statusbar.String(),
 	)
 }

--- a/pkg/remote/remote_test.go
+++ b/pkg/remote/remote_test.go
@@ -117,6 +117,7 @@ func TestWithDetection_SshConfig_Hostname(t *testing.T) {
 				},
 			}, hh)
 			assert.Contains(t, hh[0].LocalFile, "main.go")
+
 			return []heartbeat.Result{
 				{
 					Status:    201,
@@ -286,6 +287,7 @@ func TestWithDetection_SshConfig_UserKnownHostsFile_Match(t *testing.T) {
 				},
 			}, hh)
 			assert.Contains(t, hh[0].LocalFile, "main.go")
+
 			return []heartbeat.Result{
 				{
 					Status:    201,

--- a/pkg/summary/summary.go
+++ b/pkg/summary/summary.go
@@ -158,7 +158,7 @@ type (
 // RenderToday generates a text representation from summary of the current day.
 // If out is set to output.RawJSONOutput or output.JSONOutput, the summary will be marshaled to JSON.
 // Expects exactly one summary for the current day. Will return an error otherwise.
-func RenderToday(summary *Summary, hideCategories bool, maxCategories int, out output.Output) (string, error) {
+func RenderToday(summary *Summary, compact bool, hideCategories bool, maxCategories int, out output.Output) (string, error) {
 	if summary == nil {
 		return "", errors.New("no summary found for the current day")
 	}
@@ -179,7 +179,7 @@ func RenderToday(summary *Summary, hideCategories bool, maxCategories int, out o
 		}
 
 		s := simplified{
-			Text:            getText(summary, hideCategories, maxCategories),
+			Text:            getText(summary, compact, hideCategories, maxCategories),
 			HasTeamFeatures: summary.HasTeamFeatures,
 		}
 
@@ -191,11 +191,11 @@ func RenderToday(summary *Summary, hideCategories bool, maxCategories int, out o
 		return string(data), nil
 	}
 
-	return getText(summary, hideCategories, maxCategories), nil
+	return getText(summary, compact, hideCategories, maxCategories), nil
 }
 
-func getText(summary *Summary, hideCategories bool, maxCategories int) string {
-	if len(summary.Data.Categories) < 2 || hideCategories {
+func getText(summary *Summary, compact bool, hideCategories bool, maxCategories int) string {
+	if compact || len(summary.Data.Categories) < 2 || hideCategories {
 		return summary.Data.GrandTotal.Text
 	}
 

--- a/pkg/summary/summary_test.go
+++ b/pkg/summary/summary_test.go
@@ -14,6 +14,7 @@ import (
 
 func TestRenderToday(t *testing.T) {
 	tests := map[string]struct {
+		Compact       bool
 		Output        output.Output
 		MaxCategories int
 		Expected      string
@@ -33,10 +34,22 @@ func TestRenderToday(t *testing.T) {
 			MaxCategories: 1,
 			Expected:      "2 hrs 17 mins Coding",
 		},
+		"text output compact": {
+			Compact:       true,
+			Output:        output.TextOutput,
+			MaxCategories: 2,
+			Expected:      "2 hrs 17 mins",
+		},
 		"json output": {
 			Output:        output.JSONOutput,
 			MaxCategories: 0,
 			Expected:      readFile(t, "testdata/statusbar_today_simplified.json"),
+		},
+		"json output compact": {
+			Compact:       true,
+			Output:        output.JSONOutput,
+			MaxCategories: 0,
+			Expected:      `{"text":"2 hrs 17 mins","has_team_features":true}`,
 		},
 		"json output truncated 2": {
 			Output:        output.JSONOutput,
@@ -63,7 +76,7 @@ func TestRenderToday(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			s := testSummary()
-			rendered, err := summary.RenderToday(s, false, test.MaxCategories, test.Output)
+			rendered, err := summary.RenderToday(s, test.Compact, false, test.MaxCategories, test.Output)
 			require.NoError(t, err)
 
 			assert.Equal(t, test.Expected, rendered)
@@ -75,7 +88,7 @@ func TestRenderToday_OneCategory(t *testing.T) {
 	s := testSummary()
 	s.Data.Categories = s.Data.Categories[:1]
 
-	rendered, err := summary.RenderToday(s, false, 1, output.TextOutput)
+	rendered, err := summary.RenderToday(s, false, false, 1, output.TextOutput)
 	require.NoError(t, err)
 
 	assert.Equal(t, "2 hrs 17 mins", rendered)
@@ -84,7 +97,7 @@ func TestRenderToday_OneCategory(t *testing.T) {
 func TestRenderToday_OneCategoryTruncated(t *testing.T) {
 	s := testSummary()
 
-	rendered, err := summary.RenderToday(s, false, 1, output.TextOutput)
+	rendered, err := summary.RenderToday(s, false, false, 1, output.TextOutput)
 	require.NoError(t, err)
 
 	assert.Equal(t, "2 hrs 17 mins Coding", rendered)
@@ -93,14 +106,14 @@ func TestRenderToday_OneCategoryTruncated(t *testing.T) {
 func TestRenderToday_Truncated(t *testing.T) {
 	s := testSummary()
 
-	rendered, err := summary.RenderToday(s, false, 2, output.TextOutput)
+	rendered, err := summary.RenderToday(s, false, false, 2, output.TextOutput)
 	require.NoError(t, err)
 
 	assert.Equal(t, "2 hrs 17 mins Coding, 7 secs Debugging...", rendered)
 }
 
 func TestRenderToday_MultipleCategoriesHidden(t *testing.T) {
-	rendered, err := summary.RenderToday(testSummary(), true, 0, output.TextOutput)
+	rendered, err := summary.RenderToday(testSummary(), false, true, 0, output.TextOutput)
 	require.NoError(t, err)
 
 	assert.Equal(t, "2 hrs 17 mins", rendered)


### PR DESCRIPTION
This PR adds a new compact output option that currently only affects the `--today` status bar output (I personally only care about this, but this could be used for other things in the future). This option can be set via the `--compact` flag or the `compact` setting in the `.wakatime` file. When enabled, today summaries return only the total time in text and JSON outputs instead of category breakdowns, reducing noisy status bar displays.

Includes documentation in USAGE and tests covering parameter loading precedence and summary rendering in both text and JSON modes. No behavior change occurs unless compact is explicitly enabled.