### PR TITLE
Release v2.7.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/wakatime/wakatime-cli
 go 1.25.9
 
 require (
-	github.com/Azure/go-ntlmssp v0.1.0
+	github.com/Azure/go-ntlmssp v0.1.1
 	github.com/alecthomas/chroma/v2 v2.21.1
 	github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964
 	github.com/dlclark/regexp2 v1.11.5
@@ -24,6 +24,7 @@ require (
 	go.uber.org/zap v1.27.1
 	golang.org/x/crypto v0.45.0
 	golang.org/x/net v0.47.0
+	golang.org/x/sys v0.42.0
 	golang.org/x/text v0.31.0
 	gopkg.in/ini.v1 v1.67.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
@@ -55,7 +56,6 @@ require (
 	github.com/yookoala/realpath v1.0.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
-	golang.org/x/sys v0.42.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	modernc.org/libc v1.70.0 // indirect
 	modernc.org/mathutil v1.7.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/Azure/go-ntlmssp v0.1.0 h1:DjFo6YtWzNqNvQdrwEyr/e4nhU3vRiwenz5QX7sFz+A=
 github.com/Azure/go-ntlmssp v0.1.0/go.mod h1:NYqdhxd/8aAct/s4qSYZEerdPuH1liG2/X9DiVTbhpk=
+github.com/Azure/go-ntlmssp v0.1.1 h1:l+FM/EEMb0U9QZE7mKNEDw5Mu3mFiaa2GKOoTSsNDPw=
+github.com/Azure/go-ntlmssp v0.1.1/go.mod h1:NYqdhxd/8aAct/s4qSYZEerdPuH1liG2/X9DiVTbhpk=
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
 github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
 github.com/alecthomas/chroma/v2 v2.21.1 h1:FaSDrp6N+3pphkNKU6HPCiYLgm8dbe5UXIXcoBhZSWA=

--- a/pkg/ai/claude.go
+++ b/pkg/ai/claude.go
@@ -28,16 +28,18 @@ type (
 	}
 
 	claudeMessage struct {
-		ID      string                 `json:"id"`
-		Role    string                 `json:"role"`
-		Usage   *claudeUsage           `json:"usage"`
-		Content []claudeMessageContent `json:"content"`
+		ID      string                   `json:"id"`
+		Role    string                   `json:"role"`
+		Usage   *claudeUsage             `json:"usage"`
+		Content claudeMessageContentList `json:"content"`
 	}
 
 	claudeMessageContent struct {
 		Type string `json:"type"`
 		Text string `json:"text"`
 	}
+
+	claudeMessageContentList []claudeMessageContent
 
 	structuredPatch struct {
 		NewLines int `json:"newLines"`
@@ -133,6 +135,28 @@ func (v *toolUseResultValue) UnmarshalJSON(data []byte) error {
 	}
 
 	return fmt.Errorf("unsupported toolUseResult type")
+}
+
+func (c *claudeMessageContentList) UnmarshalJSON(data []byte) error {
+	if data == nil || string(data) == "null" {
+		return nil
+	}
+
+	var arr []claudeMessageContent
+	if err := json.Unmarshal(data, &arr); err == nil {
+		*c = arr
+
+		return nil
+	}
+
+	var str string
+	if err := json.Unmarshal(data, &str); err == nil {
+		*c = claudeMessageContentList{{Type: "text", Text: str}}
+
+		return nil
+	}
+
+	return fmt.Errorf("unsupported message content type")
 }
 
 func (v *contentValue) lineChanges() int {

--- a/pkg/ai/claude.go
+++ b/pkg/ai/claude.go
@@ -543,7 +543,7 @@ func (g Claude) claudeFileHeartbeat(
 	}
 
 	lineChanges := g.lineChanges(*logLine.ToolUseResult.Object)
-	isWrite := lineChanges != 0
+	isWrite := g.isWrite(*logLine.ToolUseResult.Object)
 
 	h := g.newHeartbeat(
 		heartbeat.PointerTo(lineChanges),
@@ -727,6 +727,25 @@ func (Claude) lineChanges(result toolUseResult) int {
 	return 0
 }
 
+func (Claude) isWrite(result toolUseResult) bool {
+	if result.StructuredPatch != nil && len(*result.StructuredPatch) > 0 {
+		return true
+	}
+
+	if result.Type != nil {
+		switch *result.Type {
+		case "create", "update", "delete":
+			return true
+		}
+	}
+
+	if result.OriginalFile != nil && *result.OriginalFile != "" {
+		return false
+	}
+
+	return result.Content.lineChanges() != 0
+}
+
 func (g Claude) appLineChanges(result *toolUseResultValue) int {
 	if result == nil {
 		return 0
@@ -775,15 +794,56 @@ func claudePromptLength(logLine claudeLogLine) int {
 			continue
 		}
 
-		text := strings.TrimSpace(item.Text)
-		if text == "" || strings.HasPrefix(text, "<") {
-			continue
-		}
-
-		total += promptLength(item.Text)
+		total += claudePromptTextLength(item.Text)
 	}
 
 	return total
+}
+
+func claudePromptTextLength(text string) int {
+	trimmed := strings.TrimSpace(text)
+	if trimmed == "" {
+		return 0
+	}
+
+	if !strings.HasPrefix(trimmed, "<") {
+		return promptLength(text)
+	}
+
+	for strings.HasPrefix(trimmed, "<") {
+		closeOpenTag := strings.Index(trimmed, ">")
+		if closeOpenTag < 2 {
+			return 0
+		}
+
+		tag := strings.TrimSpace(trimmed[1:closeOpenTag])
+		if tag == "" || strings.HasPrefix(tag, "/") {
+			return 0
+		}
+
+		tagName := strings.Fields(tag)[0]
+
+		tagName = strings.TrimSuffix(tagName, "/")
+		if tagName == "" {
+			return 0
+		}
+
+		if strings.HasSuffix(tag, "/") {
+			trimmed = strings.TrimSpace(trimmed[closeOpenTag+1:])
+			continue
+		}
+
+		closeTag := "</" + tagName + ">"
+
+		closeTagIndex := strings.Index(trimmed, closeTag)
+		if closeTagIndex == -1 {
+			return 0
+		}
+
+		trimmed = strings.TrimSpace(trimmed[closeTagIndex+len(closeTag):])
+	}
+
+	return promptLength(trimmed)
 }
 
 func claudeHasIDEContext(logLine claudeLogLine) bool {

--- a/pkg/ai/claude_test.go
+++ b/pkg/ai/claude_test.go
@@ -72,6 +72,10 @@ func TestClaudeParse(t *testing.T) {
 		"{\"timestamp\":\"2026-03-18T13:30:00Z\",\"sessionId\":\"claude-session\",\"toolUseResult\":{" +
 			"\"filePath\":\"/tmp/empty.go\",\"structuredPatch\":[]}," +
 			"\"message\":{\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}}",
+		"{\"timestamp\":\"2026-03-18T13:45:00Z\",\"sessionId\":\"claude-session\",\"toolUseResult\":{" +
+			"\"filePath\":\"/tmp/same-lines.go\",\"oldString\":\"before\",\"newString\":\"after\"," +
+			"\"originalFile\":\"before\",\"structuredPatch\":[{\"oldLines\":1,\"newLines\":1}]}," +
+			"\"message\":{\"usage\":{\"input_tokens\":3,\"output_tokens\":2}}}",
 		"{\"timestamp\":\"2026-03-18T14:00:00Z\",\"sessionId\":\"claude-session\",\"toolUseResult\":{" +
 			"\"structuredPatch\":[{\"oldLines\":1,\"newLines\":1}]}," +
 			"\"message\":{\"usage\":{\"input_tokens\":8,\"output_tokens\":2}}}",
@@ -88,7 +92,7 @@ func TestClaudeParse(t *testing.T) {
 
 	got, err := parser.Parse(ctx)
 	require.NoError(t, err)
-	require.Len(t, got, 8)
+	require.Len(t, got, 9)
 
 	assert.Equal(t, "Claude agent-worker", got[0].Entity)
 	assert.Equal(t, "claude-session", got[0].AISession)
@@ -182,6 +186,16 @@ func TestClaudeParse(t *testing.T) {
 	assert.Zero(t, got[7].AIPromptLength)
 	assert.Equal(t, int64(1), got[7].AIInputTokens)
 	assert.Equal(t, int64(1), got[7].AIOutputTokens)
+
+	assert.Equal(t, "/tmp/same-lines.go", got[8].Entity)
+	assert.Equal(t, "claude-session", got[8].AISession)
+	require.NotNil(t, got[8].AILineChanges)
+	assert.Equal(t, 0, *got[8].AILineChanges)
+	assert.Zero(t, got[8].AIPromptLength)
+	assert.Equal(t, int64(3), got[8].AIInputTokens)
+	assert.Equal(t, int64(2), got[8].AIOutputTokens)
+	require.NotNil(t, got[8].IsWrite)
+	assert.True(t, *got[8].IsWrite)
 }
 
 func TestClaudeParse_NoClaudeProjectsDir(t *testing.T) {
@@ -303,4 +317,72 @@ func TestClaudeParse_UserMessageContentAsPlainString(t *testing.T) {
 	assert.Equal(t, heartbeat.AppType, got[0].EntityType)
 	assert.Equal(t, "claude-session", got[0].AISession)
 	assert.Equal(t, len([]rune(expectedPrompt)), got[0].AIPromptLength)
+}
+
+func TestClaudeParse_UserMessageContentAsPlainStringWithIDEContext(t *testing.T) {
+	ctx := context.Background()
+	expectedPrompt := "please continue from the selected file"
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	transcriptDir := filepath.Join(home, ".claude", "projects", "sample-project")
+	require.NoError(t, os.MkdirAll(transcriptDir, 0o755))
+
+	transcriptPath := filepath.Join(transcriptDir, "session.jsonl")
+	content := `<ide_opened_file><path>/tmp/main.go</path></ide_opened_file>\n\n` + expectedPrompt
+	transcript := strings.Join([]string{
+		strings.Join([]string{
+			`{"timestamp":"2026-03-18T11:45:00Z","sessionId":"claude-session","version":"2.1.45",`,
+			`"cwd":"/tmp","isSidechain":false,"type":"user",`,
+			`"message":{"role":"user","content":"` + content + `"}}`,
+		}, ""),
+	}, "\n") + "\n"
+	require.NoError(t, os.WriteFile(transcriptPath, []byte(transcript), 0o644))
+
+	parser := ai.Claude{
+		After:             time.Date(2026, 3, 18, 11, 0, 0, 0, time.UTC),
+		FallbackUserAgent: "plugin/0.0.1",
+	}
+
+	got, err := parser.Parse(ctx)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+
+	assert.Equal(t, heartbeat.AppType, got[0].EntityType)
+	assert.Equal(t, "claude-session", got[0].AISession)
+	assert.Equal(t, len([]rune(expectedPrompt)), got[0].AIPromptLength)
+	assert.Equal(t, "Claude/2.1.45 plugin/0.0.1", got[0].UserAgent)
+}
+
+func TestClaudeParse_UserMessageContentAsPlainStringSystemReminder(t *testing.T) {
+	ctx := context.Background()
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	transcriptDir := filepath.Join(home, ".claude", "projects", "sample-project")
+	require.NoError(t, os.MkdirAll(transcriptDir, 0o755))
+
+	transcriptPath := filepath.Join(transcriptDir, "session.jsonl")
+	content := `<system-reminder>\nThis is metadata.\n\nDo not count this as a user prompt.\n</system-reminder>`
+	transcript := strings.Join([]string{
+		strings.Join([]string{
+			`{"timestamp":"2026-03-18T11:45:00Z","sessionId":"claude-session","version":"2.1.45",`,
+			`"cwd":"/tmp","isSidechain":false,"type":"user",`,
+			`"message":{"role":"user","content":"` + content + `"}}`,
+		}, ""),
+	}, "\n") + "\n"
+	require.NoError(t, os.WriteFile(transcriptPath, []byte(transcript), 0o644))
+
+	parser := ai.Claude{
+		After:             time.Date(2026, 3, 18, 11, 0, 0, 0, time.UTC),
+		FallbackUserAgent: "plugin/0.0.1",
+	}
+
+	got, err := parser.Parse(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, got)
 }

--- a/pkg/ai/claude_test.go
+++ b/pkg/ai/claude_test.go
@@ -269,3 +269,38 @@ func TestClaudeParse_DoesNotUseEditorUserAgentWithoutIDEContext(t *testing.T) {
 	assert.Equal(t, "Claude/2.1.45", got[0].UserAgent)
 	assert.Equal(t, "Claude/2.1.45", got[1].UserAgent)
 }
+
+func TestClaudeParse_UserMessageContentAsPlainString(t *testing.T) {
+	ctx := context.Background()
+	expectedPrompt := "yes continue"
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	transcriptDir := filepath.Join(home, ".claude", "projects", "sample-project")
+	require.NoError(t, os.MkdirAll(transcriptDir, 0o755))
+
+	transcriptPath := filepath.Join(transcriptDir, "session.jsonl")
+	transcript := strings.Join([]string{
+		strings.Join([]string{
+			`{"timestamp":"2026-03-18T11:45:00Z","sessionId":"claude-session","version":"2.1.45",`,
+			`"cwd":"/tmp","isSidechain":false,"type":"user",`,
+			`"message":{"role":"user","content":"` + expectedPrompt + `"}}`,
+		}, ""),
+	}, "\n") + "\n"
+	require.NoError(t, os.WriteFile(transcriptPath, []byte(transcript), 0o644))
+
+	parser := ai.Claude{
+		After:             time.Date(2026, 3, 18, 11, 0, 0, 0, time.UTC),
+		FallbackUserAgent: "plugin/0.0.1",
+	}
+
+	got, err := parser.Parse(ctx)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+
+	assert.Equal(t, heartbeat.AppType, got[0].EntityType)
+	assert.Equal(t, "claude-session", got[0].AISession)
+	assert.Equal(t, len([]rune(expectedPrompt)), got[0].AIPromptLength)
+}

--- a/pkg/language/forth.go
+++ b/pkg/language/forth.go
@@ -29,5 +29,5 @@ func detectForthFromContents(text string) (heartbeat.Language, float32, bool) {
 		weight = 1
 	}
 
-	return heartbeat.LanguageUnknown, weight, weight > 0
+	return heartbeat.LanguageForth, weight, weight > 0
 }

--- a/pkg/language/fsharp.go
+++ b/pkg/language/fsharp.go
@@ -22,5 +22,5 @@ func detectFSharpFromContents(text string) (heartbeat.Language, float32, bool) {
 		weight = 1
 	}
 
-	return heartbeat.LanguageUnknown, weight, weight > 0
+	return heartbeat.LanguageFSharp, weight, weight > 0
 }

--- a/pkg/language/language_test.go
+++ b/pkg/language/language_test.go
@@ -257,6 +257,13 @@ func TestDetect_FSharp_Over_Forth(t *testing.T) {
 	assert.Equal(t, heartbeat.LanguageFSharp, lang)
 }
 
+func TestDetect_Forth_Over_FSharp(t *testing.T) {
+	lang, err := language.Detect(t.Context(), "testdata/codefiles/forth.fs", false)
+	require.NoError(t, err)
+
+	assert.Equal(t, heartbeat.LanguageForth, lang)
+}
+
 func TestDetect_Delphi_FMX_FileInFolder(t *testing.T) {
 	lang, err := language.Detect(t.Context(), "testdata/codefiles/pas_with_fmx_file/delphi.pas", false)
 	require.NoError(t, err)

--- a/pkg/language/language_test.go
+++ b/pkg/language/language_test.go
@@ -603,8 +603,11 @@ func TestDetect_ChromaTopLanguagesRetrofit(t *testing.T) {
 			Expected: heartbeat.LanguageOCaml,
 		},
 		"pawn": {
-			Filepaths: []string{"path/to/file.pwn"},
-			Expected:  heartbeat.LanguagePawn,
+			Filepaths: []string{
+				"path/to/file.pwn",
+				"path/to/file.inc",
+			},
+			Expected: heartbeat.LanguagePawn,
 		},
 		"perl not prolog": {
 			Filepaths: []string{

--- a/pkg/language/priority.go
+++ b/pkg/language/priority.go
@@ -9,6 +9,9 @@ func priority(lang string) (float32, bool) {
 		"INI": 0.1,
 		// TASM uses the same file endings, but TASM is not as common as NASM, so we prioritize NASM higher by default.
 		"NASM": 0.1,
+		// Chroma gives PHP high priority for .inc files, but .inc is commonly
+		// used for Pawn include files.
+		"Pawn": 3.01,
 		"Perl": 0.01,
 		// Higher priority than Rebol
 		"R": 0.1,

--- a/pkg/language/testdata/codefiles/forth.fs
+++ b/pkg/language/testdata/codefiles/forth.fs
@@ -1,0 +1,5 @@
+: square dup * ;
+
+\ Forth line comment
+
+( stack effect comment )

--- a/pkg/language/testdata/codefiles/fsharp.fs
+++ b/pkg/language/testdata/codefiles/fsharp.fs
@@ -1,0 +1,6 @@
+let describe value =
+    match value with
+    | Some text -> text
+    | None -> "missing"
+
+// F# line comment


### PR DESCRIPTION
Changelog:
- Claude message.content can be a plain String instead of Array #1372
- Upgrade go-ntlmssp to v0.1.1 #1373
- Fix Claude transcript parsing edge cases #1374
- Prefer Pawn over PHP #1375
- Fix Forth and FSharp language detection #1376