### PR TITLE
Recover from corrupted bbolt offline db files

### DIFF
--- a/cmd/heartbeat/heartbeat.go
+++ b/cmd/heartbeat/heartbeat.go
@@ -62,8 +62,9 @@ func Run(ctx context.Context, v *viper.Viper) (int, error) {
 			return errauth.ExitCode(), fmt.Errorf("sending heartbeat(s) failed: %w", errauth)
 		}
 
-		if errwaka, ok := err.(wakaerror.Error); ok {
-			return errwaka.ExitCode(), fmt.Errorf("sending heartbeat(s) failed: %w", errwaka)
+		var errwaka wakaerror.Error
+		if errors.As(err, &errwaka) {
+			return errwaka.ExitCode(), fmt.Errorf("sending heartbeat(s) failed: %w", err)
 		}
 
 		return exitcode.ErrGeneric, fmt.Errorf(

--- a/cmd/offlinecount/offlinecount.go
+++ b/cmd/offlinecount/offlinecount.go
@@ -2,10 +2,12 @@ package offlinecount
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/wakatime/wakatime-cli/pkg/exitcode"
 	"github.com/wakatime/wakatime-cli/pkg/offline"
+	"github.com/wakatime/wakatime-cli/pkg/wakaerror"
 
 	"github.com/spf13/viper"
 )
@@ -23,6 +25,12 @@ func Run(ctx context.Context, v *viper.Viper) (int, error) {
 	count, err := offline.CountHeartbeats(ctx, queueFilepath)
 	if err != nil {
 		fmt.Println(err)
+
+		var errwaka wakaerror.Error
+		if errors.As(err, &errwaka) {
+			return errwaka.ExitCode(), fmt.Errorf("failed to count offline heartbeats: %w", err)
+		}
+
 		return exitcode.ErrGeneric, fmt.Errorf("failed to count offline heartbeats: %w", err)
 	}
 

--- a/cmd/offlineprint/offlineprint.go
+++ b/cmd/offlineprint/offlineprint.go
@@ -4,12 +4,14 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/wakatime/wakatime-cli/pkg/exitcode"
 	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 	"github.com/wakatime/wakatime-cli/pkg/offline"
 	"github.com/wakatime/wakatime-cli/pkg/params"
+	"github.com/wakatime/wakatime-cli/pkg/wakaerror"
 
 	"github.com/spf13/viper"
 )
@@ -29,6 +31,12 @@ func Run(ctx context.Context, v *viper.Viper) (int, error) {
 	hh, err := offline.ReadHeartbeats(ctx, queueFilepath, p.PrintMax)
 	if err != nil {
 		fmt.Println(err)
+
+		var errwaka wakaerror.Error
+		if errors.As(err, &errwaka) {
+			return errwaka.ExitCode(), fmt.Errorf("failed to read offline heartbeats: %w", err)
+		}
+
 		return exitcode.ErrGeneric, fmt.Errorf("failed to read offline heartbeats: %w", err)
 	}
 

--- a/cmd/offlinesync/offlinesync.go
+++ b/cmd/offlinesync/offlinesync.go
@@ -2,6 +2,7 @@ package offlinesync
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 
@@ -68,8 +69,9 @@ func run(ctx context.Context, v *viper.Viper) (int, error) {
 	}
 
 	if err = SyncOfflineActivity(ctx, v, queueFilepath); err != nil {
-		if errwaka, ok := err.(wakaerror.Error); ok {
-			return errwaka.ExitCode(), fmt.Errorf("offline sync failed: %s", errwaka.Message())
+		var errwaka wakaerror.Error
+		if errors.As(err, &errwaka) {
+			return errwaka.ExitCode(), fmt.Errorf("offline sync failed: %w", err)
 		}
 
 		return exitcode.ErrGeneric, fmt.Errorf(

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	stdlog "log"
@@ -289,13 +290,15 @@ func runCmd(ctx context.Context, v *viper.Viper, verbose bool, sendDiagsOnErrors
 	exitCode, err := cmd(ctx, v)
 	// nolint:nestif
 	if err != nil {
-		if errwaka, ok := err.(wakaerror.Error); ok {
+		var errwaka wakaerror.Error
+		if errors.As(err, &errwaka) {
 			sendDiagsOnErrors = sendDiagsOnErrors || errwaka.SendDiagsOnErrors()
 			// if verbose is not set, use the value from the error
 			verbose = verbose || errwaka.ShouldLogError()
 		}
 
-		if errloglevel, ok := err.(wakaerror.LogLevel); ok {
+		var errloglevel wakaerror.LogLevel
+		if errors.As(err, &errloglevel) {
 			logger.Logf(zapcore.Level(errloglevel.LogLevel()), "failed to run command: %s", err)
 		} else if verbose {
 			logger.Errorf("failed to run command: %s", err)

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -604,7 +604,7 @@ func TestRunCmd_SendDiagnostics_WakaError(t *testing.T) {
 
 	cmdFn := func(_ context.Context, _ *viper.Viper) (int, error) {
 		cmdNumCalls++
-		return 42, offline.ErrOpenDB{Err: errors.New("fail")}
+		return 42, fmt.Errorf("wrapped: %w", offline.ErrOpenDB{Err: errors.New("fail")})
 	}
 
 	err = cmd.RunCmd(ctx, v, false, false, cmdFn)

--- a/pkg/offline/error.go
+++ b/pkg/offline/error.go
@@ -9,7 +9,9 @@ import (
 
 // ErrOpenDB is an error returned when the database cannot be opened.
 type ErrOpenDB struct {
-	Err error
+	Err            error
+	BackupFilepath string
+	Reset          bool
 }
 
 var _ wakaerror.Error = ErrOpenDB{}

--- a/pkg/offline/offline.go
+++ b/pkg/offline/offline.go
@@ -3,9 +3,11 @@ package offline
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -18,6 +20,7 @@ import (
 	"github.com/wakatime/wakatime-cli/pkg/vipertools"
 
 	bolt "go.etcd.io/bbolt"
+	bolterrors "go.etcd.io/bbolt/errors"
 )
 
 const (
@@ -69,7 +72,7 @@ func WithQueue(filepath string) heartbeat.HandleOption {
 				requeueErr := pushHeartbeatsWithRetry(ctx, filepath, hh)
 				if requeueErr != nil {
 					return nil, fmt.Errorf(
-						"failed to push heartbeats to queue: %s",
+						"failed to push heartbeats to queue: %w",
 						requeueErr,
 					)
 				}
@@ -79,7 +82,7 @@ func WithQueue(filepath string) heartbeat.HandleOption {
 
 			_, err = handleResults(ctx, filepath, results, hh)
 			if err != nil {
-				return nil, fmt.Errorf("failed to handle results: %s", err)
+				return nil, fmt.Errorf("failed to handle results: %w", err)
 			}
 
 			return results, nil
@@ -118,7 +121,7 @@ func WithSync(filepath string, syncLimit int) heartbeat.HandleOption {
 			// logger.Debugf("execute offline sync with file %s", filepath)
 			err := Sync(ctx, filepath, syncLimit)(next)
 			if err != nil {
-				return nil, fmt.Errorf("failed to sync offline heartbeats: %s", err)
+				return nil, fmt.Errorf("failed to sync offline heartbeats: %w", err)
 			}
 
 			return nil, nil
@@ -152,7 +155,7 @@ func Sync(ctx context.Context, filepath string, syncLimit int) func(next heartbe
 
 			hh, err := popHeartbeats(ctx, filepath, num)
 			if err != nil {
-				return fmt.Errorf("failed to fetch heartbeat from offline queue: %s", err)
+				return fmt.Errorf("failed to fetch heartbeat from offline queue: %w", err)
 			}
 
 			if len(hh) == 0 {
@@ -175,7 +178,7 @@ func Sync(ctx context.Context, filepath string, syncLimit int) func(next heartbe
 
 			stopSending, err := handleResults(ctx, filepath, results, hh)
 			if err != nil {
-				return fmt.Errorf("failed to handle heartbeats api results: %s", err)
+				return fmt.Errorf("failed to handle heartbeats api results: %w", err)
 			}
 
 			if stopSending {
@@ -295,7 +298,9 @@ func missingResultHeartbeats(hh []heartbeat.Heartbeat, handled map[string]int) [
 	return missing
 }
 
-func popHeartbeats(ctx context.Context, filepath string, limit int) ([]heartbeat.Heartbeat, error) {
+func popHeartbeats(ctx context.Context, filepath string, limit int) (queued []heartbeat.Heartbeat, err error) {
+	defer recoverDBPanic(filepath, &err)
+
 	db, close, err := openDB(ctx, filepath)
 	if err != nil {
 		return nil, err
@@ -303,36 +308,42 @@ func popHeartbeats(ctx context.Context, filepath string, limit int) ([]heartbeat
 
 	defer close()
 
+	logger := log.Extract(ctx)
+
 	tx, err := db.Begin(true)
 	if err != nil {
-		return nil, fmt.Errorf("failed to start db transaction: %s", err)
+		return nil, fmt.Errorf("failed to start db transaction: %w", err)
 	}
 
+	defer func() {
+		if tx == nil {
+			return
+		}
+
+		if err := tx.Rollback(); err != nil {
+			logger.Errorf("failed to rollback transaction: %s", err)
+		}
+	}()
+
 	queue := NewQueue(tx)
-	logger := log.Extract(ctx)
 
 	_, err = queue.DeleteDuplicates()
 	if err != nil {
 		logger.Errorf("failed to delete duplicate offline heartbeats: %s", err)
 
-		_ = tx.Rollback()
-
 		return nil, err
 	}
 
-	queued, err := queue.PopMany(limit)
+	queued, err = queue.PopMany(limit)
 	if err != nil {
-		errrb := tx.Rollback()
-		if errrb != nil {
-			logger.Errorf("failed to rollback transaction: %s", errrb)
-		}
-
-		return nil, fmt.Errorf("failed to pop heartbeat(s) from queue: %s", err)
+		return nil, fmt.Errorf("failed to pop heartbeat(s) from queue: %w", err)
 	}
 
 	if err = tx.Commit(); err != nil {
-		return nil, fmt.Errorf("failed to commit db transaction: %s", err)
+		return nil, fmt.Errorf("failed to commit db transaction: %w", err)
 	}
+
+	tx = nil
 
 	return queued, nil
 }
@@ -364,6 +375,13 @@ func pushHeartbeatsWithRetry(ctx context.Context, filepath string, hh []heartbea
 		if err != nil {
 			count++
 
+			var erropen ErrOpenDB
+			if errors.As(err, &erropen) && erropen.Reset {
+				logger.Warnf("offline db was reset after corruption: %s", erropen)
+
+				continue
+			}
+
 			sleepSeconds := math.Pow(2, float64(count))
 
 			time.Sleep(time.Duration(sleepSeconds) * time.Second)
@@ -377,7 +395,9 @@ func pushHeartbeatsWithRetry(ctx context.Context, filepath string, hh []heartbea
 	return nil
 }
 
-func pushHeartbeats(ctx context.Context, filepath string, hh []heartbeat.Heartbeat) error {
+func pushHeartbeats(ctx context.Context, filepath string, hh []heartbeat.Heartbeat) (err error) {
+	defer recoverDBPanic(filepath, &err)
+
 	db, close, err := openDB(ctx, filepath)
 	if err != nil {
 		return err
@@ -385,27 +405,43 @@ func pushHeartbeats(ctx context.Context, filepath string, hh []heartbeat.Heartbe
 
 	defer close()
 
+	logger := log.Extract(ctx)
+
 	tx, err := db.Begin(true)
 	if err != nil {
-		return fmt.Errorf("failed to start db transaction: %s", err)
+		return fmt.Errorf("failed to start db transaction: %w", err)
 	}
+
+	defer func() {
+		if tx == nil {
+			return
+		}
+
+		if err := tx.Rollback(); err != nil {
+			logger.Errorf("failed to rollback transaction: %s", err)
+		}
+	}()
 
 	queue := NewQueue(tx)
 
 	err = queue.PushMany(hh)
 	if err != nil {
-		return fmt.Errorf("failed to push heartbeat(s) to queue: %s", err)
+		return fmt.Errorf("failed to push heartbeat(s) to queue: %w", err)
 	}
 
 	if err = tx.Commit(); err != nil {
-		return fmt.Errorf("failed to commit db transaction: %s", err)
+		return fmt.Errorf("failed to commit db transaction: %w", err)
 	}
+
+	tx = nil
 
 	return nil
 }
 
 // CountHeartbeats returns the total number of heartbeats in the offline db.
-func CountHeartbeats(ctx context.Context, filepath string) (int, error) {
+func CountHeartbeats(ctx context.Context, filepath string) (count int, err error) {
+	defer recoverDBPanic(filepath, &err)
+
 	db, close, err := openDB(ctx, filepath)
 	if err != nil {
 		return 0, err
@@ -415,7 +451,7 @@ func CountHeartbeats(ctx context.Context, filepath string) (int, error) {
 
 	tx, err := db.Begin(true)
 	if err != nil {
-		return 0, fmt.Errorf("failed to start db transaction: %s", err)
+		return 0, fmt.Errorf("failed to start db transaction: %w", err)
 	}
 
 	logger := log.Extract(ctx)
@@ -429,16 +465,18 @@ func CountHeartbeats(ctx context.Context, filepath string) (int, error) {
 
 	queue := NewQueue(tx)
 
-	count, err := queue.Count()
+	count, err = queue.Count()
 	if err != nil {
-		return 0, fmt.Errorf("failed to count heartbeats: %s", err)
+		return 0, fmt.Errorf("failed to count heartbeats: %w", err)
 	}
 
 	return count, nil
 }
 
 // ReadHeartbeats reads the informed heartbeats in the offline db.
-func ReadHeartbeats(ctx context.Context, filepath string, limit int) ([]heartbeat.Heartbeat, error) {
+func ReadHeartbeats(ctx context.Context, filepath string, limit int) (hh []heartbeat.Heartbeat, err error) {
+	defer recoverDBPanic(filepath, &err)
+
 	db, close, err := openDB(ctx, filepath)
 	if err != nil {
 		return nil, err
@@ -448,27 +486,36 @@ func ReadHeartbeats(ctx context.Context, filepath string, limit int) ([]heartbea
 
 	tx, err := db.Begin(true)
 	if err != nil {
-		return nil, fmt.Errorf("failed to start db transaction: %s", err)
+		return nil, fmt.Errorf("failed to start db transaction: %w", err)
 	}
 
 	queue := NewQueue(tx)
 	logger := log.Extract(ctx)
 
-	hh, err := queue.ReadMany(limit)
+	defer func() {
+		if tx == nil {
+			return
+		}
+
+		if err := tx.Rollback(); err != nil {
+			logger.Warnf("failed to rollback transaction: %s", err)
+		}
+	}()
+
+	hh, err = queue.ReadMany(limit)
 	if err != nil {
 		logger.Errorf("failed to read offline heartbeats: %s", err)
-
-		_ = tx.Rollback()
 
 		return nil, err
 	}
 
-	err = tx.Rollback()
-	if err != nil {
-		logger.Warnf("failed to rollback transaction: %s", err)
-	}
-
 	return hh, nil
+}
+
+func recoverDBPanic(dbFilepath string, err *error) {
+	if r := recover(); r != nil {
+		*err = resetCorruptDBError(dbFilepath, fmt.Errorf("panicked: %v", r))
+	}
 }
 
 // openDB opens a connection to the offline db.
@@ -477,13 +524,17 @@ func ReadHeartbeats(ctx context.Context, filepath string, limit int) ([]heartbea
 func openDB(ctx context.Context, filepath string) (db *bolt.DB, _ func(), err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			err = ErrOpenDB{Err: fmt.Errorf("panicked: %v", r)}
+			err = resetCorruptDBError(filepath, fmt.Errorf("panicked: %v", r))
 		}
 	}()
 
 	db, err = bolt.Open(filepath, 0644, &bolt.Options{Timeout: 30 * time.Second})
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to open db file: %s", err)
+		if isCorruptDBError(err) {
+			return nil, nil, resetCorruptDBError(filepath, fmt.Errorf("failed to open db file: %w", err))
+		}
+
+		return nil, nil, fmt.Errorf("failed to open db file: %w", err)
 	}
 
 	return db, func() {
@@ -500,6 +551,48 @@ func openDB(ctx context.Context, filepath string) (db *bolt.DB, _ func(), err er
 			logger.Debugf("failed to close db file: %s", err)
 		}
 	}, err
+}
+
+func isCorruptDBError(err error) bool {
+	return errors.Is(err, bolterrors.ErrInvalid) ||
+		errors.Is(err, bolterrors.ErrVersionMismatch) ||
+		errors.Is(err, bolterrors.ErrChecksum)
+}
+
+func resetCorruptDBError(dbFilepath string, cause error) ErrOpenDB {
+	backupFilepath, err := resetCorruptDB(dbFilepath)
+	if err != nil {
+		return ErrOpenDB{Err: fmt.Errorf("%w; failed to move corrupt db file: %v", cause, err)}
+	}
+
+	if backupFilepath == "" {
+		return ErrOpenDB{Err: fmt.Errorf("%w; corrupt db file already removed", cause), Reset: true}
+	}
+
+	return ErrOpenDB{
+		Err:            fmt.Errorf("%w; moved corrupt db file to %q", cause, backupFilepath),
+		BackupFilepath: backupFilepath,
+		Reset:          true,
+	}
+}
+
+func resetCorruptDB(dbFilepath string) (string, error) {
+	backupFilepath := fmt.Sprintf(
+		"%s.corrupt.%s",
+		dbFilepath,
+		time.Now().UTC().Format("20060102T150405.000000000Z"),
+	)
+
+	err := os.Rename(dbFilepath, backupFilepath)
+	if errors.Is(err, os.ErrNotExist) {
+		return "", nil
+	}
+
+	if err != nil {
+		return "", err
+	}
+
+	return backupFilepath, nil
 }
 
 // Queue is a db client to temporarily store heartbeats in bolt db, in case heartbeat
@@ -522,7 +615,7 @@ func NewQueue(tx *bolt.Tx) *Queue {
 func (q *Queue) Count() (int, error) {
 	b, err := q.tx.CreateBucketIfNotExists([]byte(q.Bucket))
 	if err != nil {
-		return 0, fmt.Errorf("failed to create/load bucket: %s", err)
+		return 0, fmt.Errorf("failed to create/load bucket: %w", err)
 	}
 
 	return b.Stats().KeyN, nil
@@ -532,7 +625,7 @@ func (q *Queue) Count() (int, error) {
 func (q *Queue) PopMany(limit int) ([]heartbeat.Heartbeat, error) {
 	b, err := q.tx.CreateBucketIfNotExists([]byte(q.Bucket))
 	if err != nil {
-		return nil, fmt.Errorf("failed to create/load bucket: %s", err)
+		return nil, fmt.Errorf("failed to create/load bucket: %w", err)
 	}
 
 	var (
@@ -554,7 +647,7 @@ func (q *Queue) PopMany(limit int) ([]heartbeat.Heartbeat, error) {
 
 		err := json.Unmarshal(value, &h)
 		if err != nil {
-			return nil, fmt.Errorf("failed to json unmarshal heartbeat data: %s", err)
+			return nil, fmt.Errorf("failed to json unmarshal heartbeat data: %w", err)
 		}
 
 		heartbeats = append(heartbeats, h)
@@ -563,7 +656,7 @@ func (q *Queue) PopMany(limit int) ([]heartbeat.Heartbeat, error) {
 
 	for _, id := range ids {
 		if err := b.Delete([]byte(id)); err != nil {
-			return nil, fmt.Errorf("failed to delete key %q: %s", id, err)
+			return nil, fmt.Errorf("failed to delete key %q: %w", id, err)
 		}
 	}
 
@@ -574,18 +667,18 @@ func (q *Queue) PopMany(limit int) ([]heartbeat.Heartbeat, error) {
 func (q *Queue) PushMany(hh []heartbeat.Heartbeat) error {
 	b, err := q.tx.CreateBucketIfNotExists([]byte(q.Bucket))
 	if err != nil {
-		return fmt.Errorf("failed to create/load bucket: %s", err)
+		return fmt.Errorf("failed to create/load bucket: %w", err)
 	}
 
 	for _, h := range hh {
 		data, err := json.Marshal(h)
 		if err != nil {
-			return fmt.Errorf("failed to json marshal heartbeat: %s", err)
+			return fmt.Errorf("failed to json marshal heartbeat: %w", err)
 		}
 
 		err = b.Put([]byte(h.ID()), data)
 		if err != nil {
-			return fmt.Errorf("failed to store heartbeat with id %q: %s", h.ID(), err)
+			return fmt.Errorf("failed to store heartbeat with id %q: %w", h.ID(), err)
 		}
 	}
 
@@ -596,7 +689,7 @@ func (q *Queue) PushMany(hh []heartbeat.Heartbeat) error {
 func (q *Queue) ReadMany(limit int) ([]heartbeat.Heartbeat, error) {
 	b, err := q.tx.CreateBucketIfNotExists([]byte(q.Bucket))
 	if err != nil {
-		return nil, fmt.Errorf("failed to create/load bucket: %s", err)
+		return nil, fmt.Errorf("failed to create/load bucket: %w", err)
 	}
 
 	var heartbeats = make([]heartbeat.Heartbeat, 0)
@@ -613,7 +706,7 @@ func (q *Queue) ReadMany(limit int) ([]heartbeat.Heartbeat, error) {
 
 		err := json.Unmarshal(value, &h)
 		if err != nil {
-			return nil, fmt.Errorf("failed to json unmarshal heartbeat data: %s", err)
+			return nil, fmt.Errorf("failed to json unmarshal heartbeat data: %w", err)
 		}
 
 		heartbeats = append(heartbeats, h)
@@ -626,7 +719,7 @@ func (q *Queue) ReadMany(limit int) ([]heartbeat.Heartbeat, error) {
 func (q *Queue) DeleteDuplicates() (int, error) {
 	b, err := q.tx.CreateBucketIfNotExists([]byte(q.Bucket))
 	if err != nil {
-		return 0, fmt.Errorf("failed to create/load bucket: %s", err)
+		return 0, fmt.Errorf("failed to create/load bucket: %w", err)
 	}
 
 	kept := make(map[string][]float64)
@@ -638,7 +731,7 @@ func (q *Queue) DeleteDuplicates() (int, error) {
 
 		err := json.Unmarshal(value, &h)
 		if err != nil {
-			return 0, fmt.Errorf("failed to json unmarshal heartbeat data: %s", err)
+			return 0, fmt.Errorf("failed to json unmarshal heartbeat data: %w", err)
 		}
 
 		isDuplicate := false
@@ -652,7 +745,7 @@ func (q *Queue) DeleteDuplicates() (int, error) {
 
 		if isDuplicate {
 			if err := c.Delete(); err != nil {
-				return 0, fmt.Errorf("failed to delete duplicate heartbeat with key %q: %s", string(key), err)
+				return 0, fmt.Errorf("failed to delete duplicate heartbeat with key %q: %w", string(key), err)
 			}
 
 			deleted++

--- a/pkg/offline/offline_test.go
+++ b/pkg/offline/offline_test.go
@@ -2,6 +2,7 @@ package offline_test
 
 import (
 	"context"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -1283,6 +1284,92 @@ func TestCountHeartbeats_Empty(t *testing.T) {
 	assert.Equal(t, count, 0)
 }
 
+func TestCountHeartbeats_CorruptDBReturnsErrOpenDB(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "")
+	require.NoError(t, err)
+
+	queuePath := f.Name()
+	require.NoError(t, f.Close())
+
+	db, err := bolt.Open(queuePath, 0600, nil)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	corruptBoltPageFlags(t, queuePath, 3, 0x0a)
+
+	count, err := offline.CountHeartbeats(t.Context(), queuePath)
+
+	var erropen offline.ErrOpenDB
+	require.ErrorAs(t, err, &erropen)
+	assert.Zero(t, count)
+	assert.True(t, erropen.Reset)
+	assert.FileExists(t, erropen.BackupFilepath)
+	assert.NoFileExists(t, queuePath)
+	assert.Contains(t, err.Error(), "panicked:")
+	assert.Contains(t, err.Error(), "page 3")
+
+	count, err = offline.CountHeartbeats(t.Context(), queuePath)
+	require.NoError(t, err)
+	assert.Zero(t, count)
+	assert.FileExists(t, queuePath)
+}
+
+func TestCountHeartbeats_InvalidDBResetsQueue(t *testing.T) {
+	queuePath := filepath.Join(t.TempDir(), "offline_heartbeats.bdb")
+	require.NoError(t, os.WriteFile(queuePath, []byte("not a bolt db"), 0600))
+
+	count, err := offline.CountHeartbeats(t.Context(), queuePath)
+
+	var erropen offline.ErrOpenDB
+	require.ErrorAs(t, err, &erropen)
+	assert.Zero(t, count)
+	assert.True(t, erropen.Reset)
+	assert.FileExists(t, erropen.BackupFilepath)
+	assert.NoFileExists(t, queuePath)
+
+	count, err = offline.CountHeartbeats(t.Context(), queuePath)
+	require.NoError(t, err)
+	assert.Zero(t, count)
+	assert.FileExists(t, queuePath)
+}
+
+func TestWithQueue_CorruptDBResetsAndSavesHeartbeats(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "")
+	require.NoError(t, err)
+
+	queuePath := f.Name()
+	require.NoError(t, f.Close())
+
+	db, err := bolt.Open(queuePath, 0600, nil)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	corruptBoltPageFlags(t, queuePath, 3, 0x0a)
+
+	h := heartbeat.Heartbeat{
+		Entity:     "/tmp/main.go",
+		EntityType: heartbeat.FileType,
+		Time:       1,
+		UserAgent:  "wakatime/test",
+	}
+
+	handle := offline.WithQueue(queuePath)(func(context.Context, []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+		return nil, errors.New("api unavailable")
+	})
+
+	_, err = handle(t.Context(), []heartbeat.Heartbeat{h})
+	require.EqualError(t, err, "api unavailable")
+
+	count, err := offline.CountHeartbeats(t.Context(), queuePath)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+
+	hh, err := offline.ReadHeartbeats(t.Context(), queuePath, 1)
+	require.NoError(t, err)
+	require.Len(t, hh, 1)
+	assert.Equal(t, h.ID(), hh[0].ID())
+}
+
 func TestReadHeartbeats(t *testing.T) {
 	// setup
 	f, err := os.CreateTemp(t.TempDir(), "")
@@ -1946,4 +2033,23 @@ func insertHeartbeatRecord(t *testing.T, db *bolt.DB, bucket string, h heartbeat
 		return nil
 	})
 	require.NoError(t, err)
+}
+
+func corruptBoltPageFlags(t *testing.T, path string, pageID uint64, flags uint16) {
+	t.Helper()
+
+	f, err := os.OpenFile(path, os.O_WRONLY, 0600)
+	require.NoError(t, err)
+
+	defer func() {
+		require.NoError(t, f.Close())
+	}()
+
+	var data [2]byte
+	binary.LittleEndian.PutUint16(data[:], flags)
+
+	offset := int64(pageID)*int64(os.Getpagesize()) + 8
+	n, err := f.WriteAt(data[:], offset)
+	require.NoError(t, err)
+	require.Equal(t, len(data), n)
 }


### PR DESCRIPTION
On detected bbolt corruption, the CLI moves the corrupt DB aside to a timestamped backup like:

    offline_heartbeats.bdb.corrupt.20260624T...Z

Then future opens create a fresh offline queue. If corruption is hit while saving heartbeats offline, it resets the DB and immediately retries the save, so the current heartbeat batch can still be written to the new queue.

It does not repair and resend old queued heartbeats from the corrupt file. Those are preserved in the .corrupt.* backup for possible manual recovery, but they won’t be synced automatically.
