### PR TITLE
Fix Claude transcript parsing edge cases

### DIFF
--- a/pkg/ai/claude.go
+++ b/pkg/ai/claude.go
@@ -543,7 +543,7 @@ func (g Claude) claudeFileHeartbeat(
 	}
 
 	lineChanges := g.lineChanges(*logLine.ToolUseResult.Object)
-	isWrite := lineChanges != 0
+	isWrite := g.isWrite(*logLine.ToolUseResult.Object)
 
 	h := g.newHeartbeat(
 		heartbeat.PointerTo(lineChanges),
@@ -727,6 +727,25 @@ func (Claude) lineChanges(result toolUseResult) int {
 	return 0
 }
 
+func (Claude) isWrite(result toolUseResult) bool {
+	if result.StructuredPatch != nil && len(*result.StructuredPatch) > 0 {
+		return true
+	}
+
+	if result.Type != nil {
+		switch *result.Type {
+		case "create", "update", "delete":
+			return true
+		}
+	}
+
+	if result.OriginalFile != nil && *result.OriginalFile != "" {
+		return false
+	}
+
+	return result.Content.lineChanges() != 0
+}
+
 func (g Claude) appLineChanges(result *toolUseResultValue) int {
 	if result == nil {
 		return 0
@@ -775,15 +794,56 @@ func claudePromptLength(logLine claudeLogLine) int {
 			continue
 		}
 
-		text := strings.TrimSpace(item.Text)
-		if text == "" || strings.HasPrefix(text, "<") {
-			continue
-		}
-
-		total += promptLength(item.Text)
+		total += claudePromptTextLength(item.Text)
 	}
 
 	return total
+}
+
+func claudePromptTextLength(text string) int {
+	trimmed := strings.TrimSpace(text)
+	if trimmed == "" {
+		return 0
+	}
+
+	if !strings.HasPrefix(trimmed, "<") {
+		return promptLength(text)
+	}
+
+	for strings.HasPrefix(trimmed, "<") {
+		closeOpenTag := strings.Index(trimmed, ">")
+		if closeOpenTag < 2 {
+			return 0
+		}
+
+		tag := strings.TrimSpace(trimmed[1:closeOpenTag])
+		if tag == "" || strings.HasPrefix(tag, "/") {
+			return 0
+		}
+
+		tagName := strings.Fields(tag)[0]
+
+		tagName = strings.TrimSuffix(tagName, "/")
+		if tagName == "" {
+			return 0
+		}
+
+		if strings.HasSuffix(tag, "/") {
+			trimmed = strings.TrimSpace(trimmed[closeOpenTag+1:])
+			continue
+		}
+
+		closeTag := "</" + tagName + ">"
+
+		closeTagIndex := strings.Index(trimmed, closeTag)
+		if closeTagIndex == -1 {
+			return 0
+		}
+
+		trimmed = strings.TrimSpace(trimmed[closeTagIndex+len(closeTag):])
+	}
+
+	return promptLength(trimmed)
 }
 
 func claudeHasIDEContext(logLine claudeLogLine) bool {

--- a/pkg/ai/claude_test.go
+++ b/pkg/ai/claude_test.go
@@ -72,6 +72,10 @@ func TestClaudeParse(t *testing.T) {
 		"{\"timestamp\":\"2026-03-18T13:30:00Z\",\"sessionId\":\"claude-session\",\"toolUseResult\":{" +
 			"\"filePath\":\"/tmp/empty.go\",\"structuredPatch\":[]}," +
 			"\"message\":{\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}}",
+		"{\"timestamp\":\"2026-03-18T13:45:00Z\",\"sessionId\":\"claude-session\",\"toolUseResult\":{" +
+			"\"filePath\":\"/tmp/same-lines.go\",\"oldString\":\"before\",\"newString\":\"after\"," +
+			"\"originalFile\":\"before\",\"structuredPatch\":[{\"oldLines\":1,\"newLines\":1}]}," +
+			"\"message\":{\"usage\":{\"input_tokens\":3,\"output_tokens\":2}}}",
 		"{\"timestamp\":\"2026-03-18T14:00:00Z\",\"sessionId\":\"claude-session\",\"toolUseResult\":{" +
 			"\"structuredPatch\":[{\"oldLines\":1,\"newLines\":1}]}," +
 			"\"message\":{\"usage\":{\"input_tokens\":8,\"output_tokens\":2}}}",
@@ -88,7 +92,7 @@ func TestClaudeParse(t *testing.T) {
 
 	got, err := parser.Parse(ctx)
 	require.NoError(t, err)
-	require.Len(t, got, 8)
+	require.Len(t, got, 9)
 
 	assert.Equal(t, "Claude agent-worker", got[0].Entity)
 	assert.Equal(t, "claude-session", got[0].AISession)
@@ -182,6 +186,16 @@ func TestClaudeParse(t *testing.T) {
 	assert.Zero(t, got[7].AIPromptLength)
 	assert.Equal(t, int64(1), got[7].AIInputTokens)
 	assert.Equal(t, int64(1), got[7].AIOutputTokens)
+
+	assert.Equal(t, "/tmp/same-lines.go", got[8].Entity)
+	assert.Equal(t, "claude-session", got[8].AISession)
+	require.NotNil(t, got[8].AILineChanges)
+	assert.Equal(t, 0, *got[8].AILineChanges)
+	assert.Zero(t, got[8].AIPromptLength)
+	assert.Equal(t, int64(3), got[8].AIInputTokens)
+	assert.Equal(t, int64(2), got[8].AIOutputTokens)
+	require.NotNil(t, got[8].IsWrite)
+	assert.True(t, *got[8].IsWrite)
 }
 
 func TestClaudeParse_NoClaudeProjectsDir(t *testing.T) {
@@ -303,4 +317,72 @@ func TestClaudeParse_UserMessageContentAsPlainString(t *testing.T) {
 	assert.Equal(t, heartbeat.AppType, got[0].EntityType)
 	assert.Equal(t, "claude-session", got[0].AISession)
 	assert.Equal(t, len([]rune(expectedPrompt)), got[0].AIPromptLength)
+}
+
+func TestClaudeParse_UserMessageContentAsPlainStringWithIDEContext(t *testing.T) {
+	ctx := context.Background()
+	expectedPrompt := "please continue from the selected file"
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	transcriptDir := filepath.Join(home, ".claude", "projects", "sample-project")
+	require.NoError(t, os.MkdirAll(transcriptDir, 0o755))
+
+	transcriptPath := filepath.Join(transcriptDir, "session.jsonl")
+	content := `<ide_opened_file><path>/tmp/main.go</path></ide_opened_file>\n\n` + expectedPrompt
+	transcript := strings.Join([]string{
+		strings.Join([]string{
+			`{"timestamp":"2026-03-18T11:45:00Z","sessionId":"claude-session","version":"2.1.45",`,
+			`"cwd":"/tmp","isSidechain":false,"type":"user",`,
+			`"message":{"role":"user","content":"` + content + `"}}`,
+		}, ""),
+	}, "\n") + "\n"
+	require.NoError(t, os.WriteFile(transcriptPath, []byte(transcript), 0o644))
+
+	parser := ai.Claude{
+		After:             time.Date(2026, 3, 18, 11, 0, 0, 0, time.UTC),
+		FallbackUserAgent: "plugin/0.0.1",
+	}
+
+	got, err := parser.Parse(ctx)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+
+	assert.Equal(t, heartbeat.AppType, got[0].EntityType)
+	assert.Equal(t, "claude-session", got[0].AISession)
+	assert.Equal(t, len([]rune(expectedPrompt)), got[0].AIPromptLength)
+	assert.Equal(t, "Claude/2.1.45 plugin/0.0.1", got[0].UserAgent)
+}
+
+func TestClaudeParse_UserMessageContentAsPlainStringSystemReminder(t *testing.T) {
+	ctx := context.Background()
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	transcriptDir := filepath.Join(home, ".claude", "projects", "sample-project")
+	require.NoError(t, os.MkdirAll(transcriptDir, 0o755))
+
+	transcriptPath := filepath.Join(transcriptDir, "session.jsonl")
+	content := `<system-reminder>\nThis is metadata.\n\nDo not count this as a user prompt.\n</system-reminder>`
+	transcript := strings.Join([]string{
+		strings.Join([]string{
+			`{"timestamp":"2026-03-18T11:45:00Z","sessionId":"claude-session","version":"2.1.45",`,
+			`"cwd":"/tmp","isSidechain":false,"type":"user",`,
+			`"message":{"role":"user","content":"` + content + `"}}`,
+		}, ""),
+	}, "\n") + "\n"
+	require.NoError(t, os.WriteFile(transcriptPath, []byte(transcript), 0o644))
+
+	parser := ai.Claude{
+		After:             time.Date(2026, 3, 18, 11, 0, 0, 0, time.UTC),
+		FallbackUserAgent: "plugin/0.0.1",
+	}
+
+	got, err := parser.Parse(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, got)
 }


### PR DESCRIPTION
Handle plain-string Claude message content with XML metadata, and mark zero-net structured patch edits as writes. Add regression coverage from real transcript shapes.