### PR TITLE
Prevent crash from parsing ai heartbeats blocking sending

### DIFF
--- a/pkg/ai/ai.go
+++ b/pkg/ai/ai.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"path/filepath"
+	"runtime/debug"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -286,7 +287,7 @@ func parseAIHeartbeats(
 	for _, p := range parsers {
 		logger.Debugf("execute %s", p.Name())
 
-		heartbeats, err := p.Parse(ctx)
+		heartbeats, err := parseHeartbeats(ctx, p)
 		if err != nil {
 			logger.Errorf("unexpected error occurred at %q: %s", p.Name(), err)
 			continue
@@ -298,6 +299,19 @@ func parseAIHeartbeats(
 	}
 
 	return aiHeartbeats, nil
+}
+
+func parseHeartbeats(ctx context.Context, parser Parser) (heartbeats Heartbeats, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Extract(ctx).Errorf("panicked: %v. Stack: %s", r, string(debug.Stack()))
+
+			heartbeats = nil
+			err = fmt.Errorf("panicked: %v", r)
+		}
+	}()
+
+	return parser.Parse(ctx)
 }
 
 func getLastParsedAt(ctx context.Context, v *viper.Viper) (time.Time, error) {

--- a/pkg/ai/ai_internal_test.go
+++ b/pkg/ai/ai_internal_test.go
@@ -1,0 +1,62 @@
+package ai
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type panicParser struct{}
+
+func (panicParser) Parse(context.Context) (Heartbeats, error) {
+	panic("OOM")
+}
+
+func (panicParser) Name() string {
+	return "panic"
+}
+
+type heartbeatsParser struct{}
+
+func (heartbeatsParser) Parse(context.Context) (Heartbeats, error) {
+	return make(Heartbeats, 2), nil
+}
+
+func (heartbeatsParser) Name() string {
+	return "heartbeats"
+}
+
+type errorParser struct{}
+
+func (errorParser) Parse(context.Context) (Heartbeats, error) {
+	return nil, errors.New("failed")
+}
+
+func (errorParser) Name() string {
+	return "error"
+}
+
+func TestParseHeartbeats_Panic(t *testing.T) {
+	heartbeats, err := parseHeartbeats(t.Context(), panicParser{})
+
+	require.Error(t, err)
+	assert.Nil(t, heartbeats)
+	assert.Contains(t, err.Error(), "panicked: OOM")
+}
+
+func TestParseHeartbeats_Success(t *testing.T) {
+	heartbeats, err := parseHeartbeats(t.Context(), heartbeatsParser{})
+
+	require.NoError(t, err)
+	assert.Len(t, heartbeats, 2)
+}
+
+func TestParseHeartbeats_Error(t *testing.T) {
+	heartbeats, err := parseHeartbeats(t.Context(), errorParser{})
+
+	require.EqualError(t, err, "failed")
+	assert.Nil(t, heartbeats)
+}

--- a/pkg/deps/deps.go
+++ b/pkg/deps/deps.go
@@ -3,6 +3,7 @@ package deps
 import (
 	"context"
 	"fmt"
+	"runtime/debug"
 
 	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 	"github.com/wakatime/wakatime-cli/pkg/log"
@@ -144,6 +145,8 @@ func Detect(ctx context.Context, filepath string, language heartbeat.Language) (
 func parseDependencies(ctx context.Context, parser DependencyParser, filepath string) (deps []string, err error) {
 	defer func() {
 		if r := recover(); r != nil {
+			log.Extract(ctx).Errorf("panicked: %v. Stack: %s", r, string(debug.Stack()))
+
 			err = fmt.Errorf("panicked: %v", r)
 		}
 	}()

--- a/pkg/deps/deps_internal_test.go
+++ b/pkg/deps/deps_internal_test.go
@@ -1,0 +1,50 @@
+package deps
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type panicParser struct{}
+
+func (panicParser) Parse(context.Context, string) ([]string, error) {
+	panic("lexer failed")
+}
+
+type dependenciesParser struct{}
+
+func (dependenciesParser) Parse(context.Context, string) ([]string, error) {
+	return []string{"requests", "requests"}, nil
+}
+
+type errorParser struct{}
+
+func (errorParser) Parse(context.Context, string) ([]string, error) {
+	return nil, errors.New("failed")
+}
+
+func TestParseDependencies_Panic(t *testing.T) {
+	dependencies, err := parseDependencies(t.Context(), panicParser{}, "testdata/python.py")
+
+	require.Error(t, err)
+	assert.Nil(t, dependencies)
+	assert.Contains(t, err.Error(), "panicked: lexer failed")
+}
+
+func TestParseDependencies_Success(t *testing.T) {
+	dependencies, err := parseDependencies(t.Context(), dependenciesParser{}, "testdata/python.py")
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"requests", "requests"}, dependencies)
+}
+
+func TestParseDependencies_Error(t *testing.T) {
+	dependencies, err := parseDependencies(t.Context(), errorParser{}, "testdata/python.py")
+
+	require.EqualError(t, err, "failed")
+	assert.Nil(t, dependencies)
+}

--- a/pkg/language/language.go
+++ b/pkg/language/language.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 	"strings"
 
 	"github.com/wakatime/wakatime-cli/pkg/file"
@@ -71,6 +72,8 @@ func detectLanguage(ctx context.Context, detect detector, fp string, guessLangua
 	language heartbeat.Language, err error) {
 	defer func() {
 		if r := recover(); r != nil {
+			log.Extract(ctx).Errorf("panicked: %v. Stack: %s", r, string(debug.Stack()))
+
 			language = heartbeat.LanguageUnknown
 			err = fmt.Errorf("panicked: %v", r)
 		}

--- a/pkg/language/language_internal_test.go
+++ b/pkg/language/language_internal_test.go
@@ -1,0 +1,46 @@
+package language
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func panicDetector(context.Context, string, bool) (heartbeat.Language, error) {
+	panic("lexer failed")
+}
+
+func languageDetector(context.Context, string, bool) (heartbeat.Language, error) {
+	return heartbeat.LanguagePython, nil
+}
+
+func errorDetector(context.Context, string, bool) (heartbeat.Language, error) {
+	return heartbeat.LanguageUnknown, errors.New("failed")
+}
+
+func TestDetectLanguage_Panic(t *testing.T) {
+	language, err := detectLanguage(t.Context(), panicDetector, "testdata/codefiles/python.py", false)
+
+	require.Error(t, err)
+	assert.Equal(t, heartbeat.LanguageUnknown, language)
+	assert.Contains(t, err.Error(), "panicked: lexer failed")
+}
+
+func TestDetectLanguage_Success(t *testing.T) {
+	language, err := detectLanguage(t.Context(), languageDetector, "testdata/codefiles/python.py", false)
+
+	require.NoError(t, err)
+	assert.Equal(t, heartbeat.LanguagePython, language)
+}
+
+func TestDetectLanguage_Error(t *testing.T) {
+	language, err := detectLanguage(t.Context(), errorDetector, "testdata/codefiles/python.py", false)
+
+	require.EqualError(t, err, "failed")
+	assert.Equal(t, heartbeat.LanguageUnknown, language)
+}


### PR DESCRIPTION
Allow sending heartbeats and parsing AI heartbeats from other agents when one AI agent parser panics.