### PR TITLE
Prevent many random project names on project file write error

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -21,7 +21,7 @@ jobs:
         name: Checkout
         uses: actions/checkout@v4
       -
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: ${{ env.GO_VERSION_FILE }}
           check-latest: ${{ env.CHECK_LATEST }}
@@ -56,7 +56,7 @@ jobs:
         name: Checkout
         uses: actions/checkout@v4
       -
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: ${{ env.GO_VERSION_FILE }}
           check-latest: ${{ env.CHECK_LATEST }}
@@ -81,7 +81,7 @@ jobs:
         name: Checkout
         uses: actions/checkout@v4
       -
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: ${{ env.GO_VERSION_FILE }}
           check-latest: ${{ env.CHECK_LATEST }}
@@ -107,7 +107,7 @@ jobs:
         name: Checkout
         uses: actions/checkout@v4
       -
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: ${{ env.GO_VERSION_FILE }}
           check-latest: ${{ env.CHECK_LATEST }}
@@ -132,7 +132,7 @@ jobs:
         name: Checkout
         uses: actions/checkout@v4
       -
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: ${{ env.GO_VERSION_FILE }}
           check-latest: ${{ env.CHECK_LATEST }}
@@ -158,7 +158,7 @@ jobs:
         name: Checkout
         uses: actions/checkout@v4
       -
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: ${{ env.GO_VERSION_FILE }}
           check-latest: ${{ env.CHECK_LATEST }}
@@ -207,7 +207,7 @@ jobs:
         name: Checkout
         uses: actions/checkout@v4
       -
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: ${{ env.GO_VERSION_FILE }}
           check-latest: ${{ env.CHECK_LATEST }}
@@ -273,7 +273,7 @@ jobs:
         uses: actions/checkout@v4
       -
         name: Setup go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: ${{ env.GO_VERSION_FILE }}
           check-latest: ${{ env.CHECK_LATEST }}
@@ -321,7 +321,7 @@ jobs:
         uses: actions/checkout@v4
       -
         name: Setup go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: ${{ env.GO_VERSION_FILE }}
           check-latest: ${{ env.CHECK_LATEST }}
@@ -362,7 +362,7 @@ jobs:
         uses: actions/checkout@v4
       -
         name: Setup go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: ${{ env.GO_VERSION_FILE }}
           check-latest: ${{ env.CHECK_LATEST }}
@@ -403,7 +403,7 @@ jobs:
         uses: actions/checkout@v4
       -
         name: Setup go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: ${{ env.GO_VERSION_FILE }}
           check-latest: ${{ env.CHECK_LATEST }}
@@ -444,7 +444,7 @@ jobs:
         uses: actions/checkout@v4
       -
         name: Setup go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: ${{ env.GO_VERSION_FILE }}
           check-latest: ${{ env.CHECK_LATEST }}
@@ -485,7 +485,7 @@ jobs:
         uses: actions/checkout@v4
       -
         name: Setup go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: ${{ env.GO_VERSION_FILE }}
           check-latest: ${{ env.CHECK_LATEST }}
@@ -526,7 +526,7 @@ jobs:
         uses: actions/checkout@v4
       -
         name: Setup go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: ${{ env.GO_VERSION_FILE }}
           check-latest: ${{ env.CHECK_LATEST }}

--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,7 @@ lint: install-linter
 .PHONY: vulncheck
 vulncheck:
 	go install golang.org/x/vuln/cmd/govulncheck@latest
-	./bin/govulncheck-with-excludes.sh ./...
+	govulncheck
 
 .PHONY: test
 test:

--- a/cmd/fileexperts/fileexperts_test.go
+++ b/cmd/fileexperts/fileexperts_test.go
@@ -12,10 +12,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/wakatime/wakatime-cli/cmd"
 	"github.com/wakatime/wakatime-cli/cmd/fileexperts"
 	"github.com/wakatime/wakatime-cli/pkg/api"
 	"github.com/wakatime/wakatime-cli/pkg/log"
+	"github.com/wakatime/wakatime-cli/pkg/log/setup"
 	"github.com/wakatime/wakatime-cli/pkg/project"
 
 	"github.com/spf13/viper"
@@ -111,7 +111,7 @@ func TestFileExperts_NonExistingEntity(t *testing.T) {
 	v.Set("log-file", logFile.Name())
 	v.Set("verbose", true)
 
-	logger, err := cmd.SetupLogging(ctx, v)
+	logger, err := setup.Logging(ctx, v)
 	require.NoError(t, err)
 
 	defer logger.Flush()

--- a/cmd/heartbeat/heartbeat_test.go
+++ b/cmd/heartbeat/heartbeat_test.go
@@ -14,13 +14,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/wakatime/wakatime-cli/cmd"
 	cmdheartbeat "github.com/wakatime/wakatime-cli/cmd/heartbeat"
 	"github.com/wakatime/wakatime-cli/pkg/api"
 	"github.com/wakatime/wakatime-cli/pkg/file"
 	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 	"github.com/wakatime/wakatime-cli/pkg/ini"
 	"github.com/wakatime/wakatime-cli/pkg/log"
+	"github.com/wakatime/wakatime-cli/pkg/log/setup"
 	"github.com/wakatime/wakatime-cli/pkg/offline"
 	"github.com/wakatime/wakatime-cli/pkg/params"
 	"github.com/wakatime/wakatime-cli/pkg/project"
@@ -560,7 +560,7 @@ func TestSendHeartbeats_ExtraHeartbeatsNestedError(t *testing.T) {
 	v.Set("log-file", logFile.Name())
 	v.Set("verbose", true)
 
-	logger, err := cmd.SetupLogging(ctx, v)
+	logger, err := setup.Logging(ctx, v)
 	require.NoError(t, err)
 
 	defer logger.Flush()
@@ -748,7 +748,7 @@ func TestSendHeartbeats_NonExistingEntity(t *testing.T) {
 	v.Set("log-file", logFile.Name())
 	v.Set("verbose", true)
 
-	logger, err := cmd.SetupLogging(ctx, v)
+	logger, err := setup.Logging(ctx, v)
 	require.NoError(t, err)
 
 	defer logger.Flush()
@@ -883,7 +883,7 @@ func TestSendHeartbeats_ExtraHeartbeatsIsUnsavedEntity(t *testing.T) {
 	v.Set("log-file", logFile.Name())
 	v.Set("verbose", true)
 
-	logger, err := cmd.SetupLogging(ctx, v)
+	logger, err := setup.Logging(ctx, v)
 	require.NoError(t, err)
 
 	defer logger.Flush()
@@ -1009,7 +1009,7 @@ func TestSendHeartbeats_NonExistingExtraHeartbeatsEntity(t *testing.T) {
 	v.Set("log-file", logFile.Name())
 	v.Set("verbose", true)
 
-	logger, err := cmd.SetupLogging(ctx, v)
+	logger, err := setup.Logging(ctx, v)
 	require.NoError(t, err)
 
 	defer logger.Flush()
@@ -1100,7 +1100,7 @@ func TestSendHeartbeats_ErrBackoff(t *testing.T) {
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
 	v.Set("log-file", logFile.Name())
 
-	logger, err := cmd.SetupLogging(ctx, v)
+	logger, err := setup.Logging(ctx, v)
 	require.NoError(t, err)
 
 	defer logger.Flush()
@@ -1162,7 +1162,7 @@ func TestSendHeartbeats_ErrBackoff_Verbose(t *testing.T) {
 	v.Set("log-file", logFile.Name())
 	v.Set("verbose", true)
 
-	logger, err := cmd.SetupLogging(ctx, v)
+	logger, err := setup.Logging(ctx, v)
 	require.NoError(t, err)
 
 	defer logger.Flush()

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	stdlog "log"
 	"os"
-	"path/filepath"
 	"runtime/debug"
 	"strings"
 
@@ -16,7 +15,6 @@ import (
 	"github.com/wakatime/wakatime-cli/cmd/configwrite"
 	"github.com/wakatime/wakatime-cli/cmd/fileexperts"
 	cmdheartbeat "github.com/wakatime/wakatime-cli/cmd/heartbeat"
-	"github.com/wakatime/wakatime-cli/cmd/logfile"
 	cmdoffline "github.com/wakatime/wakatime-cli/cmd/offline"
 	"github.com/wakatime/wakatime-cli/cmd/offlinecount"
 	"github.com/wakatime/wakatime-cli/cmd/offlineprint"
@@ -29,6 +27,7 @@ import (
 	"github.com/wakatime/wakatime-cli/pkg/ini"
 	"github.com/wakatime/wakatime-cli/pkg/lexer"
 	"github.com/wakatime/wakatime-cli/pkg/log"
+	"github.com/wakatime/wakatime-cli/pkg/log/setup"
 	"github.com/wakatime/wakatime-cli/pkg/metrics"
 	"github.com/wakatime/wakatime-cli/pkg/offline"
 	"github.com/wakatime/wakatime-cli/pkg/params"
@@ -38,7 +37,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"go.uber.org/zap/zapcore"
-	"gopkg.in/natefinch/lumberjack.v2"
 )
 
 type diagnostics struct {
@@ -66,7 +64,7 @@ func RunE(cmd *cobra.Command, v *viper.Viper) error {
 		}
 	}
 
-	logger, err = SetupLogging(ctx, v)
+	logger, err = setup.Logging(ctx, v)
 	if err != nil {
 		// log to std out and exit, as logger instance failed to setup
 		stdlog.Fatalf("failed to setup logging: %s", err)
@@ -216,43 +214,6 @@ func parseConfigFiles(ctx context.Context, v *viper.Viper) error {
 	}
 
 	return nil
-}
-
-// SetupLogging uses the --log-file param to configure logging to file or stdout.
-// It returns a logger with the configured settings or the default settings if it's not set.
-func SetupLogging(ctx context.Context, v *viper.Viper) (*log.Logger, error) {
-	params, err := logfile.LoadParams(ctx, v)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load log params: %s", err)
-	}
-
-	var destOutput io.Writer = os.Stdout
-
-	if !params.ToStdout {
-		dir := filepath.Dir(params.File)
-		if _, err := os.Stat(dir); os.IsNotExist(err) {
-			err := os.MkdirAll(dir, 0750)
-			if err != nil {
-				return nil, fmt.Errorf("failed to create log file directory %q: %s", dir, err)
-			}
-		}
-
-		// rotate log files
-		destOutput = &lumberjack.Logger{
-			Filename:   params.File,
-			MaxSize:    log.MaxLogFileSize,
-			MaxBackups: log.MaxNumberOfBackups,
-		}
-	}
-
-	logger := log.New(
-		destOutput,
-		log.WithVerbose(params.Verbose),
-		log.WithSendDiagsOnErrors(params.SendDiagsOnErrors),
-		log.WithMetrics(params.Metrics),
-	)
-
-	return logger, nil
 }
 
 // cmdFn represents a command function.

--- a/cmd/run_internal_test.go
+++ b/cmd/run_internal_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/wakatime/wakatime-cli/pkg/exitcode"
 	"github.com/wakatime/wakatime-cli/pkg/ini"
 	"github.com/wakatime/wakatime-cli/pkg/log"
+	"github.com/wakatime/wakatime-cli/pkg/log/setup"
 	"github.com/wakatime/wakatime-cli/pkg/version"
 	"github.com/wakatime/wakatime-cli/pkg/vipertools"
 
@@ -105,7 +106,7 @@ func TestRunCmd_Panic(t *testing.T) {
 	v.Set("api-url", testServerURL)
 	v.Set("log-file", logFile.Name())
 
-	logger, err := SetupLogging(ctx, v)
+	logger, err := setup.Logging(ctx, v)
 	require.NoError(t, err)
 
 	defer logger.Flush()
@@ -185,7 +186,7 @@ func TestRunCmd_Panic_Verbose(t *testing.T) {
 	v.Set("api-url", testServerURL)
 	v.Set("log-file", logFile.Name())
 
-	logger, err := SetupLogging(ctx, v)
+	logger, err := setup.Logging(ctx, v)
 	require.NoError(t, err)
 
 	defer logger.Flush()
@@ -314,7 +315,7 @@ func TestRunCmd_BackoffLoggedWithVerbose(t *testing.T) {
 	v.Set("internal.backoff_retries", "1")
 	v.Set("verbose", verbose)
 
-	logger, err := SetupLogging(ctx, v)
+	logger, err := setup.Logging(ctx, v)
 	require.NoError(t, err)
 
 	defer logger.Flush()
@@ -378,7 +379,7 @@ func TestRunCmd_BackoffNotLogged(t *testing.T) {
 	v.Set("internal.backoff_retries", "1")
 	v.Set("verbose", verbose)
 
-	logger, err := SetupLogging(ctx, v)
+	logger, err := setup.Logging(ctx, v)
 	require.NoError(t, err)
 
 	defer logger.Flush()

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/wakatime/wakatime-cli/pkg/api"
 	"github.com/wakatime/wakatime-cli/pkg/exitcode"
 	"github.com/wakatime/wakatime-cli/pkg/log"
+	"github.com/wakatime/wakatime-cli/pkg/log/setup"
 	"github.com/wakatime/wakatime-cli/pkg/offline"
 	"github.com/wakatime/wakatime-cli/pkg/version"
 
@@ -114,7 +115,7 @@ func TestRunCmd_ErrBackoff(t *testing.T) {
 	v.Set("offline-queue-file", offlineQueueFile.Name())
 	v.Set("plugin", "vim")
 
-	logger, err := cmd.SetupLogging(ctx, v)
+	logger, err := setup.Logging(ctx, v)
 	require.NoError(t, err)
 
 	defer logger.Flush()
@@ -229,7 +230,7 @@ func TestRunCmd_Verbose_ErrBackoff(t *testing.T) {
 	v.Set("log-file", logFile.Name())
 	v.Set("verbose", true)
 
-	logger, err := cmd.SetupLogging(ctx, v)
+	logger, err := setup.Logging(ctx, v)
 	require.NoError(t, err)
 
 	defer logger.Flush()
@@ -325,7 +326,7 @@ func TestRunCmd_SendDiagnostics_Err(t *testing.T) {
 	v.Set("offline-queue-file", offlineQueueFile.Name())
 	v.Set("plugin", "vim")
 
-	logger, err := cmd.SetupLogging(ctx, v)
+	logger, err := setup.Logging(ctx, v)
 	require.NoError(t, err)
 
 	ctx = log.ToContext(ctx, logger)
@@ -415,7 +416,7 @@ func TestRunCmd_SendDiagnostics_Panic(t *testing.T) {
 	v.Set("offline-queue-file", offlineQueueFile.Name())
 	v.Set("plugin", "vim")
 
-	logger, err := cmd.SetupLogging(ctx, v)
+	logger, err := setup.Logging(ctx, v)
 	require.NoError(t, err)
 
 	ctx = log.ToContext(ctx, logger)
@@ -504,7 +505,7 @@ func TestRunCmd_SendDiagnostics_NoLogs_Panic(t *testing.T) {
 	v.Set("offline-queue-file", offlineQueueFile.Name())
 	v.Set("plugin", "vim")
 
-	logger, err := cmd.SetupLogging(ctx, v)
+	logger, err := setup.Logging(ctx, v)
 	require.NoError(t, err)
 
 	ctx = log.ToContext(ctx, logger)
@@ -594,7 +595,7 @@ func TestRunCmd_SendDiagnostics_WakaError(t *testing.T) {
 	v.Set("offline-queue-file", offlineQueueFile.Name())
 	v.Set("plugin", "vim")
 
-	logger, err := cmd.SetupLogging(ctx, v)
+	logger, err := setup.Logging(ctx, v)
 	require.NoError(t, err)
 
 	ctx = log.ToContext(ctx, logger)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/wakatime/wakatime-cli
 
-go 1.24.4
+go 1.25.5
 
 require (
 	github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,6 @@ github.com/gandarez/go-realpath v1.0.0 h1:fhQBRDshH/MZNmDLWM9vbBameK2fxyLr+ctqkR
 github.com/gandarez/go-realpath v1.0.0/go.mod h1:B5MPsYoZD8dUhGtNbTlOZGuaRD/jM0CnbBWXXD1rSk8=
 github.com/go-viper/encoding/ini v0.1.1 h1:MVWY7B2XNw7lnOqHutGRc97bF3rP7omOdgjdMPAJgbs=
 github.com/go-viper/encoding/ini v0.1.1/go.mod h1:Pfi4M2V1eAGJVZ5q6FrkHPhtHED2YgLlXhvgMVrB+YQ=
-github.com/go-viper/mapstructure/v2 v2.3.0 h1:27XbWsHIqhbdR5TIC911OfYvgSaW93HM+dX7970Q7jk=
-github.com/go-viper/mapstructure/v2 v2.3.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/go-viper/mapstructure/v2 v2.4.0 h1:EBsztssimR/CONLSZZ04E8qAkxNYq4Qp9LvH92wZUgs=
 github.com/go-viper/mapstructure/v2 v2.4.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=

--- a/pkg/log/setup/setup.go
+++ b/pkg/log/setup/setup.go
@@ -1,0 +1,52 @@
+package setup
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/wakatime/wakatime-cli/cmd/logfile"
+	"github.com/wakatime/wakatime-cli/pkg/log"
+
+	"github.com/spf13/viper"
+	"gopkg.in/natefinch/lumberjack.v2"
+)
+
+// Logging uses the --log-file param to configure logging to file or stdout.
+// It returns a logger with the configured settings or the default settings if it's not set.
+func Logging(ctx context.Context, v *viper.Viper) (*log.Logger, error) {
+	params, err := logfile.LoadParams(ctx, v)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load log params: %s", err)
+	}
+
+	var destOutput io.Writer = os.Stdout
+
+	if !params.ToStdout {
+		dir := filepath.Dir(params.File)
+		if _, err := os.Stat(dir); os.IsNotExist(err) {
+			err := os.MkdirAll(dir, 0750)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create log file directory %q: %s", dir, err)
+			}
+		}
+
+		// rotate log files
+		destOutput = &lumberjack.Logger{
+			Filename:   params.File,
+			MaxSize:    log.MaxLogFileSize,
+			MaxBackups: log.MaxNumberOfBackups,
+		}
+	}
+
+	logger := log.New(
+		destOutput,
+		log.WithVerbose(params.Verbose),
+		log.WithSendDiagsOnErrors(params.SendDiagsOnErrors),
+		log.WithMetrics(params.Metrics),
+	)
+
+	return logger, nil
+}

--- a/pkg/log/setup/setup_test.go
+++ b/pkg/log/setup/setup_test.go
@@ -1,0 +1,34 @@
+package setup_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/wakatime/wakatime-cli/pkg/log/setup"
+	"github.com/wakatime/wakatime-cli/pkg/vipertools"
+
+	"github.com/alecthomas/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogging(t *testing.T) {
+	logFile, err := os.CreateTemp(t.TempDir(), "")
+	require.NoError(t, err)
+
+	defer logFile.Close()
+
+	v := vipertools.MustNew()
+	v.Set("log-file", logFile.Name())
+	v.Set("send-diagnostics-on-errors", true)
+	v.Set("metrics", true)
+	v.Set("verbose", true)
+
+	logger, err := setup.Logging(t.Context(), v)
+	require.NoError(t, err)
+
+	assert.NotNil(t, logger)
+
+	assert.True(t, logger.SendDiagsOnErrors())
+	assert.True(t, logger.IsMetricsEnabled())
+	assert.True(t, logger.IsVerboseEnabled())
+}

--- a/pkg/params/params_test.go
+++ b/pkg/params/params_test.go
@@ -13,12 +13,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/wakatime/wakatime-cli/cmd"
 	"github.com/wakatime/wakatime-cli/pkg/api"
 	"github.com/wakatime/wakatime-cli/pkg/apikey"
 	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 	inipkg "github.com/wakatime/wakatime-cli/pkg/ini"
 	"github.com/wakatime/wakatime-cli/pkg/log"
+	"github.com/wakatime/wakatime-cli/pkg/log/setup"
 	"github.com/wakatime/wakatime-cli/pkg/offline"
 	"github.com/wakatime/wakatime-cli/pkg/output"
 	paramspkg "github.com/wakatime/wakatime-cli/pkg/params"
@@ -572,7 +572,7 @@ func TestLoadHeartbeatParams_ExtraHeartbeats_NoData(t *testing.T) {
 	v.Set("log-file", logFile.Name())
 	v.Set("verbose", true)
 
-	logger, err := cmd.SetupLogging(ctx, v)
+	logger, err := setup.Logging(ctx, v)
 	require.NoError(t, err)
 
 	defer logger.Flush()
@@ -1202,7 +1202,7 @@ func TestLoadHeartbeatParams_SanitizeParams_HideBranchNames_InvalidRegex(t *test
 	v.Set("hide-branch-names", ".*secret.*\n[0-9+")
 	v.Set("log-file", logFile.Name())
 
-	logger, err := cmd.SetupLogging(ctx, v)
+	logger, err := setup.Logging(ctx, v)
 	require.NoError(t, err)
 
 	defer logger.Flush()
@@ -1359,7 +1359,7 @@ func TestLoadHeartbeatParams_SanitizeParams_HideDependencies_InvalidRegex(t *tes
 	v.Set("hide-dependencies", ".*secret.*\n[0-9+")
 	v.Set("log-file", logFile.Name())
 
-	logger, err := cmd.SetupLogging(ctx, v)
+	logger, err := setup.Logging(ctx, v)
 	require.NoError(t, err)
 
 	defer logger.Flush()
@@ -1534,7 +1534,7 @@ func TestLoadHeartbeatParams_SanitizeParams_HideProjectNames_InvalidRegex(t *tes
 	v.Set("hide-project-names", ".*secret.*\n[0-9+")
 	v.Set("log-file", logFile.Name())
 
-	logger, err := cmd.SetupLogging(ctx, v)
+	logger, err := setup.Logging(ctx, v)
 	require.NoError(t, err)
 
 	defer logger.Flush()
@@ -1744,7 +1744,7 @@ func TestLoadHeartbeatParams_SanitizeParams_HideFileNames_InvalidRegex(t *testin
 	v.Set("hide-file-names", ".*secret.*\n[0-9+")
 	v.Set("log-file", logFile.Name())
 
-	logger, err := cmd.SetupLogging(ctx, v)
+	logger, err := setup.Logging(ctx, v)
 	require.NoError(t, err)
 
 	defer logger.Flush()

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -348,7 +348,11 @@ func obfuscateProjectName(ctx context.Context, folder string) string {
 
 	err := Write(folder, project)
 	if err != nil {
-		logger.Warnf("failed to write: %s", err)
+		logger.Errorf("failed to write: %s", err)
+
+		// use 'Unknown Project' when unable to save random project name to local .wakatime-project file, to
+		// prevent tons of random project names on the dashboard
+		return ""
 	}
 
 	return project

--- a/pkg/project/project_internal_test.go
+++ b/pkg/project/project_internal_test.go
@@ -1,0 +1,82 @@
+package project
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/gandarez/go-realpath"
+	"github.com/stretchr/testify/require"
+	"github.com/wakatime/wakatime-cli/pkg/log"
+	"github.com/wakatime/wakatime-cli/pkg/log/setup"
+	"github.com/wakatime/wakatime-cli/pkg/vipertools"
+)
+
+func TestObfuscateProjectName(t *testing.T) {
+	tmpDir, err := realpath.Realpath(t.TempDir())
+	require.NoError(t, err)
+
+	project := obfuscateProjectName(t.Context(), tmpDir)
+
+	assert.NotEmpty(t, project)
+}
+
+func TestObfuscateProjectName_EmptyFolder(t *testing.T) {
+	project := obfuscateProjectName(t.Context(), "")
+
+	assert.Empty(t, project)
+}
+
+func TestObfuscateProjectName_WakatimeProjectTakesPrecedence(t *testing.T) {
+	tmpDir, err := realpath.Realpath(t.TempDir())
+	require.NoError(t, err)
+
+	copyFile(
+		t,
+		"testdata/wakatime-project",
+		filepath.Join(tmpDir, ".wakatime-project"),
+	)
+
+	project := obfuscateProjectName(t.Context(), tmpDir)
+
+	assert.Empty(t, project)
+}
+
+func TestObfuscateProjectName_Write_Err(t *testing.T) {
+	ctx := t.Context()
+
+	logFile, err := os.CreateTemp(t.TempDir(), "")
+	require.NoError(t, err)
+
+	defer logFile.Close()
+
+	v := vipertools.MustNew()
+	v.Set("log-file", logFile.Name())
+	v.Set("verbose", true)
+
+	logger, err := setup.Logging(ctx, v)
+	require.NoError(t, err)
+
+	defer logger.Flush()
+
+	ctx = log.ToContext(ctx, logger)
+
+	project := obfuscateProjectName(ctx, "-invalid-folder-name-")
+
+	assert.Empty(t, project)
+
+	output, err := io.ReadAll(logFile)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(output), "failed to write: failed to save wakatime project file")
+}
+
+func copyFile(t *testing.T, source, destination string) {
+	input, err := os.ReadFile(source)
+	require.NoError(t, err)
+
+	err = os.WriteFile(destination, input, 0600)
+	require.NoError(t, err)
+}

--- a/pkg/remote/remote_test.go
+++ b/pkg/remote/remote_test.go
@@ -14,10 +14,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/wakatime/wakatime-cli/cmd"
 	"github.com/wakatime/wakatime-cli/pkg/filter"
 	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 	"github.com/wakatime/wakatime-cli/pkg/log"
+	"github.com/wakatime/wakatime-cli/pkg/log/setup"
 	"github.com/wakatime/wakatime-cli/pkg/regex"
 	"github.com/wakatime/wakatime-cli/pkg/remote"
 	"github.com/wakatime/wakatime-cli/pkg/windows"
@@ -164,7 +164,7 @@ func TestWithDetection_SshConfig_UserKnownHostsFile_Mismatch(t *testing.T) {
 	v.Set("log-file", logFile.Name())
 	v.Set("verbose", true)
 
-	logger, err := cmd.SetupLogging(ctx, v)
+	logger, err := setup.Logging(ctx, v)
 	require.NoError(t, err)
 
 	defer logger.Flush()


### PR DESCRIPTION
When we encounter an error saving the random project name to the project's `.wakatime-project` file, use `Unknown Project` or else we'll end up with a ton of random project names... one project name for each heartbeat. It also creates a new package `setup` under `log` to move the logic to setup logger from `cmd` and avoid import cycle not allowed.