### PR TITLE
Claude message.content can be a plain String instead of Array

### DIFF
--- a/pkg/ai/claude.go
+++ b/pkg/ai/claude.go
@@ -28,16 +28,18 @@ type (
 	}
 
 	claudeMessage struct {
-		ID      string                 `json:"id"`
-		Role    string                 `json:"role"`
-		Usage   *claudeUsage           `json:"usage"`
-		Content []claudeMessageContent `json:"content"`
+		ID      string                   `json:"id"`
+		Role    string                   `json:"role"`
+		Usage   *claudeUsage             `json:"usage"`
+		Content claudeMessageContentList `json:"content"`
 	}
 
 	claudeMessageContent struct {
 		Type string `json:"type"`
 		Text string `json:"text"`
 	}
+
+	claudeMessageContentList []claudeMessageContent
 
 	structuredPatch struct {
 		NewLines int `json:"newLines"`
@@ -133,6 +135,28 @@ func (v *toolUseResultValue) UnmarshalJSON(data []byte) error {
 	}
 
 	return fmt.Errorf("unsupported toolUseResult type")
+}
+
+func (c *claudeMessageContentList) UnmarshalJSON(data []byte) error {
+	if data == nil || string(data) == "null" {
+		return nil
+	}
+
+	var arr []claudeMessageContent
+	if err := json.Unmarshal(data, &arr); err == nil {
+		*c = arr
+
+		return nil
+	}
+
+	var str string
+	if err := json.Unmarshal(data, &str); err == nil {
+		*c = claudeMessageContentList{{Type: "text", Text: str}}
+
+		return nil
+	}
+
+	return fmt.Errorf("unsupported message content type")
 }
 
 func (v *contentValue) lineChanges() int {

--- a/pkg/ai/claude_test.go
+++ b/pkg/ai/claude_test.go
@@ -269,3 +269,38 @@ func TestClaudeParse_DoesNotUseEditorUserAgentWithoutIDEContext(t *testing.T) {
 	assert.Equal(t, "Claude/2.1.45", got[0].UserAgent)
 	assert.Equal(t, "Claude/2.1.45", got[1].UserAgent)
 }
+
+func TestClaudeParse_UserMessageContentAsPlainString(t *testing.T) {
+	ctx := context.Background()
+	expectedPrompt := "yes continue"
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	transcriptDir := filepath.Join(home, ".claude", "projects", "sample-project")
+	require.NoError(t, os.MkdirAll(transcriptDir, 0o755))
+
+	transcriptPath := filepath.Join(transcriptDir, "session.jsonl")
+	transcript := strings.Join([]string{
+		strings.Join([]string{
+			`{"timestamp":"2026-03-18T11:45:00Z","sessionId":"claude-session","version":"2.1.45",`,
+			`"cwd":"/tmp","isSidechain":false,"type":"user",`,
+			`"message":{"role":"user","content":"` + expectedPrompt + `"}}`,
+		}, ""),
+	}, "\n") + "\n"
+	require.NoError(t, os.WriteFile(transcriptPath, []byte(transcript), 0o644))
+
+	parser := ai.Claude{
+		After:             time.Date(2026, 3, 18, 11, 0, 0, 0, time.UTC),
+		FallbackUserAgent: "plugin/0.0.1",
+	}
+
+	got, err := parser.Parse(ctx)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+
+	assert.Equal(t, heartbeat.AppType, got[0].EntityType)
+	assert.Equal(t, "claude-session", got[0].AISession)
+	assert.Equal(t, len([]rune(expectedPrompt)), got[0].AIPromptLength)
+}


### PR DESCRIPTION
When Claude Code emits a short user reply, it serialises `message.content` as a plain string rather than an array of content blocks:

```jsonl
{"type":"user","message":{"role":"user","content":"yes continue"},"sessionId":"...","version":"2.1.118","cwd":"..."}
```

The parser currently expects `[]claudeMessageContent` and rejects those lines during JSON unmarshal, which silently drops the turn from token accounting and from `claudePromptLength` / `claudeHasIDEContext`, and logs `failed parsing claude transcript line` for every short reply ("ok", "yes", "continue", etc.).

#1289 and #1295 applied the same string-or-X treatment to `toolUseResult` and `toolUseResult.content`. This change extends the same pattern to `claudeMessage.Content` by introducing a `claudeMessageContentList` with an `UnmarshalJSON` that accepts the array shape and wraps a plain string as a single `{"type":"text","text":<string>}` block, so the two consumers (`claudePromptLength` and `claudeHasIDEContext`) work unchanged.

Added a regression test, `TestClaudeParse_UserMessageContentAsPlainString`, covering a user turn whose `message.content` is a plain string. Validated locally with:

```
go test -race -covermode=atomic ./pkg/ai/...
go test -short -race ./...
```

Fixes #1370