### PR TITLE
Deprecate --sync-ai-after command

### DIFF
--- a/cmd/handler/option.go
+++ b/cmd/handler/option.go
@@ -22,8 +22,7 @@ type Preprocessor func(params params.Params) heartbeat.HandleOption
 func WithAIParsing() Preprocessor {
 	return func(params params.Params) heartbeat.HandleOption {
 		return ai.WithAISync(ai.Config{
-			SyncAfterTime: params.AI.SyncAfterTime,
-			SyncDisabled:  params.AI.SyncDisabled,
+			SyncDisabled: params.AI.SyncDisabled,
 		})
 	}
 }

--- a/cmd/heartbeat/heartbeat.go
+++ b/cmd/heartbeat/heartbeat.go
@@ -92,7 +92,7 @@ func SendHeartbeats(
 	setLogFields(ctx, params)
 	logger.Debugf("params: %s", params)
 
-	heartbeats, err := applyAIParsing(ctx, params, heartbeats)
+	heartbeats, err := applyAIParsing(ctx, v, params, heartbeats)
 	if err != nil {
 		return err
 	}
@@ -291,12 +291,13 @@ func initHandleOptions() []handler.Preprocessor {
 
 func applyAIParsing(
 	ctx context.Context,
+	v *viper.Viper,
 	params params.Params,
 	heartbeats []heartbeat.Heartbeat,
 ) ([]heartbeat.Heartbeat, error) {
 	handle := ai.WithAISync(ai.Config{
-		SyncAfterTime: params.AI.SyncAfterTime,
-		SyncDisabled:  params.AI.SyncDisabled,
+		SyncDisabled: params.AI.SyncDisabled,
+		V:            v,
 	})(func(_ context.Context, hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
 		results := make([]heartbeat.Result, len(hh))
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -242,7 +242,7 @@ func setFlags(cmd *cobra.Command, v *viper.Viper) {
 		"Override the bundled CA certs file. By default, uses"+
 			" system ca certs.",
 	)
-	flags.Float64("sync-ai-after", 0, "Parse AI transcript logs for Claude, Codex, Copilot, "+
+	flags.Float64("sync-ai-after", 0, "(deprecated) Parse AI transcript logs for Claude, Codex, Copilot, "+
 		"Cursor, etc. after a floating-point unix epoch timestamp. Sends any AI heartbeats"+
 		"along with normal heartbeats, changing the category of normal heartbeats to "+
 		"'AI Coding' before sending.")
@@ -292,6 +292,7 @@ func setFlags(cmd *cobra.Command, v *viper.Viper) {
 	_ = flags.MarkHidden("hide-filenames")
 	_ = flags.MarkHidden("hidefilenames")
 	_ = flags.MarkHidden("logfile")
+	_ = flags.MarkHidden("sync-ai-after")
 	_ = flags.MarkHidden("sync-ai-disable")
 
 	// hide internal flags

--- a/pkg/ai/ai.go
+++ b/pkg/ai/ai.go
@@ -2,16 +2,20 @@ package ai
 
 import (
 	"context"
+	"fmt"
 	"time"
 
+	"github.com/spf13/viper"
 	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
+	"github.com/wakatime/wakatime-cli/pkg/ini"
 	"github.com/wakatime/wakatime-cli/pkg/log"
+	"github.com/wakatime/wakatime-cli/pkg/vipertools"
 )
 
 // Config contains filtering configurations.
 type Config struct {
-	SyncAfterTime time.Time
-	SyncDisabled  bool
+	SyncDisabled bool
+	V            *viper.Viper
 }
 
 // ParserID represents an AI Parser ID.
@@ -77,7 +81,13 @@ func WithAISync(config Config) heartbeat.HandleOption {
 				return next(ctx, hh)
 			}
 
-			heartbeats, err := parseAIHeartbeats(ctx, config)
+			lastParsedAt, err := getLastParsedAt(ctx, config.V)
+			if err != nil {
+				logger.Debugf("failed ai last parsed: %s", err)
+				return next(ctx, hh)
+			}
+
+			heartbeats, err := parseAIHeartbeats(ctx, lastParsedAt)
 			if err != nil {
 				logger.Errorf("failed to parse ai heartbeats: %s", err)
 				return next(ctx, hh)
@@ -133,15 +143,15 @@ func WithAISync(config Config) heartbeat.HandleOption {
 	}
 }
 
-func parseAIHeartbeats(ctx context.Context, config Config) (Heartbeats, error) {
+func parseAIHeartbeats(ctx context.Context, after time.Time) (Heartbeats, error) {
 	logger := log.Extract(ctx)
 
 	var parsers = []Parser{
 		Claude{
-			After: config.SyncAfterTime,
+			After: after,
 		},
 		Codex{
-			After: config.SyncAfterTime,
+			After: after,
 		},
 		// Cursor{},
 	}
@@ -161,6 +171,44 @@ func parseAIHeartbeats(ctx context.Context, config Config) (Heartbeats, error) {
 	}
 
 	return nil, nil
+}
+
+func getLastParsedAt(ctx context.Context, v *viper.Viper) (time.Time, error) {
+	lastParsedAt := time.Now().Add(-1 * time.Minute)
+
+	if v == nil {
+		return lastParsedAt, fmt.Errorf("missing viper instance")
+	}
+
+	logger := log.Extract(ctx)
+
+	lastParsedAtStr := vipertools.GetString(v, "internal.ai_heartbeats_last_parsed_at")
+	if lastParsedAtStr != "" {
+		parsed, err := vipertools.SafeTimeParse(ini.DateFormat, lastParsedAtStr)
+		// nolint:gocritic
+		if err != nil {
+			logger.Warnf("failed to parse ai_heartbeats_last_parsed_at: %s", err)
+		} else if parsed.After(time.Now()) {
+			lastParsedAt = time.Now()
+		} else {
+			lastParsedAt = parsed
+		}
+	}
+
+	w, err := ini.NewWriter(ctx, v, ini.InternalFilePath)
+	if err != nil {
+		return lastParsedAt, fmt.Errorf("failed to parse internal config file: %s", err)
+	}
+
+	keyValue := map[string]string{
+		"ai_heartbeats_last_parsed_at": time.Now().Format(ini.DateFormat),
+	}
+
+	if err := w.Write(ctx, "internal", keyValue); err != nil {
+		return lastParsedAt, fmt.Errorf("failed to write to internal config file: %s", err)
+	}
+
+	return lastParsedAt, nil
 }
 
 // PreserveAttributes mutates aiHeartbeats pulling in the attributes from

--- a/pkg/ai/ai_test.go
+++ b/pkg/ai/ai_test.go
@@ -20,6 +20,7 @@ import (
 	cmdheartbeat "github.com/wakatime/wakatime-cli/cmd/heartbeat"
 	"github.com/wakatime/wakatime-cli/pkg/ai"
 	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
+	"github.com/wakatime/wakatime-cli/pkg/ini"
 	"github.com/wakatime/wakatime-cli/pkg/params"
 )
 
@@ -71,7 +72,41 @@ func TestPreserveAttributesMutatesAIHeartbeats(t *testing.T) {
 	assert.Equal(t, "/tmp/project", aiHeartbeats[0].ProjectPath)
 }
 
-/*
+func TestWithAISyncUpdatesLastParsedAtBeforeParsing(t *testing.T) {
+	tmpInternal, err := os.CreateTemp(t.TempDir(), "wakatime-internal")
+	require.NoError(t, err)
+
+	defer tmpInternal.Close()
+
+	v := viper.New()
+	v.Set("internal-config", tmpInternal.Name())
+
+	handle := ai.WithAISync(ai.Config{
+		V: v,
+	})(func(_ context.Context, hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+		results := make([]heartbeat.Result, len(hh))
+		for i := range hh {
+			results[i] = heartbeat.Result{Heartbeat: hh[i]}
+		}
+
+		return results, nil
+	})
+
+	_, err = handle(t.Context(), []heartbeat.Heartbeat{})
+	require.NoError(t, err)
+
+	writer, err := ini.NewWriter(t.Context(), v, ini.InternalFilePath)
+	require.NoError(t, err)
+
+	err = writer.File.Reload()
+	require.NoError(t, err)
+
+	lastParsedAt, err := writer.File.Section("internal").Key("ai_heartbeats_last_parsed_at").TimeFormat(ini.DateFormat)
+	require.NoError(t, err)
+
+	assert.WithinDuration(t, time.Now(), lastParsedAt, 2*time.Second)
+}
+
 func TestSendHeartbeats_WithAIParsing(t *testing.T) {
 	resetSingleton(t)
 
@@ -116,6 +151,11 @@ func TestSendHeartbeats_WithAIParsing(t *testing.T) {
 	require.NoError(t, err)
 
 	defer tmpFile.Close()
+
+	tmpInternalFile, err := os.CreateTemp(t.TempDir(), "wakatime-internal-config")
+	require.NoError(t, err)
+
+	defer tmpInternalFile.Close()
 
 	router.HandleFunc("/users/current/heartbeats.bulk", func(w http.ResponseWriter, req *http.Request) {
 		numCalls++
@@ -168,6 +208,7 @@ func TestSendHeartbeats_WithAIParsing(t *testing.T) {
 	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("api-url", testServerURL)
 	v.Set("config", tmpFile.Name())
+	v.Set("internal-config", tmpInternalFile.Name())
 	v.Set("category", "debugging")
 	v.Set("cursorpos", 42)
 	v.Set("entity", entity)
@@ -181,7 +222,7 @@ func TestSendHeartbeats_WithAIParsing(t *testing.T) {
 	v.Set("time", 1773835200.1)
 	v.Set("timeout", 5)
 	v.Set("write", true)
-	v.Set("sync-ai-after", float64(time.Date(2026, 3, 18, 11, 0, 0, 0, time.UTC).Unix()))
+	v.Set("internal.ai_heartbeats_last_parsed_at", time.Date(2026, 3, 18, 11, 0, 0, 0, time.UTC).Format(ini.DateFormat))
 
 	offlineQueueFile, err := os.CreateTemp(t.TempDir(), "")
 	require.NoError(t, err)
@@ -196,7 +237,6 @@ func TestSendHeartbeats_WithAIParsing(t *testing.T) {
 
 	assert.Eventually(t, func() bool { return numCalls == 1 }, time.Second, 50*time.Millisecond)
 }
-*/
 
 func TestSendHeartbeats_WithAIParsingDisabled(t *testing.T) {
 	resetSingleton(t)
@@ -240,6 +280,11 @@ func TestSendHeartbeats_WithAIParsingDisabled(t *testing.T) {
 	require.NoError(t, err)
 
 	defer tmpFile.Close()
+
+	tmpInternalFile, err := os.CreateTemp(t.TempDir(), "wakatime-internal-config")
+	require.NoError(t, err)
+
+	defer tmpInternalFile.Close()
 
 	router.HandleFunc("/users/current/heartbeats.bulk", func(w http.ResponseWriter, req *http.Request) {
 		numCalls++
@@ -287,6 +332,7 @@ func TestSendHeartbeats_WithAIParsingDisabled(t *testing.T) {
 	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("api-url", testServerURL)
 	v.Set("config", tmpFile.Name())
+	v.Set("internal-config", tmpInternalFile.Name())
 	v.Set("category", "debugging")
 	v.Set("cursorpos", 42)
 	v.Set("entity", entity)
@@ -300,7 +346,7 @@ func TestSendHeartbeats_WithAIParsingDisabled(t *testing.T) {
 	v.Set("time", 1773835200.1)
 	v.Set("timeout", 5)
 	v.Set("write", true)
-	v.Set("sync-ai-after", float64(time.Date(2026, 3, 18, 11, 0, 0, 0, time.UTC).Unix()))
+	v.Set("internal.ai_heartbeats_last_parsed_at", time.Date(2026, 3, 18, 11, 0, 0, 0, time.UTC).Format(ini.DateFormat))
 	v.Set("sync-ai-disabled", true)
 
 	offlineQueueFile, err := os.CreateTemp(t.TempDir(), "")
@@ -357,6 +403,11 @@ func TestSendHeartbeats_WithAIParsingBatchAppliedOnce(t *testing.T) {
 
 	defer tmpFile.Close()
 
+	tmpInternalFile, err := os.CreateTemp(t.TempDir(), "wakatime-internal-config")
+	require.NoError(t, err)
+
+	defer tmpInternalFile.Close()
+
 	router.HandleFunc("/users/current/heartbeats.bulk", func(w http.ResponseWriter, req *http.Request) {
 		numCalls++
 
@@ -389,6 +440,7 @@ func TestSendHeartbeats_WithAIParsingBatchAppliedOnce(t *testing.T) {
 	v.SetDefault("sync-offline-activity", 1000)
 	v.Set("api-url", testServerURL)
 	v.Set("config", tmpFile.Name())
+	v.Set("internal-config", tmpInternalFile.Name())
 	v.Set("category", "debugging")
 	v.Set("cursorpos", 42)
 	v.Set("entity", entity)
@@ -402,7 +454,7 @@ func TestSendHeartbeats_WithAIParsingBatchAppliedOnce(t *testing.T) {
 	v.Set("time", 1773835200.1)
 	v.Set("timeout", 5)
 	v.Set("write", true)
-	v.Set("sync-ai-after", float64(time.Date(2026, 3, 18, 11, 0, 0, 0, time.UTC).Unix()))
+	v.Set("internal.ai_heartbeats_last_parsed_at", time.Date(2026, 3, 18, 11, 0, 0, 0, time.UTC).Format(ini.DateFormat))
 
 	params, heartbeats, err := testLoadParamsAndHeartbeats(t.Context(), v)
 	require.NoError(t, err)

--- a/pkg/params/params.go
+++ b/pkg/params/params.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
-	"runtime/debug"
 	"strconv"
 	"strings"
 	"sync"
@@ -238,8 +237,7 @@ type (
 
 	// AIParams contains AI sync command parameters.
 	AIParams struct {
-		SyncAfterTime time.Time
-		SyncDisabled  bool
+		SyncDisabled bool
 	}
 
 	// Offline contains offline related parameters.
@@ -470,7 +468,7 @@ func loadBackoffParams(ctx context.Context, v *viper.Viper) (backoffAt time.Time
 
 	backoffAtStr := vipertools.GetString(v, "internal.backoff_at")
 	if backoffAtStr != "" {
-		parsed, err := safeTimeParse(ini.DateFormat, backoffAtStr)
+		parsed, err := vipertools.SafeTimeParse(ini.DateFormat, backoffAtStr)
 		// nolint:gocritic
 		if err != nil {
 			logger.Warnf("failed to parse backoff_at: %s", err)
@@ -870,20 +868,8 @@ func loadProjectMapPatterns(ctx context.Context, v *viper.Viper, prefix string) 
 
 // LoadAIParams loads ai sync params from viper.Viper instance.
 func LoadAIParams(_ context.Context, v *viper.Viper, _ FlagReadOrder) (AIParams, error) {
-	syncAIAfter := v.GetFloat64("sync-ai-after")
-
-	var syncAfterTime time.Time
-	if syncAIAfter == 0 {
-		syncAfterTime = time.Now().Add(2 * time.Minute)
-	} else {
-		syncAfterTime = time.Unix(0, int64(syncAIAfter*float64(time.Second)))
-	}
-
-	// Disable AI parsing until #1288 fixed
 	return AIParams{
-		SyncAfterTime: syncAfterTime,
-		SyncDisabled: true ||
-			v.GetBool("sync-ai-disable") ||
+		SyncDisabled: v.GetBool("sync-ai-disable") ||
 			v.GetBool("sync-ai-disabled") ||
 			v.GetBool("settings.sync_ai_disabled"),
 	}, nil
@@ -933,7 +919,7 @@ func LoadOfflineParams(ctx context.Context, v *viper.Viper, order FlagReadOrder)
 
 	lastSentAtStr := vipertools.GetString(v, "internal.heartbeats_last_sent_at")
 	if lastSentAtStr != "" {
-		parsed, err := safeTimeParse(ini.DateFormat, lastSentAtStr)
+		parsed, err := vipertools.SafeTimeParse(ini.DateFormat, lastSentAtStr)
 		// nolint:gocritic
 		if err != nil {
 			logger.Warnf("failed to parse heartbeats_last_sent_at: %s", err)
@@ -997,18 +983,6 @@ func LoadStatusBarParams(v *viper.Viper, order FlagReadOrder) (StatusBar, error)
 		MaxCategories:  maxCategories,
 		Output:         out,
 	}, nil
-}
-
-func safeTimeParse(format, s string) (parsed time.Time, err error) {
-	defer func() {
-		if r := recover(); r != nil {
-			err = fmt.Errorf("panicked: failed to time.Parse: %v. Stack: %s", r, string(debug.Stack()))
-		}
-	}()
-
-	parsed, err = time.Parse(format, s)
-
-	return parsed, err
 }
 
 func readAPIKeyFromCommand(cmdStr string) (string, error) {
@@ -1379,14 +1353,8 @@ func (p Offline) String() string {
 
 // String implements fmt.Stringer interface.
 func (p AIParams) String() string {
-	var syncAfterTime string
-	if !p.SyncAfterTime.IsZero() {
-		syncAfterTime = p.SyncAfterTime.Format(ini.DateFormat)
-	}
-
 	return fmt.Sprintf(
-		"sync after time: '%s', disabled: %t",
-		syncAfterTime,
+		"disabled: %t",
 		p.SyncDisabled,
 	)
 }

--- a/pkg/params/params_internal_test.go
+++ b/pkg/params/params_internal_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/wakatime/wakatime-cli/pkg/ini"
 	"github.com/wakatime/wakatime-cli/pkg/regex"
+	"github.com/wakatime/wakatime-cli/pkg/vipertools"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -65,7 +66,7 @@ func TestParseBoolOrRegexList(t *testing.T) {
 }
 
 func TestSafeTimeParse(t *testing.T) {
-	parsed, err := safeTimeParse(ini.DateFormat, "2024-01-13T13:35:58Z")
+	parsed, err := vipertools.SafeTimeParse(ini.DateFormat, "2024-01-13T13:35:58Z")
 	require.NoError(t, err)
 
 	assert.Equal(t, time.Date(2024, 1, 13, 13, 35, 58, 0, time.UTC), parsed)
@@ -88,7 +89,7 @@ func TestSafeTimeParse_Err(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			parsed, err := safeTimeParse(ini.DateFormat, test.Input)
+			parsed, err := vipertools.SafeTimeParse(ini.DateFormat, test.Input)
 			require.Equal(t, time.Time{}, parsed)
 
 			assert.EqualError(t, err, test.Expected)

--- a/pkg/params/params_test.go
+++ b/pkg/params/params_test.go
@@ -3138,17 +3138,13 @@ func TestOffline_String(t *testing.T) {
 }
 
 func TestParamsString_IncludesAIParams(t *testing.T) {
-	syncAfterTime, err := time.Parse(inipkg.DateFormat, "2026-03-29T07:35:07-04:00")
-	require.NoError(t, err)
-
 	params := paramspkg.AIParams{
-		SyncAfterTime: syncAfterTime,
-		SyncDisabled:  true,
+		SyncDisabled: true,
 	}
 
 	assert.Equal(
 		t,
-		"sync after time: '2026-03-29T07:35:07-04:00', disabled: true",
+		"disabled: true",
 		params.String(),
 	)
 }

--- a/pkg/vipertools/vipertools.go
+++ b/pkg/vipertools/vipertools.go
@@ -2,7 +2,9 @@ package vipertools
 
 import (
 	"fmt"
+	"runtime/debug"
 	"strings"
+	"time"
 
 	viperini "github.com/go-viper/encoding/ini"
 	"github.com/spf13/cast"
@@ -131,4 +133,17 @@ func GetStringMapString(v *viper.Viper, prefix string) map[string]string {
 	}
 
 	return m
+}
+
+// SafeTimeParse turns a string into a time.Time.
+func SafeTimeParse(format, s string) (parsed time.Time, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("panicked: failed to time.Parse: %v. Stack: %s", r, string(debug.Stack()))
+		}
+	}()
+
+	parsed, err = time.Parse(format, s)
+
+	return parsed, err
 }


### PR DESCRIPTION
Instead, keep track of last parsed ai transcripts timestamp in the `internal.ai_heartbeats_last_parsed_at` ini config.