### PR TITLE
Fix parsing api_urls using defaults

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -86,36 +86,36 @@ Notice how you have to include the exclude patterns from your main `~/.wakatime.
 
 ### Settings Section
 
-| option                         | description | type | default value |
-| ---                            | ---         | ---  | ---           |
-| debug                          | Turns on debug messages in log file. | _bool_ | `false` |
-| api_key                        | Your wakatime api key. | _string_ | |
-| api_key_vault_cmd              | A command to get your api key, perhaps from some sort of secure vault. Actually a space-separated list of an executable and its arguments. Executables in PATH can be referred to by their basenames. Shell syntax not supported. | _string_ | |
-| api_url                        | The WakaTime API base url. | _string_ | <https://api.wakatime.com/api/v1> |
-| heartbeat_rate_limit_seconds   | Rate limit sending heartbeats to the API once per duration. Set to 0 to disable rate limiting. | _int_ | `120` |
-| hide_file_names                | Obfuscate filenames. Will not send file names to api. | _bool_;_list_ | `false` |
-| hide_project_names             | Obfuscate project names. When a project folder is detected instead of using the folder name as the project, a `.wakatime-project file` is created with a random project name. | _bool_;_list_ | `false` |
-| hide_branch_names              | Obfuscate branch names. Will not send revision control branch names to api. | _bool_;_list_ | `false` |
-| hide_dependencies              | Prevent sending imports/libraries/dependencies used in currently focused file to the api.  | _bool_;_list_ | `false` |
-| hide_project_folder            | When set, send the file's path relative to the project folder. For ex: `/User/me/projects/bar/src/file.ts` is sent as `src/file.ts` so the server never sees the full path. When the project folder cannot be detected, only the file name is sent. For ex: `file.ts`. | _bool_ | `false` |
-| exclude                        | Filename patterns to exclude from logging. POSIX regex syntax. | _bool_;_list_ | |
-| include                        | Filename patterns to log. When used in combination with `exclude`, files matching `include` will still be logged. POSIX regex syntax | _bool_;_list_ | |
-| include_only_with_project_file | Disables tracking folders unless they contain a `.wakatime-project file`. | _bool_ | `false` |
-| exclude_unknown_project        | When set, any activity where the project cannot be detected will be ignored. | _bool_ | `false` |
-| status_bar_enabled             | Turns on wakatime status bar for certain editors. | _bool_ | `true` |
-| status_bar_coding_activity     | Enables displaying Today's code stats in the status bar of some editors. When false, only the WakaTime icon is displayed in the status bar. | _bool_ | `true` |
-| status_bar_hide_categories     | When `true`, --today only displays the total code stats, never displaying Categories in the output. | _bool_ | `false` |
-| status_bar_max_categories      | When greater than zero, limits the number of categories displayed in the status bar. | _int_ | `0` |
-| offline                        | Enables saving code stats locally to ~/.wakatime/offline_heartbeats.bdb when offline, and syncing to the dashboard later when back online. | _bool_ | `true` |
-| proxy                          | Optional proxy configuration. Supports HTTPS, SOCKS and NTLM proxies. For ex: `https://user:pass@host:port`, `socks5://user:pass@host:port`, `domain\\user:pass` | _string_ | |
-| no_ssl_verify                  | Disables SSL certificate verification for HTTPS requests. By default, SSL certificates are verified. | _bool_ | `false` |
-| ssl_certs_file                 | Path to a CA certs file. By default, uses bundled Letsencrypt CA cert along with system ca certs. | _filepath_ | |
-| timeout                        | Connection timeout in seconds when communicating with the api. | _int_ | `120` |
-| hostname                       | Optional name of local machine. By default, auto-detects the local machine’s hostname. | _string_ | |
-| log_file                       | Optional log file path. | _filepath_ | `~/.wakatime/wakatime.log` |
-| import_cfg                     | Optional path to another wakatime.cfg file to import. If set it will overwrite values loaded from $WAKATIME_HOME/.wakatime.cfg file. | _filepath_ | |
-| metrics                        | When set, collects metrics usage in '~/.wakatime/metrics' folder. For further reference visit <https://go.dev/blog/pprof>. | _bool_ | `false` |
-| guess_language                 | When `true`, enables detecting programming language from file contents. | _bool_ | `false` |
+| option                         | description                                                                                                                                                                                                                                                            | type          | default value                     |
+| ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- | --------------------------------- |
+| debug                          | Turns on debug messages in log file.                                                                                                                                                                                                                                   | _bool_        | `false`                           |
+| api_key                        | Your wakatime api key.                                                                                                                                                                                                                                                 | _string_      |                                   |
+| api_key_vault_cmd              | A command to get your api key, perhaps from some sort of secure vault. Actually a space-separated list of an executable and its arguments. Executables in PATH can be referred to by their basenames. Shell syntax not supported.                                      | _string_      |                                   |
+| api_url                        | The WakaTime API base url.                                                                                                                                                                                                                                             | _string_      | <https://api.wakatime.com/api/v1> |
+| heartbeat_rate_limit_seconds   | Rate limit sending heartbeats to the API once per duration. Set to 0 to disable rate limiting.                                                                                                                                                                         | _int_         | `120`                             |
+| hide_file_names                | Obfuscate filenames. Will not send file names to api.                                                                                                                                                                                                                  | _bool_;_list_ | `false`                           |
+| hide_project_names             | Obfuscate project names. When a project folder is detected instead of using the folder name as the project, a `.wakatime-project file` is created with a random project name.                                                                                          | _bool_;_list_ | `false`                           |
+| hide_branch_names              | Obfuscate branch names. Will not send revision control branch names to api.                                                                                                                                                                                            | _bool_;_list_ | `false`                           |
+| hide_dependencies              | Prevent sending imports/libraries/dependencies used in currently focused file to the api.                                                                                                                                                                              | _bool_;_list_ | `false`                           |
+| hide_project_folder            | When set, send the file's path relative to the project folder. For ex: `/User/me/projects/bar/src/file.ts` is sent as `src/file.ts` so the server never sees the full path. When the project folder cannot be detected, only the file name is sent. For ex: `file.ts`. | _bool_        | `false`                           |
+| exclude                        | Filename patterns to exclude from logging. POSIX regex syntax.                                                                                                                                                                                                         | _bool_;_list_ |                                   |
+| include                        | Filename patterns to log. When used in combination with `exclude`, files matching `include` will still be logged. POSIX regex syntax                                                                                                                                   | _bool_;_list_ |                                   |
+| include_only_with_project_file | Disables tracking folders unless they contain a `.wakatime-project file`.                                                                                                                                                                                              | _bool_        | `false`                           |
+| exclude_unknown_project        | When set, any activity where the project cannot be detected will be ignored.                                                                                                                                                                                           | _bool_        | `false`                           |
+| status_bar_enabled             | Turns on wakatime status bar for certain editors.                                                                                                                                                                                                                      | _bool_        | `true`                            |
+| status_bar_coding_activity     | Enables displaying Today's code stats in the status bar of some editors. When false, only the WakaTime icon is displayed in the status bar.                                                                                                                            | _bool_        | `true`                            |
+| status_bar_hide_categories     | When `true`, --today only displays the total code stats, never displaying Categories in the output.                                                                                                                                                                    | _bool_        | `false`                           |
+| status_bar_max_categories      | When greater than zero, limits the number of categories displayed in the status bar.                                                                                                                                                                                   | _int_         | `0`                               |
+| offline                        | Enables saving code stats locally to ~/.wakatime/offline_heartbeats.bdb when offline, and syncing to the dashboard later when back online.                                                                                                                             | _bool_        | `true`                            |
+| proxy                          | Optional proxy configuration. Supports HTTPS, SOCKS and NTLM proxies. For ex: `https://user:pass@host:port`, `socks5://user:pass@host:port`, `domain\\user:pass`                                                                                                       | _string_      |                                   |
+| no_ssl_verify                  | Disables SSL certificate verification for HTTPS requests. By default, SSL certificates are verified.                                                                                                                                                                   | _bool_        | `false`                           |
+| ssl_certs_file                 | Path to a CA certs file. By default, uses bundled Letsencrypt CA cert along with system ca certs.                                                                                                                                                                      | _filepath_    |                                   |
+| timeout                        | Connection timeout in seconds when communicating with the api.                                                                                                                                                                                                         | _int_         | `120`                             |
+| hostname                       | Optional name of local machine. By default, auto-detects the local machine’s hostname.                                                                                                                                                                                 | _string_      |                                   |
+| log_file                       | Optional log file path.                                                                                                                                                                                                                                                | _filepath_    | `~/.wakatime/wakatime.log`        |
+| import_cfg                     | Optional path to another wakatime.cfg file to import. If set it will overwrite values loaded from $WAKATIME_HOME/.wakatime.cfg file.                                                                                                                                   | _filepath_    |                                   |
+| metrics                        | When set, collects metrics usage in '~/.wakatime/metrics' folder. For further reference visit <https://go.dev/blog/pprof>.                                                                                                                                             | _bool_        | `false`                           |
+| guess_language                 | When `true`, enables detecting programming language from file contents.                                                                                                                                                                                                | _bool_        | `false`                           |
 
 ### Project Map Section
 
@@ -153,7 +153,7 @@ The format is: `pattern = api_url|api_key`
 [api_urls]
 ^/home/user/work/ = https://work.example.com/api/v1|your-work-api-key
 ^/home/user/personal/ = https://personal.example.com/api/v1|your-personal-api-key
-.* = your-personal-api-key ⁠
+.* =
 ⁠.* = https://your-backup-server.com/api/v1|your-backup-api-key ⁠
 
 ```
@@ -162,7 +162,8 @@ With this configuration:
 
 - Files in `/home/user/work/` are sent to both the default WakaTime API (if `api_key` is set) AND `work.example.com`
 - Files in `/home/user/personal/` are sent to both the default WakaTime API (if `api_key` is set) AND `personal.example.com`
-- ⁠Files not matching the work or personal regex patterns are sent to both the default api url and your-backup-server.com (duplicated)
+- When no api_url or no api_key are present(`.* = `), the default api_key and api_url are used
+- ⁠Files not matching the work or personal regex patterns are sent to both the default api url and your-backup-server.com (duplicated/tee'd)
 
 ### Api Key Environment Variable
 
@@ -172,9 +173,9 @@ However, if an api key exists in your `~/.wakatime.cfg` file then it takes prece
 
 ### Git Section
 
-| option              | description | type | default value |
-| ---                 | ---         | ---  | ---           |
-| submodules_disabled | It will be matched against the submodule path and if matching, will skip it. | _bool_;_list_ | false |
+| option              | description                                                                  | type          | default value |
+| ------------------- | ---------------------------------------------------------------------------- | ------------- | ------------- |
+| submodules_disabled | It will be matched against the submodule path and if matching, will skip it. | _bool_;_list_ | false         |
 
 ### Git Submodule Project Map Section
 
@@ -219,10 +220,10 @@ You can use the `{project}` placeholder in the first line to include the folder 
 Examples:
 
 | `.wakatime-project` content | Folder name | Resulting project name |
-| --- | --- | --- |
-| `my-company/{project}` | `api` | `my-company/api` |
-| `{project}-backend` | `users` | `users-backend` |
-| `team/{project}/main` | `dashboard` | `team/dashboard/main` |
+| --------------------------- | ----------- | ---------------------- |
+| `my-company/{project}`      | `api`       | `my-company/api`       |
+| `{project}-backend`         | `users`     | `users-backend`        |
+| `team/{project}/main`       | `dashboard` | `team/dashboard/main`  |
 
 This is useful when you want to organize projects under a common namespace (like your company or team name) without hardcoding the folder name.
 

--- a/cmd/offlinesync/offlinesync_test.go
+++ b/cmd/offlinesync/offlinesync_test.go
@@ -427,7 +427,9 @@ func TestSyncOfflineActivity_MultipleAPIURLs(t *testing.T) {
 	// Handler for default server
 	defaultRouter.HandleFunc("/users/current/heartbeats.bulk", func(w http.ResponseWriter, req *http.Request) {
 		mu.Lock()
+
 		defaultServerCalls++
+
 		mu.Unlock()
 
 		// check request
@@ -460,7 +462,9 @@ func TestSyncOfflineActivity_MultipleAPIURLs(t *testing.T) {
 	// Handler for custom server
 	customRouter.HandleFunc("/users/current/heartbeats.bulk", func(w http.ResponseWriter, req *http.Request) {
 		mu.Lock()
+
 		customServerCalls++
+
 		mu.Unlock()
 
 		// check request

--- a/pkg/apikey/apikey.go
+++ b/pkg/apikey/apikey.go
@@ -58,9 +58,7 @@ type (
 func WithReplacing(config Config) heartbeat.HandleOption {
 	return func(next heartbeat.Handle) heartbeat.Handle {
 		return func(ctx context.Context, hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
-			logger := log.Extract(ctx)
-			logger.Debugln("execute api key replacing")
-
+			// logger.Debugln("execute api key replacing")
 			var result []heartbeat.Heartbeat
 
 			for _, h := range hh {

--- a/pkg/backoff/backoff.go
+++ b/pkg/backoff/backoff.go
@@ -42,7 +42,7 @@ func WithBackoff(config Config) heartbeat.HandleOption {
 	return func(next heartbeat.Handle) heartbeat.Handle {
 		return func(ctx context.Context, hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
 			logger := log.Extract(ctx)
-			logger.Debugln("execute heartbeat backoff algorithm")
+			// logger.Debugln("execute heartbeat backoff algorithm")
 
 			if shouldBackoff(ctx, config.Retries, config.At) {
 				if config.HasProxy {

--- a/pkg/deps/deps.go
+++ b/pkg/deps/deps.go
@@ -37,7 +37,7 @@ func WithDetection(c Config) heartbeat.HandleOption {
 	return func(next heartbeat.Handle) heartbeat.Handle {
 		return func(ctx context.Context, hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
 			logger := log.Extract(ctx)
-			logger.Debugln("execute dependency detection")
+			// logger.Debugln("execute dependency detection")
 
 			for n, h := range hh {
 				if h.EntityType != heartbeat.FileType {

--- a/pkg/fileexperts/validation.go
+++ b/pkg/fileexperts/validation.go
@@ -14,7 +14,7 @@ func WithValidation() heartbeat.HandleOption {
 	return func(next heartbeat.Handle) heartbeat.Handle {
 		return func(ctx context.Context, hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
 			logger := log.Extract(ctx)
-			logger.Debugln("execute fileexperts validation")
+			// logger.Debugln("execute fileexperts validation")
 
 			var filtered []heartbeat.Heartbeat
 

--- a/pkg/filestats/filestats.go
+++ b/pkg/filestats/filestats.go
@@ -16,7 +16,7 @@ func WithDetection() heartbeat.HandleOption {
 	return func(next heartbeat.Handle) heartbeat.Handle {
 		return func(ctx context.Context, hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
 			logger := log.Extract(ctx)
-			logger.Debugln("execute filestats detection")
+			// logger.Debugln("execute filestats detection")
 
 			for n, h := range hh {
 				if h.EntityType != heartbeat.FileType {

--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -25,7 +25,7 @@ func WithFiltering(config Config) heartbeat.HandleOption {
 	return func(next heartbeat.Handle) heartbeat.Handle {
 		return func(ctx context.Context, hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
 			logger := log.Extract(ctx)
-			logger.Debugln("execute heartbeat filtering")
+			// logger.Debugln("execute heartbeat filtering")
 
 			var filtered []heartbeat.Heartbeat
 
@@ -51,7 +51,7 @@ func WithLengthValidator() heartbeat.HandleOption {
 	return func(next heartbeat.Handle) heartbeat.Handle {
 		return func(ctx context.Context, hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
 			logger := log.Extract(ctx)
-			logger.Debugln("execute heartbeats length validation")
+			// logger.Debugln("execute heartbeats length validation")
 
 			if len(hh) == 0 {
 				logger.Debugln("no heartbeats left after filtering. abort heartbeat handling.")

--- a/pkg/heartbeat/category.go
+++ b/pkg/heartbeat/category.go
@@ -90,7 +90,7 @@ func WithCategory() HandleOption {
 	return func(next Handle) Handle {
 		return func(ctx context.Context, hh []Heartbeat) ([]Result, error) {
 			logger := log.Extract(ctx)
-			logger.Debugln("execute heartbeat category detection")
+			// logger.Debugln("execute heartbeat category detection")
 
 			for n, h := range hh {
 				// remove category coding if it was set by the user to avoid sending it to the API

--- a/pkg/heartbeat/entity_modify.go
+++ b/pkg/heartbeat/entity_modify.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"path/filepath"
 	"strings"
-
-	"github.com/wakatime/wakatime-cli/pkg/log"
 )
 
 // WithEntityModifier initializes and returns a heartbeat handle option, which
@@ -13,9 +11,8 @@ import (
 func WithEntityModifier() HandleOption {
 	return func(next Handle) Handle {
 		return func(ctx context.Context, hh []Heartbeat) ([]Result, error) {
-			logger := log.Extract(ctx)
-			logger.Debugln("execute heartbeat entity modifier")
-
+			// logger := log.Extract(ctx)
+			// logger.Debugln("execute heartbeat entity modifier")
 			for n, h := range hh {
 				// Support XCode playgrounds
 				if h.EntityType == FileType && isXCodePlayground(ctx, h.Entity) {

--- a/pkg/heartbeat/format.go
+++ b/pkg/heartbeat/format.go
@@ -16,9 +16,7 @@ import (
 func WithFormatting() HandleOption {
 	return func(next Handle) Handle {
 		return func(ctx context.Context, hh []Heartbeat) ([]Result, error) {
-			logger := log.Extract(ctx)
-			logger.Debugln("execute heartbeat filepath formatting")
-
+			// logger.Debugln("execute heartbeat filepath formatting")
 			for n, h := range hh {
 				if h.EntityType != FileType {
 					continue

--- a/pkg/heartbeat/sanitize.go
+++ b/pkg/heartbeat/sanitize.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/wakatime/wakatime-cli/pkg/log"
 	"github.com/wakatime/wakatime-cli/pkg/regex"
 )
 
@@ -30,9 +29,7 @@ type SanitizeConfig struct {
 func WithSanitization(config SanitizeConfig) HandleOption {
 	return func(next Handle) Handle {
 		return func(ctx context.Context, hh []Heartbeat) ([]Result, error) {
-			logger := log.Extract(ctx)
-			logger.Debugln("execute heartbeat sanitization")
-
+			// logger.Debugln("execute heartbeat sanitization")
 			for n, h := range hh {
 				hh[n] = Sanitize(ctx, h, config)
 			}

--- a/pkg/language/language.go
+++ b/pkg/language/language.go
@@ -25,7 +25,7 @@ func WithDetection(config Config) heartbeat.HandleOption {
 	return func(next heartbeat.Handle) heartbeat.Handle {
 		return func(ctx context.Context, hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
 			logger := log.Extract(ctx)
-			logger.Debugln("execute language detection")
+			// logger.Debugln("execute language detection")
 
 			for n, h := range hh {
 				if hh[n].Language != nil {

--- a/pkg/offline/offline.go
+++ b/pkg/offline/offline.go
@@ -51,7 +51,7 @@ func WithQueue(filepath string) heartbeat.HandleOption {
 	return func(next heartbeat.Handle) heartbeat.Handle {
 		return func(ctx context.Context, hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
 			logger := log.Extract(ctx)
-			logger.Debugf("execute offline queue with file %s", filepath)
+			// logger.Debugf("execute offline queue with file %s", filepath)
 
 			if len(hh) == 0 {
 				logger.Debugln("abort execution, as there are no heartbeats ready for sending")
@@ -112,9 +112,7 @@ func QueueFilepath(ctx context.Context, v *viper.Viper) (string, error) {
 func WithSync(filepath string, syncLimit int) heartbeat.HandleOption {
 	return func(next heartbeat.Handle) heartbeat.Handle {
 		return func(ctx context.Context, _ []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
-			logger := log.Extract(ctx)
-			logger.Debugf("execute offline sync with file %s", filepath)
-
+			// logger.Debugf("execute offline sync with file %s", filepath)
 			err := Sync(ctx, filepath, syncLimit)(next)
 			if err != nil {
 				return nil, fmt.Errorf("failed to sync offline heartbeats: %s", err)

--- a/pkg/params/params.go
+++ b/pkg/params/params.go
@@ -280,17 +280,17 @@ func LoadAPIParams(ctx context.Context, v *viper.Viper, order FlagReadOrder) (AP
 		return API{}, err
 	}
 
+	apiURL, err := loadAPIURL(v)
+	if err != nil {
+		return API{}, err
+	}
+
 	apiKeyPatterns, err := loadAPIKeyPatterns(ctx, v, apiKey)
 	if err != nil {
 		return API{}, err
 	}
 
-	apiURLPatterns, err := loadAPIURLPatterns(ctx, v)
-	if err != nil {
-		return API{}, err
-	}
-
-	apiURL, err := loadAPIURL(v)
+	apiURLPatterns, err := loadAPIURLPatterns(ctx, v, apiURL, apiKey)
 	if err != nil {
 		return API{}, err
 	}
@@ -370,7 +370,12 @@ func loadAPIKeyPatterns(ctx context.Context, v *viper.Viper, defaultAPIKey strin
 	return patterns, nil
 }
 
-func loadAPIURLPatterns(ctx context.Context, v *viper.Viper) ([]apikey.URLPattern, error) {
+func loadAPIURLPatterns(
+	ctx context.Context,
+	v *viper.Viper,
+	defaultURL *url.URL,
+	defaultKey string,
+) ([]apikey.URLPattern, error) {
 	logger := log.Extract(ctx)
 
 	var patterns []apikey.URLPattern
@@ -391,13 +396,21 @@ func loadAPIURLPatterns(ctx context.Context, v *viper.Viper) ([]apikey.URLPatter
 
 		// split value by | to get api_url and api_key
 		parts := strings.SplitN(s, "|", 2)
-		if len(parts) != 2 {
+		if len(parts) > 2 {
 			logger.Warnf("invalid api_urls format for %q, expected 'api_url|api_key'", k)
 			continue
 		}
 
-		apiURLValue := strings.TrimSpace(parts[0])
-		apiKeyValue := strings.TrimSpace(parts[1])
+		apiURLValue := defaultURL.String()
+		apiKeyValue := defaultKey
+
+		if len(parts) > 0 && strings.TrimSpace(parts[0]) != "" {
+			apiURLValue = strings.TrimSpace(parts[0])
+		}
+
+		if len(parts) == 2 {
+			apiKeyValue = strings.TrimSpace(parts[1])
+		}
 
 		if apiURLValue == "" {
 			logger.Warnf("empty api_url for %q", k)
@@ -427,7 +440,7 @@ func loadAPIURLPatterns(ctx context.Context, v *viper.Viper) ([]apikey.URLPatter
 func loadAPIURL(v *viper.Viper) (*url.URL, error) {
 	apiURLStr := api.BaseURL
 
-	if u := vipertools.FirstNonEmptyString(v, "api-url", "apiurl", "settings.api_url"); u != "" {
+	if u := vipertools.FirstNonEmptyString(v, "api-url", "apiurl", "api_url", "settings.api_url"); u != "" {
 		apiURLStr = u
 	}
 

--- a/pkg/params/params_test.go
+++ b/pkg/params/params_test.go
@@ -3266,18 +3266,27 @@ func TestLoadAPIParams_APIURLs_ParseConfig(t *testing.T) {
 	assert.Equal(t, expected, params.URLPatterns)
 }
 
-func TestLoadAPIParams_APIURLs_InvalidFormat(t *testing.T) {
+func TestLoadAPIParams_APIURLs_MissingAPIKey(t *testing.T) {
 	ctx := t.Context()
 
 	v := vipertools.MustNew()
 	v.Set("key", "00000000-0000-4000-8000-000000000000")
+	v.Set("api_url", "https://default.com/api/v1")
 	v.Set("api_urls./work/projects", "https://work.example.com/api/v1") // missing api key
 
 	params, err := paramspkg.LoadAPIParams(ctx, v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
-	// Invalid format should be skipped with a warning
-	assert.Empty(t, params.URLPatterns)
+	// missing api key should default to api_key
+	expected := []apikey.URLPattern{
+		{
+			APIURL: "https://work.example.com/api/v1",
+			APIKey: "00000000-0000-4000-8000-000000000000",
+			Regex:  regex.NewRegexpWrap(regexp.MustCompile("(?i)/work/projects")),
+		},
+	}
+
+	assert.Equal(t, expected, params.URLPatterns)
 }
 
 func TestLoadAPIParams_APIURLs_InvalidAPIKey(t *testing.T) {
@@ -3293,6 +3302,29 @@ func TestLoadAPIParams_APIURLs_InvalidAPIKey(t *testing.T) {
 	var errAuth api.ErrAuth
 
 	assert.ErrorAs(t, err, &errAuth)
+}
+
+func TestLoadAPIParams_APIURLs_Empty(t *testing.T) {
+	ctx := t.Context()
+
+	v := vipertools.MustNew()
+	v.Set("key", "00000000-0000-4000-8000-000000000000")
+	v.Set("api_url", "https://default.com/api/v1")
+	v.Set("api_urls./work/projects", "")
+
+	params, err := paramspkg.LoadAPIParams(ctx, v, paramspkg.FlagReadOrderFlagPrecedence)
+	require.NoError(t, err)
+
+	// empty string should default to api_url and api_key
+	expected := []apikey.URLPattern{
+		{
+			APIURL: "https://default.com/api/v1",
+			APIKey: "00000000-0000-4000-8000-000000000000",
+			Regex:  regex.NewRegexpWrap(regexp.MustCompile("(?i)/work/projects")),
+		},
+	}
+
+	assert.Equal(t, expected, params.URLPatterns)
 }
 
 func TestLoadAPIParams_APIURLs_NormalizesURL(t *testing.T) {

--- a/pkg/project/filter.go
+++ b/pkg/project/filter.go
@@ -22,7 +22,7 @@ func WithFiltering(config FilterConfig) heartbeat.HandleOption {
 	return func(next heartbeat.Handle) heartbeat.Handle {
 		return func(ctx context.Context, hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
 			logger := log.Extract(ctx)
-			logger.Debugln("execute project filtering")
+			// logger.Debugln("execute project filtering")
 
 			var filtered []heartbeat.Heartbeat
 

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -142,10 +142,8 @@ type (
 func WithDetection(config Config) heartbeat.HandleOption {
 	return func(next heartbeat.Handle) heartbeat.Handle {
 		return func(ctx context.Context, hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
-			logger := log.Extract(ctx)
-
 			for n, h := range hh {
-				logger.Debugf("execute project detection for: %s", h.Entity)
+				// logger.Debugf("execute project detection for: %s", h.Entity)
 
 				// First use .wakatime-project or [projectmap] section with entity path.
 				// Then, detect with project folder. This tries to use the same project name
@@ -276,8 +274,7 @@ func Detect(ctx context.Context, patterns []MapPattern, args ...DetecterArg) (Re
 		}
 
 		for _, p := range configPlugins {
-			logger.Debugf("execute %s", p.ID().String())
-
+			// logger.Debugf("execute %s", p.ID().String())
 			result, detected, err := p.Detect(ctx)
 			if err != nil {
 				logger.Errorf("unexpected error occurred at %q: %s", p.ID().String(), err)
@@ -326,8 +323,7 @@ func DetectWithRevControl(
 		}
 
 		for _, p := range revControlPlugins {
-			logger.Debugf("execute %s", p.ID().String())
-
+			// logger.Debugf("execute %s", p.ID().String())
 			result, detected, err := p.Detect(ctx)
 			if err != nil {
 				logger.Errorf("unexpected error occurred at %q: %s", p.ID().String(), err)

--- a/pkg/project/subversion.go
+++ b/pkg/project/subversion.go
@@ -7,8 +7,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
-
-	"github.com/wakatime/wakatime-cli/pkg/log"
 )
 
 // Subversion contains svn data.
@@ -19,11 +17,8 @@ type Subversion struct {
 
 // Detect gets information about the svn project for a given file.
 func (s Subversion) Detect(ctx context.Context) (Result, bool, error) {
-	logger := log.Extract(ctx)
-
-	binary, ok := findSvnBinary(ctx)
+	binary, ok := findSvnBinary()
 	if !ok {
-		logger.Debugln("svn binary not found")
 		return Result{}, false, nil
 	}
 
@@ -80,21 +75,18 @@ func svnInfo(fp string, binary string) (map[string]string, bool, error) {
 	return result, true, nil
 }
 
-func findSvnBinary(ctx context.Context) (string, bool) {
+func findSvnBinary() (string, bool) {
 	locations := []string{
 		"svn",
 		"/usr/bin/svn",
 		"/usr/local/bin/svn",
 	}
 
-	logger := log.Extract(ctx)
-
 	for _, loc := range locations {
 		cmd := exec.Command(loc, "--version") // nolint:gosec
 
 		err := cmd.Run()
 		if err != nil {
-			logger.Debugf("failed while calling %s --version: %s", loc, err)
 			continue
 		}
 

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -51,7 +51,7 @@ func WithDetection() heartbeat.HandleOption {
 	return func(next heartbeat.Handle) heartbeat.Handle {
 		return func(ctx context.Context, hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
 			logger := log.Extract(ctx)
-			logger.Debugln("execute remote file detection")
+			// logger.Debugln("execute remote file detection")
 
 			var filtered []heartbeat.Heartbeat
 
@@ -107,7 +107,7 @@ func WithCleanup() heartbeat.HandleOption {
 	return func(next heartbeat.Handle) heartbeat.Handle {
 		return func(ctx context.Context, hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
 			logger := log.Extract(ctx)
-			logger.Debugln("execute remote cleanup")
+			// logger.Debugln("execute remote cleanup")
 
 			for _, h := range hh {
 				if h.LocalFileNeedsCleanup {


### PR DESCRIPTION
Fixes a bug in #1268 where we incorrectly parsed `api_urls` requiring both url and key. Instead, we should default to the normal url and key when not set. For example, all these should work:

```ini
[api_urls]
.* = 
.* = https://myapi.com/api/v1
.* = https://myapi.com/api/v1|my-key
```

But only the last line was working.

I also removed noisy debug logs that only showed execution path, not useful normally.

Still getting a warning when sending 1 heartbeat to 2 api urls, but I'll fix that in a future PR:

```json
{
    "level": "warn",
    "now": "2026-01-21T12:41:37-04:00",
    "caller": "offline/offline.go:203",
    "func": "github.com/wakatime/wakatime-cli/pkg/offline.handleResults",
    "message": "expected 1 results from api but received 2",
    "version": "<local-build>",
    "os/arch": "darwin/arm64",
    "time": 1769013687
  }
  ```