### PR TITLE
Prevent adding IDE to Claude User-Agent when running standalone

### DIFF
--- a/cmd/heartbeat/ai_sync_test.go
+++ b/cmd/heartbeat/ai_sync_test.go
@@ -92,7 +92,7 @@ func TestRunAISyncActivity_SendsAIHeartbeatsWithoutEntity(t *testing.T) {
 		assert.Zero(t, entities[0].AIInputTokens)
 		assert.Equal(t, int64(7), entities[0].AIOutputTokens)
 		assert.Contains(t, entities[0].UserAgent, "Claude/2.1.45")
-		assert.Contains(t, entities[0].UserAgent, "plugin/0.0.1")
+		assert.NotContains(t, entities[0].UserAgent, "plugin/0.0.1")
 
 		w.WriteHeader(http.StatusCreated)
 

--- a/pkg/ai/ai_test.go
+++ b/pkg/ai/ai_test.go
@@ -145,10 +145,11 @@ func TestSendHeartbeats_WithAIParsing(t *testing.T) {
 		assert.Greater(t, *entities[0].ProjectRootCount, 1)
 		assert.Equal(
 			t,
-			heartbeat.UserAgent(t.Context(), "Claude/2.1.45 "+plugin),
+			heartbeat.UserAgent(t.Context(), "Claude/2.1.45"),
 			entities[0].UserAgent,
 		)
 		assert.Contains(t, entities[0].UserAgent, "Claude/2.1.45")
+		assert.NotContains(t, entities[0].UserAgent, plugin)
 		assert.Equal(t, local, entities[1].Entity)
 
 		// send response

--- a/pkg/ai/claude.go
+++ b/pkg/ai/claude.go
@@ -290,6 +290,7 @@ func (g Claude) parseTranscript(ctx context.Context, transcript string) (Heartbe
 
 	claudeVersion := ""
 	cwd := ""
+	ideSession := false
 	sessionID := g.sessionIDFromPath(transcript)
 	sessionEntity := appHeartbeatEntity("Claude", transcript)
 
@@ -323,6 +324,10 @@ func (g Claude) parseTranscript(ctx context.Context, transcript string) (Heartbe
 			cwd = lineCwd
 		}
 
+		if claudeHasIDEContext(logLine) {
+			ideSession = true
+		}
+
 		tokens = g.claudeTokenCounts(logLine, tokens, &lastMsg)
 
 		if logLine.Timestamp.IsZero() || logLine.Timestamp.Before(g.After) {
@@ -330,7 +335,7 @@ func (g Claude) parseTranscript(ctx context.Context, transcript string) (Heartbe
 			continue
 		}
 
-		parsed := g.claudeHeartbeats(logLine, sessionEntity, sessionID, claudeVersion, cwd, tokens)
+		parsed := g.claudeHeartbeats(logLine, sessionEntity, sessionID, claudeVersion, cwd, ideSession, tokens)
 		if len(parsed) == 0 {
 			continue
 		}
@@ -430,6 +435,7 @@ func (g Claude) claudeHeartbeats(
 	sessionID string,
 	version string,
 	cwd string,
+	ideSession bool,
 	tokens heartbeat.AITokens,
 ) Heartbeats {
 	var heartbeats Heartbeats
@@ -443,6 +449,7 @@ func (g Claude) claudeHeartbeats(
 		sessionID,
 		version,
 		cwd,
+		ideSession,
 		appTokens,
 	); heartbeat != nil {
 		heartbeats = append(heartbeats, *heartbeat)
@@ -454,6 +461,7 @@ func (g Claude) claudeHeartbeats(
 		logLine,
 		sessionID,
 		version,
+		ideSession,
 		fileTokens,
 	); heartbeat != nil {
 		heartbeats = append(heartbeats, *heartbeat)
@@ -468,6 +476,7 @@ func (g Claude) claudeAppHeartbeat(
 	sessionID string,
 	version string,
 	cwd string,
+	ideSession bool,
 	tokens *heartbeat.AITokens,
 ) *heartbeat.Heartbeat {
 	lineChanges := g.appLineChanges(logLine.ToolUseResult)
@@ -486,7 +495,7 @@ func (g Claude) claudeAppHeartbeat(
 		heartbeat.PointerTo(false),
 		cwd,
 		float64(logLine.Timestamp.Unix()),
-		aiUserAgent(sessionEntity, g.UserAgents, g.FallbackUserAgent, aiPlugin(g, version)),
+		g.userAgent(sessionEntity, version, ideSession),
 	)
 	h.AIPromptLength = promptLength
 
@@ -497,6 +506,7 @@ func (g Claude) claudeFileHeartbeat(
 	logLine claudeLogLine,
 	sessionID string,
 	version string,
+	ideSession bool,
 	tokens *heartbeat.AITokens,
 ) *heartbeat.Heartbeat {
 	if logLine.ToolUseResult == nil || logLine.ToolUseResult.Object == nil {
@@ -520,10 +530,18 @@ func (g Claude) claudeFileHeartbeat(
 		heartbeat.PointerTo(isWrite),
 		"",
 		float64(logLine.Timestamp.Unix()),
-		aiUserAgent(filePath, g.UserAgents, g.FallbackUserAgent, aiPlugin(g, version)),
+		g.userAgent(filePath, version, ideSession),
 	)
 
 	return &h
+}
+
+func (g Claude) userAgent(entity string, version string, ideSession bool) string {
+	if !ideSession {
+		return aiPlugin(g, version)
+	}
+
+	return aiUserAgent(entity, g.UserAgents, g.FallbackUserAgent, aiPlugin(g, version))
 }
 
 func (Claude) tokenDelta(tokens heartbeat.AITokens) (int64, int64) {
@@ -742,6 +760,24 @@ func claudePromptLength(logLine claudeLogLine) int {
 	}
 
 	return total
+}
+
+func claudeHasIDEContext(logLine claudeLogLine) bool {
+	if logLine.Message == nil {
+		return false
+	}
+
+	for _, item := range logLine.Message.Content {
+		if item.Type != "text" {
+			continue
+		}
+
+		if strings.Contains(item.Text, "<ide_") {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (Claude) sessionIDFromPath(path string) string {

--- a/pkg/ai/claude_test.go
+++ b/pkg/ai/claude_test.go
@@ -229,3 +229,43 @@ func TestClaudeParse_RetainsProjectFolderFromSkippedFileLine(t *testing.T) {
 	assert.Equal(t, heartbeat.AppType, got[0].EntityType)
 	assert.Equal(t, filepath.Dir("/workspace/project/main.go"), got[0].ProjectPathOverride)
 }
+
+func TestClaudeParse_DoesNotUseEditorUserAgentWithoutIDEContext(t *testing.T) {
+	ctx := context.Background()
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	transcriptDir := filepath.Join(home, ".claude", "projects", "sample-project")
+	require.NoError(t, os.MkdirAll(transcriptDir, 0o755))
+
+	transcriptPath := filepath.Join(transcriptDir, "session.jsonl")
+	transcript := strings.Join([]string{
+		strings.Join([]string{
+			`{"timestamp":"2026-03-18T11:45:00Z","sessionId":"claude-session","version":"2.1.45",`,
+			`"cwd":"/tmp","type":"user","message":{"role":"user","content":[`,
+			`{"type":"text","text":"please update the file"}`,
+			`]}}`,
+		}, ""),
+		"{\"timestamp\":\"2026-03-18T12:00:00Z\",\"sessionId\":\"claude-session\",\"version\":\"2.1.45\"," +
+			"\"toolUseResult\":{\"filePath\":\"/tmp/edited.go\"," +
+			"\"structuredPatch\":[{\"oldLines\":1,\"newLines\":2}]}}",
+	}, "\n") + "\n"
+	require.NoError(t, os.WriteFile(transcriptPath, []byte(transcript), 0o644))
+
+	parser := ai.Claude{
+		After:             time.Date(2026, 3, 18, 11, 0, 0, 0, time.UTC),
+		FallbackUserAgent: "nvim/0.11.0",
+		UserAgents: map[string]string{
+			"/tmp/edited.go": heartbeat.UserAgent(ctx, "nvim/0.11.0"),
+		},
+	}
+
+	got, err := parser.Parse(ctx)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+
+	assert.Equal(t, "Claude/2.1.45", got[0].UserAgent)
+	assert.Equal(t, "Claude/2.1.45", got[1].UserAgent)
+}


### PR DESCRIPTION
Fixes #1365, but now it prefers not adding IDE to the User-Agent string and might miss the IDE in some cases when using Claude as an IDE extension instead of standalone cli.