### PR TITLE
Default to hide status bar categories in Today output

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -32,7 +32,7 @@ include_only_with_project_file = false
 exclude_unknown_project = false
 status_bar_enabled = true
 status_bar_coding_activity = true
-status_bar_hide_categories = false
+status_bar_show_categories = false
 status_bar_max_categories = 0
 offline = true
 proxy = https://user:pass@localhost:8080
@@ -104,7 +104,7 @@ Notice how you have to include the exclude patterns from your main `~/.wakatime.
 | exclude_unknown_project        | When set, any activity where the project cannot be detected will be ignored.                                                                                                                                                                                           | _bool_        | `false`                           |
 | status_bar_enabled             | Turns on wakatime status bar for certain editors.                                                                                                                                                                                                                      | _bool_        | `true`                            |
 | status_bar_coding_activity     | Enables displaying Today's code stats in the status bar of some editors. When false, only the WakaTime icon is displayed in the status bar.                                                                                                                            | _bool_        | `true`                            |
-| status_bar_hide_categories     | When `true`, --today only displays the total code stats, never displaying Categories in the output.                                                                                                                                                                    | _bool_        | `false`                           |
+| status_bar_show_categories     | When `true`, --today displays category breakdowns in the status bar output.                                                                                                                                                                                             | _bool_        | `false`                           |
 | status_bar_max_categories      | When greater than zero, limits the number of categories displayed in the status bar.                                                                                                                                                                                   | _int_         | `0`                               |
 | offline                        | Enables saving code stats locally to ~/.wakatime/offline_heartbeats.bdb when offline, and syncing to the dashboard later when back online.                                                                                                                             | _bool_        | `true`                            |
 | proxy                          | Optional proxy configuration. Supports HTTPS, SOCKS and NTLM proxies. For ex: `https://user:pass@host:port`, `socks5://user:pass@host:port`, `domain\\user:pass`                                                                                                       | _string_      |                                   |

--- a/pkg/params/params.go
+++ b/pkg/params/params.go
@@ -158,9 +158,9 @@ var (
 		FlagReadOrderFlagPrecedence:          {"heartbeat-rate-limit-seconds", "settings.heartbeat_rate_limit_seconds"},
 		FlagReadOrderProjectConfigPrecedence: {"settings.heartbeat_rate_limit_seconds", "heartbeat-rate-limit-seconds"},
 	}
-	todayHideCategoriesOrder = map[FlagReadOrder][]string{
-		FlagReadOrderFlagPrecedence:          {"today-hide-categories", "settings.status_bar_hide_categories"},
-		FlagReadOrderProjectConfigPrecedence: {"settings.status_bar_hide_categories", "today-hide-categories"},
+	todayCategoriesOrder = map[FlagReadOrder][]string{
+		FlagReadOrderFlagPrecedence:          {"today-hide-categories", "settings.status_bar_show_categories"},
+		FlagReadOrderProjectConfigPrecedence: {"settings.status_bar_show_categories", "today-hide-categories"},
 	}
 	todayMaxCategoriesOrder = map[FlagReadOrder][]string{
 		FlagReadOrderFlagPrecedence:          {"today-max-categories", "settings.status_bar_max_categories"},
@@ -955,15 +955,30 @@ func LoadOfflineParams(ctx context.Context, v *viper.Viper, order FlagReadOrder)
 
 // LoadStatusBarParams loads status bar params from viper.Viper instance.
 func LoadStatusBarParams(v *viper.Viper, order FlagReadOrder) (StatusBar, error) {
-	var hideCategories bool
+	hideCategories := true
 
-	if hideCategoriesStr := vipertools.FirstNonEmptyString(v, todayHideCategoriesOrder[order]...); hideCategoriesStr != "" {
-		val, err := strconv.ParseBool(hideCategoriesStr)
+	for _, key := range todayCategoriesOrder[order] {
+		valStr := vipertools.GetString(v, key)
+		if valStr == "" {
+			continue
+		}
+
+		val, err := strconv.ParseBool(valStr)
 		if err != nil {
+			if key == "settings.status_bar_show_categories" {
+				return StatusBar{}, fmt.Errorf("failed to parse status_bar_show_categories: %s", err)
+			}
+
 			return StatusBar{}, fmt.Errorf("failed to parse today-hide-categories: %s", err)
 		}
 
-		hideCategories = val
+		if key == "settings.status_bar_show_categories" {
+			hideCategories = !val
+		} else {
+			hideCategories = val
+		}
+
+		break
 	}
 
 	maxCategories := 2

--- a/pkg/params/params_test.go
+++ b/pkg/params/params_test.go
@@ -2884,10 +2884,19 @@ func TestLoadOfflineParams_SyncMax_NonIntegerValue(t *testing.T) {
 	assert.Equal(t, math.MaxInt32, params.SyncMax)
 }
 
+func TestLoadStatusBarParams_HideCategories_Default(t *testing.T) {
+	v := vipertools.MustNew()
+
+	params, err := paramspkg.LoadStatusBarParams(v, paramspkg.FlagReadOrderFlagPrecedence)
+	require.NoError(t, err)
+
+	assert.True(t, params.HideCategories)
+}
+
 func TestLoadStatusBarParams_HideCategories_FlagTakesPrecedence(t *testing.T) {
 	v := vipertools.MustNew()
 	v.Set("today-hide-categories", false)
-	v.Set("settings.status_bar_hide_categories", true)
+	v.Set("settings.status_bar_show_categories", false)
 
 	params, err := paramspkg.LoadStatusBarParams(v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
@@ -2897,12 +2906,37 @@ func TestLoadStatusBarParams_HideCategories_FlagTakesPrecedence(t *testing.T) {
 
 func TestLoadStatusBarParams_HideCategories_ConfigTakesPrecedence(t *testing.T) {
 	v := vipertools.MustNew()
-	v.Set("settings.status_bar_hide_categories", true)
+	v.Set("today-hide-categories", false)
+	v.Set("settings.status_bar_show_categories", false)
+
+	params, err := paramspkg.LoadStatusBarParams(v, paramspkg.FlagReadOrderProjectConfigPrecedence)
+	require.NoError(t, err)
+
+	assert.True(t, params.HideCategories)
+}
+
+func TestLoadStatusBarParams_HideCategories_ShowCategoriesEnabled(t *testing.T) {
+	v := vipertools.MustNew()
+	v.Set("settings.status_bar_show_categories", true)
 
 	params, err := paramspkg.LoadStatusBarParams(v, paramspkg.FlagReadOrderFlagPrecedence)
 	require.NoError(t, err)
 
-	assert.True(t, params.HideCategories)
+	assert.False(t, params.HideCategories)
+}
+
+func TestLoadStatusBarParams_HideCategories_ShowCategoriesInvalid(t *testing.T) {
+	v := vipertools.MustNew()
+	v.Set("settings.status_bar_show_categories", "invalid")
+
+	_, err := paramspkg.LoadStatusBarParams(v, paramspkg.FlagReadOrderFlagPrecedence)
+	require.Error(t, err)
+
+	assert.Equal(
+		t,
+		"failed to parse status_bar_show_categories: strconv.ParseBool: parsing \"invalid\": invalid syntax",
+		err.Error(),
+	)
 }
 
 func TestLoadStatusBarParams_Output(t *testing.T) {


### PR DESCRIPTION
Changes default output of `~/.wakatime/wakatime-cli --today` from:

`54 mins AI Coding, 8 mins Writing Tests`

to

`1 hr 2 mins`