### PR TITLE
Fix building AI user agent strings

### DIFF
--- a/cmd/heartbeat/heartbeat.go
+++ b/cmd/heartbeat/heartbeat.go
@@ -41,7 +41,7 @@ func Run(ctx context.Context, v *viper.Viper) (int, error) {
 	if err != nil {
 		logger.Errorf("sending heartbeats failed: %s", err)
 
-		if errSave := offlinecmd.SaveHeartbeats(ctx, v, queueFilepath, heartbeats); errSave != nil {
+		if errSave := offlinecmd.SaveHeartbeats(ctx, v, queueFilepath, renderUserAgents(ctx, heartbeats)); errSave != nil {
 			return exitcode.ErrConfigFileParse, fmt.Errorf("failed to save heartbeats to offline queue: %s", errSave)
 		}
 
@@ -55,7 +55,7 @@ func Run(ctx context.Context, v *viper.Viper) (int, error) {
 		// api.ErrAuth represents an error when parsing api key or timeout.
 		// Save heartbeats to offline db when api.ErrAuth as it avoids losing heartbeats.
 		if errors.As(err, &errauth) {
-			if err := offlinecmd.SaveHeartbeats(ctx, v, queueFilepath, heartbeats); err != nil {
+			if err := offlinecmd.SaveHeartbeats(ctx, v, queueFilepath, renderUserAgents(ctx, heartbeats)); err != nil {
 				logger.Errorf("failed to save heartbeats to offline queue: %s", err)
 			}
 
@@ -155,8 +155,6 @@ func buildHandle(ctx context.Context, v *viper.Viper, params params.Params, queu
 
 // BuildHeartbeats builds the command line heartbeat then appends any extra stdin heartbeats.
 func BuildHeartbeats(ctx context.Context, plugin string, heartbeatParams params.Heartbeat) []heartbeat.Heartbeat {
-	userAgent := heartbeat.UserAgent(ctx, plugin)
-
 	var heartbeats = make([]heartbeat.Heartbeat, 0, 1+len(heartbeatParams.ExtraHeartbeats))
 
 	heartbeats = append(heartbeats, heartbeat.New(
@@ -179,7 +177,7 @@ func BuildHeartbeats(ctx context.Context, plugin string, heartbeatParams params.
 		heartbeatParams.Project.Override,
 		heartbeatParams.Sanitize.ProjectPathOverride,
 		heartbeatParams.Time,
-		userAgent,
+		plugin,
 	))
 
 	if len(heartbeatParams.ExtraHeartbeats) > 0 {
@@ -187,10 +185,18 @@ func BuildHeartbeats(ctx context.Context, plugin string, heartbeatParams params.
 		logger.Debugf("include %d extra heartbeat(s) from stdin", len(heartbeatParams.ExtraHeartbeats))
 
 		for _, h := range heartbeatParams.ExtraHeartbeats {
-			h.UserAgent = userAgent
+			h.UserAgent = plugin
 
 			heartbeats = append(heartbeats, h)
 		}
+	}
+
+	return heartbeats
+}
+
+func renderUserAgents(ctx context.Context, heartbeats []heartbeat.Heartbeat) []heartbeat.Heartbeat {
+	for i := range heartbeats {
+		heartbeats[i].UserAgent = heartbeat.UserAgent(ctx, heartbeats[i].UserAgent)
 	}
 
 	return heartbeats
@@ -258,6 +264,8 @@ func sendPreparedHeartbeats(
 	withProjectConfig bool,
 ) error {
 	logger := log.Extract(ctx)
+
+	heartbeats = renderUserAgents(ctx, heartbeats)
 
 	setLogFields(ctx, params)
 	logger.Debugf("params: %s", params)

--- a/pkg/ai/ai.go
+++ b/pkg/ai/ai.go
@@ -427,15 +427,15 @@ func entityUserAgents(hh []heartbeat.Heartbeat) map[string]string {
 	return userAgents
 }
 
-func aiUserAgent(ctx context.Context, entity string, userAgents map[string]string, fallback string, parser string) string {
+func aiUserAgent(entity string, userAgents map[string]string, fallback string, parser string) string {
 	existing := fallback
 	if fromHeartbeat, found := userAgents[entity]; found && fromHeartbeat != "" {
 		existing = fromHeartbeat
 	}
 
 	if existing != "" {
-		return heartbeat.UserAgent(ctx, parser+" "+existing)
+		return parser + " " + existing
 	}
 
-	return heartbeat.UserAgent(ctx, parser)
+	return parser
 }

--- a/pkg/ai/ai_test.go
+++ b/pkg/ai/ai_test.go
@@ -143,7 +143,11 @@ func TestSendHeartbeats_WithAIParsing(t *testing.T) {
 		assert.Equal(t, "wakatime-cli", *entities[0].Project)
 		assert.Equal(t, "Golang", *entities[0].Language)
 		assert.Greater(t, *entities[0].ProjectRootCount, 1)
-		assert.Contains(t, entities[0].UserAgent, heartbeat.UserAgent(t.Context(), plugin))
+		assert.Equal(
+			t,
+			heartbeat.UserAgent(t.Context(), "ClaudeCode/2.1.45 "+plugin),
+			entities[0].UserAgent,
+		)
 		assert.Contains(t, entities[0].UserAgent, "ClaudeCode/2.1.45")
 		assert.Equal(t, local, entities[1].Entity)
 

--- a/pkg/ai/claude.go
+++ b/pkg/ai/claude.go
@@ -288,7 +288,7 @@ func (g Claude) parseTranscript(ctx context.Context, transcript string) (Heartbe
 			continue
 		}
 
-		heartbeats = append(heartbeats, g.claudeHeartbeats(ctx, logLine, sessionEntity, claudeVersion, cwd)...)
+		heartbeats = append(heartbeats, g.claudeHeartbeats(logLine, sessionEntity, claudeVersion, cwd)...)
 	}
 
 	if err := scanner.Err(); err != nil {
@@ -299,7 +299,6 @@ func (g Claude) parseTranscript(ctx context.Context, transcript string) (Heartbe
 }
 
 func (g Claude) claudeHeartbeats(
-	ctx context.Context,
 	logLine claudeLogLine,
 	sessionEntity string,
 	version string,
@@ -307,11 +306,11 @@ func (g Claude) claudeHeartbeats(
 ) Heartbeats {
 	var heartbeats Heartbeats
 
-	if heartbeat := g.claudeAppHeartbeat(ctx, logLine, sessionEntity, version, cwd); heartbeat != nil {
+	if heartbeat := g.claudeAppHeartbeat(logLine, sessionEntity, version, cwd); heartbeat != nil {
 		heartbeats = append(heartbeats, *heartbeat)
 	}
 
-	if heartbeat := g.claudeFileHeartbeat(ctx, logLine, version); heartbeat != nil {
+	if heartbeat := g.claudeFileHeartbeat(logLine, version); heartbeat != nil {
 		heartbeats = append(heartbeats, *heartbeat)
 	}
 
@@ -319,7 +318,6 @@ func (g Claude) claudeHeartbeats(
 }
 
 func (g Claude) claudeAppHeartbeat(
-	ctx context.Context,
 	logLine claudeLogLine,
 	sessionEntity string,
 	version string,
@@ -350,13 +348,13 @@ func (g Claude) claudeAppHeartbeat(
 		"",
 		cwd,
 		float64(logLine.Timestamp.Unix()),
-		aiUserAgent(ctx, sessionEntity, g.UserAgents, g.FallbackUserAgent, claudePlugin(version)),
+		aiUserAgent(sessionEntity, g.UserAgents, g.FallbackUserAgent, claudePlugin(version)),
 	)
 
 	return &h
 }
 
-func (g Claude) claudeFileHeartbeat(ctx context.Context, logLine claudeLogLine, version string) *heartbeat.Heartbeat {
+func (g Claude) claudeFileHeartbeat(logLine claudeLogLine, version string) *heartbeat.Heartbeat {
 	if logLine.ToolUseResult == nil || logLine.ToolUseResult.Object == nil {
 		return nil
 	}
@@ -389,7 +387,7 @@ func (g Claude) claudeFileHeartbeat(ctx context.Context, logLine claudeLogLine, 
 		"",
 		"",
 		float64(logLine.Timestamp.Unix()),
-		aiUserAgent(ctx, filePath, g.UserAgents, g.FallbackUserAgent, claudePlugin(version)),
+		aiUserAgent(filePath, g.UserAgents, g.FallbackUserAgent, claudePlugin(version)),
 	)
 
 	return &h

--- a/pkg/ai/claude_test.go
+++ b/pkg/ai/claude_test.go
@@ -72,7 +72,11 @@ func TestClaudeParse(t *testing.T) {
 	require.NotNil(t, got[0].IsWrite)
 	assert.True(t, *got[0].IsWrite)
 	assert.Equal(t, float64(time.Date(2026, 3, 18, 12, 0, 0, 0, time.UTC).Unix()), got[0].Time)
-	assert.Contains(t, got[0].UserAgent, heartbeat.UserAgent(ctx, "editor/1.2.3"))
+	assert.Equal(
+		t,
+		"ClaudeCode/2.1.45 "+heartbeat.UserAgent(ctx, "editor/1.2.3"),
+		got[0].UserAgent,
+	)
 	assert.Contains(t, got[0].UserAgent, "ClaudeCode/2.1.45")
 
 	assert.Equal(t, "Claude session", got[1].Entity)

--- a/pkg/ai/codex.go
+++ b/pkg/ai/codex.go
@@ -210,7 +210,6 @@ func (g Codex) parseTranscript(ctx context.Context, transcript string) (Heartbea
 		}
 
 		entities := getCodexEntities(
-			ctx,
 			logLine.Timestamp,
 			sessionEntity,
 			version,
@@ -250,7 +249,6 @@ func codexSessionInfo(cwd string, version string, sessionMeta *codexSessionMeta)
 }
 
 func getCodexEntities(
-	ctx context.Context,
 	timestamp time.Time,
 	sessionEntity string,
 	version string,
@@ -261,7 +259,6 @@ func getCodexEntities(
 ) Heartbeats {
 	if payload.Type == "message" && payload.Role != nil {
 		if heartbeat := codexMessageHeartbeat(
-			ctx,
 			timestamp,
 			sessionEntity,
 			version,
@@ -278,11 +275,10 @@ func getCodexEntities(
 		return nil
 	}
 
-	return codexPatchHeartbeats(ctx, timestamp, version, cwd, userAgents, fallbackUserAgent, *payload.Input)
+	return codexPatchHeartbeats(timestamp, version, cwd, userAgents, fallbackUserAgent, *payload.Input)
 }
 
 func codexPatchHeartbeats(
-	ctx context.Context,
 	timestamp time.Time,
 	version string,
 	cwd string,
@@ -308,7 +304,6 @@ func codexPatchHeartbeats(
 		if strings.HasPrefix(line, "*** ") {
 			if currentFile != "" {
 				heartbeats = append(heartbeats, codexHeartbeat(
-					ctx,
 					currentFile,
 					timestamp,
 					version,
@@ -333,7 +328,6 @@ func codexPatchHeartbeats(
 
 	if currentFile != "" {
 		heartbeats = append(heartbeats, codexHeartbeat(
-			ctx,
 			currentFile,
 			timestamp,
 			version,
@@ -348,7 +342,6 @@ func codexPatchHeartbeats(
 }
 
 func codexMessageHeartbeat(
-	ctx context.Context,
 	timestamp time.Time,
 	sessionEntity string,
 	version string,
@@ -404,7 +397,7 @@ func codexMessageHeartbeat(
 		"",
 		cwd,
 		float64(timestamp.Unix()),
-		aiUserAgent(ctx, entity, userAgents, fallbackUserAgent, codexPlugin(version)),
+		aiUserAgent(entity, userAgents, fallbackUserAgent, codexPlugin(version)),
 	)
 
 	return &h
@@ -430,7 +423,6 @@ func codexFilePath(cwd string, line string) string {
 }
 
 func codexHeartbeat(
-	ctx context.Context,
 	currentFile string,
 	timestamp time.Time,
 	version string,
@@ -459,7 +451,7 @@ func codexHeartbeat(
 		"",
 		"",
 		float64(timestamp.Unix()),
-		aiUserAgent(ctx, currentFile, userAgents, fallbackUserAgent, codexPlugin(version)),
+		aiUserAgent(currentFile, userAgents, fallbackUserAgent, codexPlugin(version)),
 	)
 }
 

--- a/pkg/ai/copilot.go
+++ b/pkg/ai/copilot.go
@@ -217,10 +217,10 @@ func (g Copilot) Parse(ctx context.Context) (Heartbeats, error) {
 	var timed []copilotTimedHeartbeat
 
 	for _, ws := range workspaces {
-		sessionHeartbeats, requestMeta := g.sessionHeartbeats(ctx, ws)
+		sessionHeartbeats, requestMeta := g.sessionHeartbeats(ws)
 		timed = append(timed, sessionHeartbeats...)
 
-		editHeartbeats, err := g.editHeartbeats(ctx, ws.workspaceDir, requestMeta)
+		editHeartbeats, err := g.editHeartbeats(ws.workspaceDir, requestMeta)
 		if err != nil {
 			return nil, err
 		}
@@ -576,7 +576,6 @@ func parseJSONInt(raw json.RawMessage) (int, bool) {
 }
 
 func (g Copilot) sessionHeartbeats(
-	ctx context.Context,
 	ws copilotWorkspaceState,
 ) ([]copilotTimedHeartbeat, map[string]copilotRequestMeta) {
 	var timed []copilotTimedHeartbeat
@@ -611,7 +610,6 @@ func (g Copilot) sessionHeartbeats(
 				timed = append(timed, copilotTimedHeartbeat{
 					timestamp: requestTime,
 					heartbeat: copilotAppHeartbeat(
-						ctx,
 						sessionEntity,
 						requestTime,
 						projectPath,
@@ -628,7 +626,6 @@ func (g Copilot) sessionHeartbeats(
 				timed = append(timed, copilotTimedHeartbeat{
 					timestamp: readTime,
 					heartbeat: copilotFileHeartbeat(
-						ctx,
 						path,
 						readTime,
 						g.UserAgents,
@@ -644,7 +641,6 @@ func (g Copilot) sessionHeartbeats(
 				timed = append(timed, copilotTimedHeartbeat{
 					timestamp: completedAt,
 					heartbeat: copilotAppHeartbeat(
-						ctx,
 						sessionEntity,
 						completedAt,
 						projectPath,
@@ -661,7 +657,6 @@ func (g Copilot) sessionHeartbeats(
 }
 
 func (g Copilot) editHeartbeats(
-	ctx context.Context,
 	workspaceDir string,
 	requestMeta map[string]copilotRequestMeta,
 ) ([]copilotTimedHeartbeat, error) {
@@ -688,7 +683,7 @@ func (g Copilot) editHeartbeats(
 			continue
 		}
 
-		sessionTimed, err := g.parseEditState(ctx, statePath, requestMeta)
+		sessionTimed, err := g.parseEditState(statePath, requestMeta)
 		if err != nil {
 			return nil, err
 		}
@@ -709,7 +704,6 @@ func copilotFileModifiedAfter(path string, after time.Time) bool {
 }
 
 func (g Copilot) parseEditState(
-	ctx context.Context,
 	statePath string,
 	requestMeta map[string]copilotRequestMeta,
 ) ([]copilotTimedHeartbeat, error) {
@@ -800,7 +794,6 @@ func (g Copilot) parseEditState(
 		timed = append(timed, copilotTimedHeartbeat{
 			timestamp: timestamp,
 			heartbeat: copilotFileHeartbeat(
-				ctx,
 				op.URI.FSPath,
 				timestamp,
 				g.UserAgents,
@@ -1009,7 +1002,6 @@ func copilotShouldTrackReadPath(path string) bool {
 }
 
 func copilotAppHeartbeat(
-	ctx context.Context,
 	entity string,
 	timestamp time.Time,
 	projectPath string,
@@ -1037,12 +1029,11 @@ func copilotAppHeartbeat(
 		"",
 		projectPath,
 		float64(timestamp.UnixMilli())/1000,
-		aiUserAgent(ctx, entity, userAgents, fallbackUserAgent, plugin),
+		aiUserAgent(entity, userAgents, fallbackUserAgent, plugin),
 	)
 }
 
 func copilotFileHeartbeat(
-	ctx context.Context,
 	path string,
 	timestamp time.Time,
 	userAgents map[string]string,
@@ -1071,7 +1062,7 @@ func copilotFileHeartbeat(
 		"",
 		"",
 		float64(timestamp.UnixMilli())/1000,
-		aiUserAgent(ctx, path, userAgents, fallbackUserAgent, plugin),
+		aiUserAgent(path, userAgents, fallbackUserAgent, plugin),
 	)
 }
 

--- a/pkg/ai/cursor.go
+++ b/pkg/ai/cursor.go
@@ -115,7 +115,7 @@ func (g Cursor) Parse(ctx context.Context) (Heartbeats, error) {
 			continue
 		}
 
-		parsed := g.cursorHeartbeats(ctx, logLine, bubbleCWDs[logLine.BubbleID])
+		parsed := g.cursorHeartbeats(logLine, bubbleCWDs[logLine.BubbleID])
 		if len(parsed) == 0 {
 			continue
 		}
@@ -222,10 +222,10 @@ ORDER BY json_extract(CAST(value AS TEXT), '$.createdAt') ASC;
 	return results, nil
 }
 
-func (g Cursor) cursorHeartbeats(ctx context.Context, logLine cursorLogLine, cwd string) Heartbeats {
+func (g Cursor) cursorHeartbeats(logLine cursorLogLine, cwd string) Heartbeats {
 	var heartbeats Heartbeats
 
-	if heartbeat := g.cursorAppHeartbeat(ctx, logLine, cwd); heartbeat != nil {
+	if heartbeat := g.cursorAppHeartbeat(logLine, cwd); heartbeat != nil {
 		heartbeats = append(heartbeats, *heartbeat)
 	}
 
@@ -233,14 +233,14 @@ func (g Cursor) cursorHeartbeats(ctx context.Context, logLine cursorLogLine, cwd
 		return heartbeats
 	}
 
-	if heartbeat := g.cursorFileHeartbeat(ctx, logLine); heartbeat != nil {
+	if heartbeat := g.cursorFileHeartbeat(logLine); heartbeat != nil {
 		heartbeats = append(heartbeats, *heartbeat)
 	}
 
 	return heartbeats
 }
 
-func (g Cursor) cursorAppHeartbeat(ctx context.Context, logLine cursorLogLine, cwd string) *heartbeat.Heartbeat {
+func (g Cursor) cursorAppHeartbeat(logLine cursorLogLine, cwd string) *heartbeat.Heartbeat {
 	if strings.TrimSpace(logLine.Text) == "" {
 		return nil
 	}
@@ -271,13 +271,13 @@ func (g Cursor) cursorAppHeartbeat(ctx context.Context, logLine cursorLogLine, c
 		"",
 		cwd,
 		float64(logLine.CreatedAt.Unix()),
-		aiUserAgent(ctx, entity, g.UserAgents, g.FallbackUserAgent, cursorPlugin()),
+		aiUserAgent(entity, g.UserAgents, g.FallbackUserAgent, cursorPlugin()),
 	)
 
 	return &h
 }
 
-func (g Cursor) cursorFileHeartbeat(ctx context.Context, logLine cursorLogLine) *heartbeat.Heartbeat {
+func (g Cursor) cursorFileHeartbeat(logLine cursorLogLine) *heartbeat.Heartbeat {
 	switch logLine.ToolFormerData.Name {
 	case "edit_file_v2":
 		var params cursorEditParams
@@ -311,7 +311,7 @@ func (g Cursor) cursorFileHeartbeat(ctx context.Context, logLine cursorLogLine) 
 			"",
 			"",
 			float64(logLine.CreatedAt.Unix()),
-			aiUserAgent(ctx, filePath, g.UserAgents, g.FallbackUserAgent, cursorPlugin()),
+			aiUserAgent(filePath, g.UserAgents, g.FallbackUserAgent, cursorPlugin()),
 		)
 
 		return &h
@@ -359,7 +359,7 @@ func (g Cursor) cursorFileHeartbeat(ctx context.Context, logLine cursorLogLine) 
 			"",
 			"",
 			float64(logLine.CreatedAt.Unix()),
-			aiUserAgent(ctx, filePath, g.UserAgents, g.FallbackUserAgent, cursorPlugin()),
+			aiUserAgent(filePath, g.UserAgents, g.FallbackUserAgent, cursorPlugin()),
 		)
 
 		return &h
@@ -417,7 +417,7 @@ func (g Cursor) cursorFileHeartbeat(ctx context.Context, logLine cursorLogLine) 
 			"",
 			"",
 			float64(logLine.CreatedAt.Unix()),
-			aiUserAgent(ctx, filePath, g.UserAgents, g.FallbackUserAgent, cursorPlugin()),
+			aiUserAgent(filePath, g.UserAgents, g.FallbackUserAgent, cursorPlugin()),
 		)
 
 		return &h

--- a/pkg/ai/helpers_internal_test.go
+++ b/pkg/ai/helpers_internal_test.go
@@ -45,18 +45,30 @@ func TestEntityUserAgentsAndAIUserAgent(t *testing.T) {
 	assert.Equal(t, map[string]string{"/tmp/main.go": "editor/1.0.0"}, userAgents)
 	assert.Equal(
 		t,
-		heartbeat.UserAgent(ctx, cursorPlugin()+" "+"editor/1.0.0"),
-		aiUserAgent(ctx, "/tmp/main.go", userAgents, "plugin/0.1.0", cursorPlugin()),
+		cursorPlugin()+" "+"editor/1.0.0",
+		aiUserAgent("/tmp/main.go", userAgents, "plugin/0.1.0", cursorPlugin()),
 	)
 	assert.Equal(
 		t,
-		heartbeat.UserAgent(ctx, cursorPlugin()+" "+"plugin/0.1.0"),
-		aiUserAgent(ctx, "/tmp/other.go", userAgents, "plugin/0.1.0", cursorPlugin()),
+		cursorPlugin()+" "+"plugin/0.1.0",
+		aiUserAgent("/tmp/other.go", userAgents, "plugin/0.1.0", cursorPlugin()),
 	)
 	assert.Equal(
 		t,
-		heartbeat.UserAgent(ctx, cursorPlugin()),
-		aiUserAgent(ctx, "/tmp/other.go", userAgents, "", cursorPlugin()),
+		cursorPlugin()+" "+heartbeat.UserAgent(ctx, "editor/1.0.0"),
+		aiUserAgent(
+			"/tmp/rendered.go",
+			map[string]string{
+				"/tmp/rendered.go": heartbeat.UserAgent(ctx, "editor/1.0.0"),
+			},
+			"plugin/0.1.0",
+			cursorPlugin(),
+		),
+	)
+	assert.Equal(
+		t,
+		cursorPlugin(),
+		aiUserAgent("/tmp/other.go", userAgents, "", cursorPlugin()),
 	)
 }
 
@@ -190,11 +202,10 @@ func TestCursorHelpers(t *testing.T) {
 }
 
 func TestCursorHeartbeatFallbacks(t *testing.T) {
-	ctx := context.Background()
 	parser := Cursor{FallbackUserAgent: "plugin/0.1.0"}
 	createdAt := time.Date(2026, 3, 20, 12, 0, 0, 0, time.UTC)
 
-	editHeartbeats := parser.cursorHeartbeats(ctx, cursorLogLine{
+	editHeartbeats := parser.cursorHeartbeats(cursorLogLine{
 		CreatedAt: createdAt,
 		Type:      2,
 		ToolFormerData: &cursorToolFormerData{
@@ -213,7 +224,7 @@ func TestCursorHeartbeatFallbacks(t *testing.T) {
 	require.NotNil(t, edit.IsWrite)
 	assert.True(t, *edit.IsWrite)
 
-	readHeartbeats := parser.cursorHeartbeats(ctx, cursorLogLine{
+	readHeartbeats := parser.cursorHeartbeats(cursorLogLine{
 		CreatedAt: createdAt,
 		Type:      2,
 		ToolFormerData: &cursorToolFormerData{
@@ -233,7 +244,7 @@ func TestCursorHeartbeatFallbacks(t *testing.T) {
 	require.NotNil(t, read.IsWrite)
 	assert.False(t, *read.IsWrite)
 
-	appHeartbeats := parser.cursorHeartbeats(ctx, cursorLogLine{
+	appHeartbeats := parser.cursorHeartbeats(cursorLogLine{
 		BubbleID:  "composer-1",
 		CreatedAt: createdAt,
 		Type:      1,
@@ -247,7 +258,7 @@ func TestCursorHeartbeatFallbacks(t *testing.T) {
 	require.NotNil(t, appHeartbeats[0].IsWrite)
 	assert.False(t, *appHeartbeats[0].IsWrite)
 
-	assert.Nil(t, parser.cursorFileHeartbeat(ctx, cursorLogLine{
+	assert.Nil(t, parser.cursorFileHeartbeat(cursorLogLine{
 		CreatedAt: createdAt,
 		Type:      2,
 		ToolFormerData: &cursorToolFormerData{
@@ -338,17 +349,15 @@ func TestClaudeHelpers(t *testing.T) {
 }
 
 func TestCodexHelpers(t *testing.T) {
-	ctx := context.Background()
 	timestamp := time.Date(2026, 3, 28, 12, 0, 0, 0, time.UTC)
 
-	assert.Nil(t, getCodexEntities(ctx, timestamp, "session.jsonl", "1.2.3", "/workspace", nil, "", codexPayload{}))
-	assert.Nil(t, getCodexEntities(ctx, timestamp, "session.jsonl", "1.2.3", "/workspace", nil, "", codexPayload{
+	assert.Nil(t, getCodexEntities(timestamp, "session.jsonl", "1.2.3", "/workspace", nil, "", codexPayload{}))
+	assert.Nil(t, getCodexEntities(timestamp, "session.jsonl", "1.2.3", "/workspace", nil, "", codexPayload{
 		Name:  heartbeat.PointerTo("not_apply_patch"),
 		Input: heartbeat.PointerTo("*** Update File: pkg/main.go\n+one"),
 	}))
 
 	userHeartbeats := getCodexEntities(
-		ctx,
 		timestamp,
 		"session.jsonl",
 		"1.2.3",
@@ -372,7 +381,6 @@ func TestCodexHelpers(t *testing.T) {
 	assert.Contains(t, userHeartbeats[0].UserAgent, "Codex/1.2.3")
 
 	assistantHeartbeats := getCodexEntities(
-		ctx,
 		timestamp,
 		"session.jsonl",
 		"1.2.3",
@@ -395,7 +403,6 @@ func TestCodexHelpers(t *testing.T) {
 	assert.False(t, *assistantHeartbeats[0].IsWrite)
 
 	heartbeats := getCodexEntities(
-		ctx,
 		timestamp,
 		"session.jsonl",
 		"1.2.3",


### PR DESCRIPTION
Before:

```
wakatime/v2.2.5 (darwin-24.6.0-arm64) go1.25.9 Codex/0.119.0-alpha.28 wakatime/v2.2.5 (darwin-24.6.0-arm64) go1.25.9 vscode/1.115.0 vscode-wakatime/30.0.6
```

After:

```
wakatime/v2.2.5 (darwin-24.6.0-arm64) go1.25.9 Codex/0.119.0-alpha.28 vscode/1.115.0 vscode-wakatime/30.0.6
```