### PR TITLE
Disable parsing Cursor transcripts on BSD

### DIFF
--- a/pkg/ai/cursor.go
+++ b/pkg/ai/cursor.go
@@ -1,3 +1,5 @@
+//go:build !freebsd && !openbsd && !netbsd && !dragonfly
+
 package ai
 
 import (

--- a/pkg/ai/cursor_stub.go
+++ b/pkg/ai/cursor_stub.go
@@ -1,0 +1,25 @@
+//go:build freebsd || openbsd || netbsd || dragonfly
+
+package ai
+
+import (
+	"context"
+	"time"
+)
+
+// Cursor contains params for detecting heartbeats from Cursor transcripts.
+type Cursor struct {
+	After             time.Time
+	FallbackUserAgent string
+	UserAgents        map[string]string
+}
+
+// Parse is a no-op on BSD because the Cursor SQLite reader is not built there.
+func (Cursor) Parse(context.Context) (Heartbeats, error) {
+	return Heartbeats{}, nil
+}
+
+// ID returns its id.
+func (Cursor) ID() ParserID {
+	return CursorParser
+}

--- a/pkg/ai/cursor_test.go
+++ b/pkg/ai/cursor_test.go
@@ -1,3 +1,5 @@
+//go:build !freebsd && !openbsd && !netbsd && !dragonfly
+
 package ai_test
 
 import (


### PR DESCRIPTION
```
# modernc.org/libc
Error: ../../../go/pkg/mod/modernc.org/libc@v1.70.0/libc_freebsd.go:247:25: cannot use int64(off) (value of type int64) as int32 value in assignment
Error: ../../../go/pkg/mod/modernc.org/libc@v1.70.0/libc_freebsd.go:269:50: cannot use int64(off) (value of type int64) as int32 value in assignment
Error: ../../../go/pkg/mod/modernc.org/libc@v1.70.0/libc_freebsd.go:1642:17: invalid operation: Uint64(Uint64FromInt32(-1)) / uint64(255) * size_t(c) (mismatched types uint64 and size_t)
Error: ../../../go/pkg/mod/modernc.org/libc@v1.70.0/libc_freebsd.go:1643:192: invalid operation: *(*uint64)(unsafe.Pointer(w)) ^ k (mismatched types uint64 and size_t)
Error: ../../../go/pkg/mod/modernc.org/libc@v1.70.0/libc_freebsd.go:1662:42: cannot use &l1 (value of type *size_t) as *uint64 value in argument to AssignUint64
Error: ../../../go/pkg/mod/modernc.org/libc@v1.70.0/libc_freebsd.go:1662:47: cannot use size_t((int64(X__strchrnul(tls, var1, '=')) - int64(var1)) / 1) (value of uint32 type size_t) as uint64 value in argument to AssignUint64
Error: ../../../go/pkg/mod/modernc.org/libc@v1.70.0/libc_freebsd.go:1671:19: invalid operation: l1 + l2 + uint64(2) (mismatched types size_t and uint64)
Error: ../../../go/pkg/mod/modernc.org/libc@v1.70.0/libc_freebsd.go:1677:48: invalid operation: l2 + uint64(1) (mismatched types size_t and uint64)
Error: ../../../go/pkg/mod/modernc.org/libc@v1.70.0/libc_freebsd.go:1690:6: cannot use uint64(0) (constant 0 of type uint64) as size_t value in assignment
Error: ../../../go/pkg/mod/modernc.org/libc@v1.70.0/libc_freebsd.go:1700:57: invalid operation: l + uint64(1) (mismatched types size_t and uint64)
Error: ../../../go/pkg/mod/modernc.org/libc@v1.70.0/libc_freebsd.go:1700:57: too many errors
```