### PR TITLE
Log net use output when unable to parse columns

### DIFF
--- a/pkg/windows/windows.go
+++ b/pkg/windows/windows.go
@@ -188,7 +188,7 @@ func parseNetUseOutput(text string) (remoteDrives, error) {
 		if cols.Empty() {
 			cols, err = parseNetUseColumns(line)
 			if err != nil {
-				return nil, fmt.Errorf("failed to parse columns from 'net use' output: %s", err)
+				return nil, fmt.Errorf("%s from 'net use' output: %s", err, strings.Join(lines, "\n"))
 			}
 
 			continue


### PR DESCRIPTION
Needed to debug the output from net use when unable to parse.