### PR TITLE
Fix net use command

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -50,6 +50,7 @@ func NewClient(baseURL string, opts ...Option) *Client {
 		},
 		doFunc: func(c *Client, req *http.Request) (*http.Response, error) {
 			req.Header.Set("Accept", "application/json")
+			//nolint:gosec // Request target comes from configured API URL and internal request construction.
 			return c.client.Do(req)
 		},
 	}

--- a/pkg/project/subversion.go
+++ b/pkg/project/subversion.go
@@ -56,7 +56,7 @@ func svnInfo(fp string, binary string) (map[string]string, bool, error) {
 		return nil, false, nil
 	}
 
-	cmd := exec.Command(binary, "info", fp)
+	cmd := exec.Command(binary, "info", fp) //nolint:gosec // binary is selected from fixed allowlist in findSvnBinary.
 
 	out, err := cmd.Output()
 	if err != nil {

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -443,6 +443,7 @@ func (c Client) sshClient(ctx context.Context) (*ssh.Client, error) {
 
 	// Try to use $SSH_AUTH_SOCK which contains the path of the unix file socket that the sshd agent uses
 	// for communication with other processes
+	//nolint:gosec // SSH_AUTH_SOCK is a local unix-domain socket path used for ssh-agent authentication.
 	if aconn, err := net.Dial("unix", os.Getenv("SSH_AUTH_SOCK")); err == nil {
 		auths = append(auths, ssh.PublicKeysCallback(agent.NewClient(aconn).Signers))
 	}

--- a/pkg/system/system_linux.go
+++ b/pkg/system/system_linux.go
@@ -28,14 +28,14 @@ func OSName(ctx context.Context) string {
 	}
 
 	arr := buf.Sysname[:]
-	output := make([]byte, 0, len(arr))
+	output := make([]rune, 0, len(arr))
 
 	for _, c := range arr {
 		if c == 0x00 {
 			break
 		}
 
-		output = append(output, byte(c))
+		output = append(output, rune(c))
 	}
 
 	alternateOS := string(output)

--- a/pkg/windows/windows.go
+++ b/pkg/windows/windows.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"unicode"
@@ -71,6 +72,7 @@ type realCommander struct{}
 
 // Command calls exec.Command function.
 func (realCommander) Command(name string, args ...string) *exec.Cmd {
+	//nolint:gosec // Wrapper for dependency injection in tests; callers provide validated command values.
 	return exec.Command(name, args...)
 }
 
@@ -113,7 +115,7 @@ func toUncPath(fp string) (string, error) {
 		return fp, nil
 	}
 
-	out, err := cmd.Command("net use").Output()
+	out, err := netUseOutput()
 	if err != nil {
 		return "", fmt.Errorf("failed to execute net use command: %s", err)
 	}
@@ -128,6 +130,34 @@ func toUncPath(fp string) (string, error) {
 	}
 
 	return fp, nil
+}
+
+func netUseOutput() ([]byte, error) {
+	var (
+		out     []byte
+		err     error
+		cmdErrs []string
+	)
+
+	cmds := [][]string{
+		{"net", "use"},
+		{"net.exe", "use"},
+	}
+
+	if winDir := os.Getenv("WINDIR"); winDir != "" {
+		cmds = append(cmds, []string{filepath.Join(winDir, "System32", "net.exe"), "use"})
+	}
+
+	for _, args := range cmds {
+		out, err = cmd.Command(args[0], args[1:]...).Output()
+		if err == nil {
+			return out, nil
+		}
+
+		cmdErrs = append(cmdErrs, fmt.Sprintf("%q: %s", strings.Join(args, " "), err))
+	}
+
+	return nil, errors.New(strings.Join(cmdErrs, "; "))
 }
 
 // driveLetter represents the letter of a drive.

--- a/pkg/windows/windows_internal_test.go
+++ b/pkg/windows/windows_internal_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,16 +33,22 @@ The command completed successfully.`
 )
 
 // testCommander implements commander interface.
-type testCommander struct{}
+type testCommander struct {
+	allowed []string
+}
 
 // Command uses the test executable (taken from os.Args[0]), to execute
 // TestNetUseOutput test to emulate `net use` command execution.
-func (testCommander) Command(_ string, args ...string) *exec.Cmd {
+func (c testCommander) Command(name string, args ...string) *exec.Cmd {
 	cs := []string{"-test.run=TestNetUseOutput", "--"}
+	cs = append(cs, name)
 	cs = append(cs, args...)
 	// nolint:gosec
 	cmd := exec.Command(os.Args[0], cs...)
-	cmd.Env = []string{"GO_WANT_TEST_OUTPUT=1"}
+	cmd.Env = []string{
+		"GO_WANT_TEST_OUTPUT=1",
+		fmt.Sprintf("GO_ALLOWED_NET_NAMES=%s", strings.Join(c.allowed, ",")),
+	}
 
 	return cmd
 }
@@ -54,13 +62,45 @@ func TestNetUseOutput(*testing.T) {
 		return
 	}
 
-	defer os.Exit(0)
+	args := os.Args
+
+	idx := len(args)
+	for i, arg := range args {
+		if arg == "--" {
+			idx = i + 1
+			break
+		}
+	}
+
+	if idx+1 >= len(args) {
+		os.Exit(1)
+	}
+
+	name := args[idx]
+	if args[idx+1] != "use" {
+		os.Exit(1)
+	}
+
+	allowed := strings.Split(os.Getenv("GO_ALLOWED_NET_NAMES"), ",")
+	isAllowed := false
+
+	for _, candidate := range allowed {
+		if candidate == name {
+			isAllowed = true
+			break
+		}
+	}
+
+	if !isAllowed {
+		os.Exit(1)
+	}
 
 	fmt.Print(netUseOutputMultiple)
+	os.Exit(0)
 }
 
 func TestFormatLocalFilePath(t *testing.T) {
-	cmd = testCommander{}
+	cmd = testCommander{allowed: []string{"net", "net.exe"}}
 	formatted, err := FormatLocalFilePath(`X:\localfile`, `S:\entity`)
 	require.NoError(t, err)
 
@@ -73,7 +113,7 @@ func TestFormatLocalFilePath_LocalFileExists(t *testing.T) {
 
 	defer tmpFile.Close()
 
-	cmd = testCommander{}
+	cmd = testCommander{allowed: []string{"net", "net.exe"}}
 	formatted, err := FormatLocalFilePath(tmpFile.Name(), `S:\entity`)
 	require.NoError(t, err)
 
@@ -86,7 +126,7 @@ func TestFormatLocalFilePath_EntityExists(t *testing.T) {
 
 	defer tmpFile.Close()
 
-	cmd = testCommander{}
+	cmd = testCommander{allowed: []string{"net", "net.exe"}}
 	formatted, err := FormatLocalFilePath(`X:\localfile`, tmpFile.Name())
 	require.NoError(t, err)
 
@@ -94,7 +134,7 @@ func TestFormatLocalFilePath_EntityExists(t *testing.T) {
 }
 
 func TestToUncPath(t *testing.T) {
-	cmd = testCommander{}
+	cmd = testCommander{allowed: []string{"net", "net.exe"}}
 	x, err := toUncPath(`S:\path\to\file`)
 	require.NoError(t, err)
 
@@ -102,11 +142,23 @@ func TestToUncPath(t *testing.T) {
 }
 
 func TestToUncPath_NoDrive(t *testing.T) {
-	cmd = testCommander{}
+	cmd = testCommander{allowed: []string{"net", "net.exe"}}
 	x, err := toUncPath(`path\to\file`)
 	require.NoError(t, err)
 
 	assert.Equal(t, `path\to\file`, x)
+}
+
+func TestToUncPath_FallbackToSystem32NetExe(t *testing.T) {
+	t.Setenv("WINDIR", `C:\Windows`)
+
+	system32NetExe := filepath.Join(`C:\Windows`, "System32", "net.exe")
+	cmd = testCommander{allowed: []string{system32NetExe}}
+
+	x, err := toUncPath(`S:\path\to\file`)
+	require.NoError(t, err)
+
+	assert.Equal(t, `\\tower\Movies\path\to\file`, x)
 }
 
 func TestParseNetUseOutput(t *testing.T) {


### PR DESCRIPTION
`net use` was the command, now `net` is the command and `use` is the first argument.

Fixes https://github.com/wakatime/jetbrains-wakatime/issues/313