### PR TITLE
Fetch git tags on release

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -248,6 +248,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
       -
         name: Calculate semver tag
         id: semver-tag


### PR DESCRIPTION
Might fix failed version in [last release](https://github.com/wakatime/wakatime-cli/actions/runs/23708718072/job/69071286993).