### PR TITLE
feat: Add MDX language support

### DIFF
--- a/pkg/heartbeat/category.go
+++ b/pkg/heartbeat/category.go
@@ -129,7 +129,7 @@ func DetectCategory(h Heartbeat) Category {
 		return WritingTestsCategory
 	}
 
-	if strings.HasSuffix(file, ".md") {
+	if strings.HasSuffix(file, ".md") || strings.HasSuffix(file, ".mdx") {
 		return WritingDocsCategory
 	}
 


### PR DESCRIPTION
Proper implementaion of #1253 

cf00d5b320586a7d67b04a30c77013b12895b379 adds MDX to the map of known languages
7e3cb344d9403ee176150f23e7dec619e2a70a96 routes any file ending in MDX to the `WritingDocsCategory` instead of `unknown`

Development was done against Wakapi, but should work on the official Wakatime instance without any change

