### PR TITLE
Enable reading project placeholder from .wakatime-project file

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -175,11 +175,25 @@ See the [source code](https://github.com/wakatime/wakatime-cli/blob/36f6372880d7
 
 ### WakaTime Project File
 
-To overwrite the auto-detected project, create a `.wakatime-project` file in your project’s root folder.
+To overwrite the auto-detected project, create a `.wakatime-project` file in your project's root folder.
 The first line of the file contents overwrites the project name, if present.
 The second line, if present, overwrites the current branch name when working inside this folder.
-When the `.wakatime-project` file is empty, the folder’s name is used as the project name.
+When the `.wakatime-project` file is empty, the folder's name is used as the project name.
 Whenever a `.wakatime-project` file is found, it overwrites all other project detection.
+
+#### Project Name Placeholder
+
+You can use the `{project}` placeholder in the first line to include the folder name dynamically. This allows you to add a prefix or suffix to your project name while keeping the actual folder name.
+
+Examples:
+
+| `.wakatime-project` content | Folder name | Resulting project name |
+| --- | --- | --- |
+| `my-company/{project}` | `api` | `my-company/api` |
+| `{project}-backend` | `users` | `users-backend` |
+| `team/{project}/main` | `dashboard` | `team/dashboard/main` |
+
+This is useful when you want to organize projects under a common namespace (like your company or team name) without hardcoding the folder name.
 
 ## Internal INI Config File
 

--- a/pkg/project/file.go
+++ b/pkg/project/file.go
@@ -10,6 +10,10 @@ import (
 	"github.com/wakatime/wakatime-cli/pkg/log"
 )
 
+const (
+	projectNamePlaceholder = "{project}"
+)
+
 // File contains file data.
 type File struct {
 	Filepath string
@@ -38,7 +42,12 @@ func (f File) Detect(ctx context.Context) (Result, bool, error) {
 	}
 
 	if len(lines) > 0 {
-		result.Project = strings.TrimSpace(lines[0])
+		trimmed := strings.TrimSpace(lines[0])
+		if strings.Contains(trimmed, projectNamePlaceholder) {
+			trimmed = strings.ReplaceAll(trimmed, projectNamePlaceholder, result.Project)
+		}
+
+		result.Project = strings.TrimSpace(trimmed)
 	}
 
 	if len(lines) > 1 {

--- a/pkg/project/file_test.go
+++ b/pkg/project/file_test.go
@@ -39,6 +39,74 @@ func TestFile_Detect_FileExists(t *testing.T) {
 	assert.Equal(t, expected, result)
 }
 
+func TestFile_Detect_ProjectPlaceholder(t *testing.T) {
+	tmpDir, err := realpath.Realpath(t.TempDir())
+	require.NoError(t, err)
+
+	// by default t.TempDir() returns a path like /tmp/xyz123, so we append
+	// wakatime-cli to simulate a project folder name
+	tmpDir = filepath.Join(tmpDir, "wakatime-cli")
+
+	err = os.MkdirAll(tmpDir, 0700)
+	require.NoError(t, err)
+
+	copyFile(
+		t,
+		"testdata/wakatime-project-placeholder",
+		filepath.Join(tmpDir, ".wakatime-project"),
+	)
+
+	f := project.File{
+		Filepath: filepath.Join(tmpDir, ".wakatime-project"),
+	}
+
+	result, detected, err := f.Detect(t.Context())
+	require.NoError(t, err)
+
+	expected := project.Result{
+		Branch:  "master",
+		Folder:  tmpDir,
+		Project: "my-company/wakatime-cli",
+	}
+
+	assert.True(t, detected)
+	assert.Equal(t, expected, result)
+}
+
+func TestFile_Detect_ProjectPlaceholderOnly(t *testing.T) {
+	tmpDir, err := realpath.Realpath(t.TempDir())
+	require.NoError(t, err)
+
+	// by default t.TempDir() returns a path like /tmp/xyz123, so we append
+	// wakatime-cli to simulate a project folder name
+	tmpDir = filepath.Join(tmpDir, "wakatime-cli")
+
+	err = os.MkdirAll(tmpDir, 0700)
+	require.NoError(t, err)
+
+	copyFile(
+		t,
+		"testdata/wakatime-project-only-placeholder",
+		filepath.Join(tmpDir, ".wakatime-project"),
+	)
+
+	f := project.File{
+		Filepath: filepath.Join(tmpDir, ".wakatime-project"),
+	}
+
+	result, detected, err := f.Detect(t.Context())
+	require.NoError(t, err)
+
+	expected := project.Result{
+		Branch:  "",
+		Folder:  tmpDir,
+		Project: "wakatime-cli",
+	}
+
+	assert.True(t, detected)
+	assert.Equal(t, expected, result)
+}
+
 func TestFile_Detect_ParentFolderExists(t *testing.T) {
 	tmpDir, err := realpath.Realpath(t.TempDir())
 	require.NoError(t, err)

--- a/pkg/project/testdata/wakatime-project-only-placeholder
+++ b/pkg/project/testdata/wakatime-project-only-placeholder
@@ -1,0 +1,1 @@
+{project}

--- a/pkg/project/testdata/wakatime-project-placeholder
+++ b/pkg/project/testdata/wakatime-project-placeholder
@@ -1,0 +1,2 @@
+my-company/{project}
+master


### PR DESCRIPTION
This PR enables reading project placeholder from .wakatime-project file

It commit adds support for a `{project}` placeholder in `.wakatime-project` files, allowing users to dynamically include the folder name in their project configuration. 

Previously, users had to hardcode the full project name in their `.wakatime-project` file. This was limiting because:

* Organization prefixes - Many teams want to prefix project names with their company or team name (e.g., `my-company/wakatime-cli`) but didn't want to manually type the folder name
* Consistency - If you rename a folder, you'd have to manually update the `.wakatime-project` file to match
* Reusability - The same `.wakatime-project` template couldn't be reused across different projects

**How It Works Now**

With the `{project}` placeholder, users can dynamically include the folder name in their project configuration:

.wakatime-project content | Folder name | Result sent in heartbeat
--- | --- | --- |
my-company/{project} | wakatime-cli | my-company/wakatime-cli
{project}-backend | api | api-backend
{project} | myapp | myapp
team/{project}/main | dashboard | team/dashboard/main

This allows users to add **prefixes** (like organization names), **suffixes** (like environment indicators), or both, while still automatically picking up the actual folder name. The heartbeat sent to WakaTime will contain the fully resolved project name, making dashboards and reports more organized and consistent across teams.