### PR TITLE
Sync AI Activity command line param

### DIFF
--- a/cmd/heartbeat/ai_sync.go
+++ b/cmd/heartbeat/ai_sync.go
@@ -1,0 +1,69 @@
+package heartbeat
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/wakatime/wakatime-cli/pkg/exitcode"
+	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
+	"github.com/wakatime/wakatime-cli/pkg/log"
+	"github.com/wakatime/wakatime-cli/pkg/offline"
+	"github.com/wakatime/wakatime-cli/pkg/params"
+	"github.com/wakatime/wakatime-cli/pkg/wakaerror"
+
+	"github.com/spf13/viper"
+)
+
+// RunAISyncActivity parses AI transcripts and sends resulting AI heartbeats
+// without requiring a CLI heartbeat entity.
+func RunAISyncActivity(ctx context.Context, v *viper.Viper) (int, error) {
+	logger := log.Extract(ctx)
+
+	queueFilepath, err := offline.QueueFilepath(ctx, v)
+	if err != nil {
+		logger.Warnf("failed to load offline queue filepath: %s", err)
+	}
+
+	aiParams, err := params.LoadAIParams(ctx, v, params.FlagReadOrderFlagPrecedence)
+	if err != nil {
+		return exitcode.ErrAuth, fmt.Errorf("failed to load ai parameters: %w", err)
+	}
+
+	apiParams, err := params.LoadAPIParams(ctx, v, params.FlagReadOrderFlagPrecedence)
+	if err != nil {
+		return exitcode.ErrAuth, fmt.Errorf("failed to load API parameters: %w", err)
+	}
+
+	loadedParams := params.Params{
+		AI:      aiParams,
+		API:     apiParams,
+		Offline: params.LoadOfflineParams(ctx, v, params.FlagReadOrderFlagPrecedence),
+	}
+
+	heartbeats, err := applyAIParsing(ctx, v, loadedParams, []heartbeat.Heartbeat{})
+	if err != nil {
+		if errwaka, ok := err.(wakaerror.Error); ok {
+			return errwaka.ExitCode(), fmt.Errorf("sending ai activity failed: %w", errwaka)
+		}
+
+		return exitcode.ErrGeneric, fmt.Errorf("sending ai activity failed: %w", err)
+	}
+
+	if len(heartbeats) == 0 {
+		logger.Debugln("no ai activity found to sync")
+
+		return exitcode.Success, nil
+	}
+
+	if err := sendPreparedHeartbeats(ctx, v, loadedParams, queueFilepath, heartbeats, false); err != nil {
+		if errwaka, ok := err.(wakaerror.Error); ok {
+			return errwaka.ExitCode(), fmt.Errorf("sending ai activity failed: %w", errwaka)
+		}
+
+		return exitcode.ErrGeneric, fmt.Errorf("sending ai activity failed: %w", err)
+	}
+
+	logger.Debugln("successfully synced ai activity")
+
+	return exitcode.Success, nil
+}

--- a/cmd/heartbeat/ai_sync_test.go
+++ b/cmd/heartbeat/ai_sync_test.go
@@ -1,0 +1,106 @@
+package heartbeat_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	cmdheartbeat "github.com/wakatime/wakatime-cli/cmd/heartbeat"
+	"github.com/wakatime/wakatime-cli/pkg/ini"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunAISyncActivity_SendsAIHeartbeatsWithoutEntity(t *testing.T) {
+	resetSingleton(t)
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	entity, err := filepath.Abs("testdata/main.go")
+	require.NoError(t, err)
+
+	entity = strings.ReplaceAll(entity, "\\", "/")
+
+	transcriptDir := filepath.Join(home, ".claude", "projects", "sample-project")
+	require.NoError(t, os.MkdirAll(transcriptDir, 0o755))
+
+	transcriptPath := filepath.Join(transcriptDir, "session.jsonl")
+	transcript := strings.Join([]string{
+		"{\"timestamp\":\"2026-03-18T12:00:00Z\",\"version\":\"2.1.45\"," +
+			"\"toolUseResult\":{\"filePath\":\"" + entity + "\"," +
+			"\"structuredPatch\":[{\"oldLines\":3,\"newLines\":5},{\"oldLines\":4,\"newLines\":1}]}}",
+	}, "\n") + "\n"
+	require.NoError(t, os.WriteFile(transcriptPath, []byte(transcript), 0o644))
+
+	testServerURL, router, tearDown := setupTestServer()
+	defer tearDown()
+
+	var numCalls int
+
+	router.HandleFunc("/users/current/heartbeats.bulk", func(w http.ResponseWriter, req *http.Request) {
+		numCalls++
+
+		assert.Equal(t, http.MethodPost, req.Method)
+		assert.Equal(t, []string{"application/json"}, req.Header["Accept"])
+		assert.Equal(t, []string{"application/json"}, req.Header["Content-Type"])
+
+		body, err := io.ReadAll(req.Body)
+		require.NoError(t, err)
+
+		var entities []struct {
+			Entity       string  `json:"entity"`
+			Category     string  `json:"category"`
+			Language     *string `json:"language"`
+			UserAgent    string  `json:"user_agent"`
+			AILineChange *int    `json:"ai_line_changes"`
+		}
+
+		require.NoError(t, json.Unmarshal(body, &entities))
+		require.Len(t, entities, 1)
+		assert.Equal(t, entity, entities[0].Entity)
+		assert.Equal(t, "ai coding", entities[0].Category)
+		require.NotNil(t, entities[0].Language)
+		assert.Equal(t, "Go", *entities[0].Language)
+		require.NotNil(t, entities[0].AILineChange)
+		assert.Equal(t, -1, *entities[0].AILineChange)
+		assert.Contains(t, entities[0].UserAgent, "ClaudeCode/2.1.45")
+		assert.Contains(t, entities[0].UserAgent, "plugin/0.0.1")
+
+		w.WriteHeader(http.StatusCreated)
+
+		f, err := os.Open("testdata/api_heartbeats_response.json")
+		require.NoError(t, err)
+
+		defer f.Close()
+
+		_, err = io.Copy(w, f)
+		require.NoError(t, err)
+	})
+
+	tmpInternalFile, err := os.CreateTemp(t.TempDir(), "wakatime-internal-config")
+	require.NoError(t, err)
+
+	defer tmpInternalFile.Close()
+
+	v := viper.New()
+	v.Set("api-url", testServerURL)
+	v.Set("internal-config", tmpInternalFile.Name())
+	v.Set("key", "00000000-0000-4000-8000-000000000000")
+	v.Set("plugin", "plugin/0.0.1")
+	v.Set("timeout", 5)
+	v.Set("internal.ai_heartbeats_last_parsed_at", time.Date(2026, 3, 18, 11, 0, 0, 0, time.UTC).Format(ini.DateFormat))
+
+	code, err := cmdheartbeat.RunAISyncActivity(t.Context(), v)
+	require.NoError(t, err)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, 1, numCalls)
+}

--- a/cmd/heartbeat/heartbeat.go
+++ b/cmd/heartbeat/heartbeat.go
@@ -97,82 +97,7 @@ func SendHeartbeats(
 		return err
 	}
 
-	if ratelimit.IsRateLimited(ratelimit.Params{
-		Disabled:   params.Offline.Disabled,
-		LastSentAt: params.Offline.LastSentAt,
-		Timeout:    params.Offline.RateLimit,
-	}) {
-		err := offlinecmd.SaveHeartbeats(ctx, v, queueFilepath, heartbeats)
-		if err == nil {
-			return nil
-		}
-
-		// log offline db error then try to send heartbeats to API so they're not lost
-		logger.Errorf("failed to save rate limited heartbeats: %s", err)
-	}
-
-	var (
-		chOfflineSave = make(chan bool)
-		savedOffline  bool
-	)
-
-	// only send at once the maximum amount of `offline.SendLimit`.
-	if len(heartbeats) > offline.SendLimit {
-		savedOffline = true
-
-		extraHeartbeats := heartbeats[offline.SendLimit:]
-
-		logger.Debugf("save %d extra heartbeat(s) to offline queue", len(extraHeartbeats))
-
-		go func(done chan<- bool) {
-			if err := offlinecmd.SaveHeartbeats(ctx, v, queueFilepath, extraHeartbeats); err != nil {
-				logger.Errorf("failed to save extra heartbeats to offline queue: %s", err)
-			}
-
-			done <- true
-		}(chOfflineSave)
-
-		heartbeats = heartbeats[:offline.SendLimit]
-	}
-
-	handleOpts := initHandleOptions()
-
-	sender, err := buildHandle(ctx, v, params, queueFilepath)
-	if err != nil {
-		if err := offlinecmd.SaveHeartbeats(ctx, v, queueFilepath, heartbeats); err != nil {
-			log.Extract(ctx).Errorf("failed to save extra heartbeats to offline queue: %s", err)
-		}
-
-		return fmt.Errorf("failed to initialize api client: %w", err)
-	}
-
-	handle := handler.New(v, handler.Config{
-		Params:       params,
-		ParamsLoader: loadParams,
-		Opts:         handleOpts,
-	})(sender)
-	results, err := handle(ctx, heartbeats)
-
-	// wait for offline queue save to finish
-	if savedOffline {
-		<-chOfflineSave
-	}
-
-	if err != nil {
-		return err
-	}
-
-	for _, result := range results {
-		if len(result.Errors) > 0 {
-			logger.Warnln(strings.Join(result.Errors, " "))
-		}
-	}
-
-	if err := ratelimit.Reset(ctx, v); err != nil {
-		logger.Errorf("failed to reset rate limit: %s", err)
-	}
-
-	return nil
+	return sendPreparedHeartbeats(ctx, v, params, queueFilepath, heartbeats, true)
 }
 
 func loadParams(
@@ -320,6 +245,102 @@ func applyAIParsing(
 	}
 
 	return parsed, nil
+}
+
+func sendPreparedHeartbeats(
+	ctx context.Context,
+	v *viper.Viper,
+	params params.Params,
+	queueFilepath string,
+	heartbeats []heartbeat.Heartbeat,
+	withProjectConfig bool,
+) error {
+	logger := log.Extract(ctx)
+
+	setLogFields(ctx, params)
+	logger.Debugf("params: %s", params)
+
+	if ratelimit.IsRateLimited(ratelimit.Params{
+		Disabled:   params.Offline.Disabled,
+		LastSentAt: params.Offline.LastSentAt,
+		Timeout:    params.Offline.RateLimit,
+	}) {
+		err := offlinecmd.SaveHeartbeats(ctx, v, queueFilepath, heartbeats)
+		if err == nil {
+			return nil
+		}
+
+		logger.Errorf("failed to save rate limited heartbeats: %s", err)
+	}
+
+	var (
+		chOfflineSave = make(chan bool)
+		savedOffline  bool
+	)
+
+	if len(heartbeats) > offline.SendLimit {
+		savedOffline = true
+
+		extraHeartbeats := heartbeats[offline.SendLimit:]
+
+		logger.Debugf("save %d extra heartbeat(s) to offline queue", len(extraHeartbeats))
+
+		go func(done chan<- bool) {
+			if err := offlinecmd.SaveHeartbeats(ctx, v, queueFilepath, extraHeartbeats); err != nil {
+				logger.Errorf("failed to save extra heartbeats to offline queue: %s", err)
+			}
+
+			done <- true
+		}(chOfflineSave)
+
+		heartbeats = heartbeats[:offline.SendLimit]
+	}
+
+	sender, err := buildHandle(ctx, v, params, queueFilepath)
+	if err != nil {
+		if err := offlinecmd.SaveHeartbeats(ctx, v, queueFilepath, heartbeats); err != nil {
+			logger.Errorf("failed to save extra heartbeats to offline queue: %s", err)
+		}
+
+		return fmt.Errorf("failed to initialize api client: %w", err)
+	}
+
+	opts := initHandleOptions()
+
+	handle := sender
+	if withProjectConfig {
+		handle = handler.New(v, handler.Config{
+			Params:       params,
+			ParamsLoader: loadParams,
+			Opts:         opts,
+		})(sender)
+	} else {
+		for i := len(opts) - 1; i >= 0; i-- {
+			handle = opts[i](params)(handle)
+		}
+	}
+
+	results, err := handle(ctx, heartbeats)
+
+	if savedOffline {
+		<-chOfflineSave
+	}
+
+	if err != nil {
+		return err
+	}
+
+	for _, result := range results {
+		if len(result.Errors) > 0 {
+			logger.Warnln(strings.Join(result.Errors, " "))
+		}
+	}
+
+	if err := ratelimit.Reset(ctx, v); err != nil {
+		logger.Errorf("failed to reset rate limit: %s", err)
+	}
+
+	return nil
 }
 
 func setLogFields(ctx context.Context, params params.Params) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -246,6 +246,12 @@ func setFlags(cmd *cobra.Command, v *viper.Viper) {
 		"Cursor, etc. after a floating-point unix epoch timestamp. Sends any AI heartbeats"+
 		"along with normal heartbeats, changing the category of normal heartbeats to "+
 		"'AI Coding' before sending.")
+	flags.Bool(
+		"sync-ai-activity",
+		false,
+		"Parse AI transcript logs for Claude, Codex, Cursor, etc. and send any resulting AI heartbeats"+
+			" without requiring --entity.",
+	)
 	flags.Bool("sync-ai-disabled", false, "Disable parsing AI transcript logs when sending heartbeats. "+
 		"By default, AI transcript logs are parsed every time when sending heartbeats.")
 	flags.Bool("sync-ai-disable", false, "")

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -144,6 +144,12 @@ func RunE(cmd *cobra.Command, v *viper.Viper) error {
 		return RunCmd(ctx, v, logger.IsVerboseEnabled(), logger.SendDiagsOnErrors(), offlinesync.RunWithoutRateLimiting)
 	}
 
+	if v.GetBool("sync-ai-activity") {
+		logger.Debugln("command: sync-ai-activity")
+
+		return RunCmd(ctx, v, logger.IsVerboseEnabled(), logger.SendDiagsOnErrors(), cmdheartbeat.RunAISyncActivity)
+	}
+
 	if v.GetBool("offline-count") {
 		logger.Debugln("command: offline-count")
 
@@ -163,6 +169,7 @@ func RunE(cmd *cobra.Command, v *viper.Viper) error {
 		"--file-experts",
 		"--offline-count",
 		"--print-offline-heartbeats",
+		"--sync-ai-activity",
 		"--sync-offline-activity",
 		"--today",
 		"--today-goal",


### PR DESCRIPTION
New param `--sync-ai-activity` to parse AI transcript logs without needing an `--entity` heartbeat.