### PR TITLE
feat (heartbeat): Class MDX files as documentation

### DIFF
--- a/pkg/heartbeat/category.go
+++ b/pkg/heartbeat/category.go
@@ -129,7 +129,7 @@ func DetectCategory(h Heartbeat) Category {
 		return WritingTestsCategory
 	}
 
-	if strings.HasSuffix(file, ".md") {
+	if strings.HasSuffix(file, ".md") || strings.HasSuffix(file, ".mdx") {
 		return WritingDocsCategory
 	}
 


### PR DESCRIPTION
MDX files are Markdown files supporting components. In my case, I use them with Docusaurus, but since it's Markdown, I believe the heartbeats should be in the "writing docs" category