### PR TITLE
Allow api key without settings section

### DIFF
--- a/pkg/params/params.go
+++ b/pkg/params/params.go
@@ -69,8 +69,20 @@ const (
 // nolint:gochecknoglobals
 var (
 	apiKeyOrder = map[FlagReadOrder][]string{
-		FlagReadOrderFlagPrecedence:          {"key", "settings.api_key", "settings.apikey"},
-		FlagReadOrderProjectConfigPrecedence: {"settings.api_key", "key", "settings.apikey"},
+		FlagReadOrderFlagPrecedence: {
+			"key",
+			"settings.api_key",
+			"api_key",
+			"settings.apikey",
+			"apikey",
+		},
+		FlagReadOrderProjectConfigPrecedence: {
+			"settings.api_key",
+			"api_key",
+			"key",
+			"settings.apikey",
+			"apikey",
+		},
 	}
 	guessLanguageOrder = map[FlagReadOrder][]string{
 		FlagReadOrderFlagPrecedence:          {"guess-language", "settings.guess_language"},

--- a/pkg/params/params_test.go
+++ b/pkg/params/params_test.go
@@ -2163,6 +2163,18 @@ func TestLoadAPIParams_APIKey_FromConfig(t *testing.T) {
 	assert.Equal(t, "10000000-0000-4000-8000-000000000000", params.Key)
 }
 
+func TestLoadAPIParams_APIKey_FromTopLevelConfig(t *testing.T) {
+	ctx := t.Context()
+
+	v := vipertools.MustNew()
+	v.Set("api_key", "30000000-0000-4000-8000-000000000000")
+
+	params, err := paramspkg.LoadAPIParams(ctx, v, paramspkg.FlagReadOrderFlagPrecedence)
+	require.NoError(t, err)
+
+	assert.Equal(t, "30000000-0000-4000-8000-000000000000", params.Key)
+}
+
 func TestLoadAPIParams_APIKey_ConfigDeprecatedTakesPrecedence(t *testing.T) {
 	ctx := t.Context()
 
@@ -2173,6 +2185,18 @@ func TestLoadAPIParams_APIKey_ConfigDeprecatedTakesPrecedence(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "20000000-0000-4000-8000-000000000000", params.Key)
+}
+
+func TestLoadAPIParams_APIKey_TopLevelDeprecatedTakesPrecedence(t *testing.T) {
+	ctx := t.Context()
+
+	v := vipertools.MustNew()
+	v.Set("apikey", "40000000-0000-4000-8000-000000000000")
+
+	params, err := paramspkg.LoadAPIParams(ctx, v, paramspkg.FlagReadOrderFlagPrecedence)
+	require.NoError(t, err)
+
+	assert.Equal(t, "40000000-0000-4000-8000-000000000000", params.Key)
 }
 
 func TestLoadAPIParams_APIKeyUnset(t *testing.T) {


### PR DESCRIPTION
It's technically invalid, but we'll allow it just to avoid problems.

Might fix #1239.