### PR TITLE
Improve test coverage across CLI and parser packages

### DIFF
--- a/cmd/dispatch_internal_test.go
+++ b/cmd/dispatch_internal_test.go
@@ -297,6 +297,7 @@ func newRunEViper(t *testing.T) *viper.Viper {
 	v.Set("config", filepath.Join(tmpDir, "missing.cfg"))
 	v.Set("internal-config", filepath.Join(tmpDir, "missing-internal.cfg"))
 	v.Set("log-file", filepath.Join(tmpDir, "wakatime.log"))
+	v.Set("log-to-stdout", true)
 
 	return v
 }

--- a/cmd/heartbeat/heartbeat_internal_test.go
+++ b/cmd/heartbeat/heartbeat_internal_test.go
@@ -1,22 +1,132 @@
 package heartbeat
 
 import (
+	"path/filepath"
 	"testing"
+	"time"
 
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
-	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
+	"github.com/stretchr/testify/require"
+	heartbeatpkg "github.com/wakatime/wakatime-cli/pkg/heartbeat"
+	offlinepkg "github.com/wakatime/wakatime-cli/pkg/offline"
+	paramspkg "github.com/wakatime/wakatime-cli/pkg/params"
 )
 
-func TestShouldUseProjectConfig(t *testing.T) {
-	assert.False(t, shouldUseProjectConfig(nil))
-	assert.False(t, shouldUseProjectConfig([]heartbeat.Heartbeat{
-		{Entity: "Claude session", EntityType: heartbeat.AppType},
-	}))
-	assert.False(t, shouldUseProjectConfig([]heartbeat.Heartbeat{
-		{Entity: "untitled", EntityType: heartbeat.FileType, IsUnsavedEntity: true},
-	}))
-	assert.True(t, shouldUseProjectConfig([]heartbeat.Heartbeat{
-		{Entity: "Claude session", EntityType: heartbeat.AppType},
-		{Entity: "/tmp/main.go", EntityType: heartbeat.FileType},
-	}))
+func TestLoadParamsInternalBranches(t *testing.T) {
+	_, err := loadParams(t.Context(), nil, paramspkg.FlagReadOrderFlagPrecedence)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "viper instance unset")
+
+	v := viper.New()
+	v.Set("key", "00000000-0000-4000-8000-000000000000")
+
+	_, err = loadParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to load heartbeat params")
+
+	_, err = loadAISyncParams(t.Context(), viper.New(), paramspkg.FlagReadOrderFlagPrecedence)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to load API params")
+}
+
+func TestApplyAIParsingDisabledPassesThrough(t *testing.T) {
+	input := []heartbeatpkg.Heartbeat{{
+		Entity:     "Terminal",
+		EntityType: heartbeatpkg.AppType,
+		Time:       1,
+		UserAgent:  "plugin/0.0.1",
+	}}
+
+	got, err := applyAIParsing(t.Context(), viper.New(), paramspkg.Params{
+		AI:  paramspkg.AIParams{SyncDisabled: true},
+		API: paramspkg.API{Plugin: "plugin/0.0.1"},
+	}, input)
+
+	require.NoError(t, err)
+	assert.Equal(t, input, got)
+}
+
+func TestSendPreparedHeartbeatsRateLimitedSavesOffline(t *testing.T) {
+	queueFile := filepath.Join(t.TempDir(), "offline.bdb")
+	params := internalCommandParams()
+	params.Offline.LastSentAt = time.Now()
+	params.Offline.RateLimit = time.Hour
+
+	err := sendPreparedHeartbeats(
+		t.Context(),
+		viper.New(),
+		params,
+		queueFile,
+		[]heartbeatpkg.Heartbeat{internalAppHeartbeat()},
+		false,
+		loadParams,
+	)
+
+	require.NoError(t, err)
+
+	count, err := offlinepkg.CountHeartbeats(t.Context(), queueFile)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+}
+
+func TestSendPreparedHeartbeatsBuildHandleErrorSavesOffline(t *testing.T) {
+	queueFile := filepath.Join(t.TempDir(), "offline.bdb")
+	params := internalCommandParams()
+	params.API.SSLCertFilepath = filepath.Join(t.TempDir(), "missing.pem")
+
+	err := sendPreparedHeartbeats(
+		t.Context(),
+		viper.New(),
+		params,
+		queueFile,
+		[]heartbeatpkg.Heartbeat{internalAppHeartbeat()},
+		false,
+		loadParams,
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to initialize api client")
+
+	count, countErr := offlinepkg.CountHeartbeats(t.Context(), queueFile)
+	require.NoError(t, countErr)
+	assert.Equal(t, 1, count)
+}
+
+func TestShouldUseProjectConfigBranches(t *testing.T) {
+	assert.False(t, shouldUseProjectConfig([]heartbeatpkg.Heartbeat{{Entity: "Terminal", EntityType: heartbeatpkg.AppType}}))
+	assert.False(t, shouldUseProjectConfig([]heartbeatpkg.Heartbeat{{
+		Entity:          "/tmp/unsaved.go",
+		EntityType:      heartbeatpkg.FileType,
+		IsUnsavedEntity: true,
+	}}))
+	assert.True(t, shouldUseProjectConfig([]heartbeatpkg.Heartbeat{{
+		Entity:     "/tmp/main.go",
+		EntityType: heartbeatpkg.FileType,
+	}}))
+}
+
+func internalCommandParams() paramspkg.Params {
+	return paramspkg.Params{
+		API: paramspkg.API{
+			Plugin:  "plugin/0.0.1",
+			Timeout: time.Second,
+			URL:     "http://127.0.0.1",
+		},
+		Heartbeat: paramspkg.Heartbeat{
+			Category:   heartbeatpkg.CodingCategory,
+			Entity:     "Terminal",
+			EntityType: heartbeatpkg.AppType,
+			Time:       1,
+		},
+	}
+}
+
+func internalAppHeartbeat() heartbeatpkg.Heartbeat {
+	return heartbeatpkg.Heartbeat{
+		Entity:     "Terminal",
+		EntityType: heartbeatpkg.AppType,
+		Time:       1,
+		UserAgent:  "plugin/0.0.1",
+	}
 }

--- a/pkg/ai/ai_internal_test.go
+++ b/pkg/ai/ai_internal_test.go
@@ -1,12 +1,20 @@
 package ai
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
 	"testing"
 
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/wakatime/wakatime-cli/pkg/log"
 )
 
 type panicParser struct{}
@@ -73,4 +81,99 @@ func TestParseHeartbeats_Error(t *testing.T) {
 
 	require.EqualError(t, err, "failed")
 	assert.Nil(t, heartbeats)
+}
+
+func TestCaptureAIParsingLogsVerbose(t *testing.T) {
+	var output bytes.Buffer
+
+	logger := log.New(&output, log.WithVerbose(true))
+	ctx := log.ToContext(t.Context(), logger)
+
+	captured, reset := captureAIParsingLogs(ctx)
+
+	logger.Debugln("captured debug")
+	reset()
+	logger.Debugln("after reset")
+
+	assert.Contains(t, output.String(), "captured debug")
+	assert.Contains(t, output.String(), "after reset")
+	assert.Contains(t, captured.String(), "captured debug")
+	assert.NotContains(t, captured.String(), "after reset")
+}
+
+func TestSendAIPanicDiagnostics(t *testing.T) {
+	t.Setenv("HTTP_PROXY", "")
+	t.Setenv("HTTPS_PROXY", "")
+	t.Setenv("NO_PROXY", "*")
+
+	var called bool
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		called = true
+
+		assert.Equal(t, http.MethodPost, req.Method)
+		assert.Equal(t, "/plugins/errors", req.URL.Path)
+		assert.Equal(t, "application/json", req.Header.Get("Content-Type"))
+		assert.NotEmpty(t, req.Header.Get("Authorization"))
+
+		body, err := io.ReadAll(req.Body)
+		require.NoError(t, err)
+
+		var payload struct {
+			ErrorMessage string `json:"error_message"`
+			IsPanic      bool   `json:"is_panic"`
+			Logs         string `json:"logs"`
+			Plugin       string `json:"plugin"`
+			Stack        string `json:"stacktrace"`
+		}
+
+		require.NoError(t, json.Unmarshal(body, &payload))
+		assert.Equal(t, `ai parser "panic" panicked: OOM`, payload.ErrorMessage)
+		assert.True(t, payload.IsPanic)
+		assert.Equal(t, "parser logs", payload.Logs)
+		assert.Equal(t, "plugin/0.0.1", payload.Plugin)
+		assert.Equal(t, "stack", payload.Stack)
+
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer server.Close()
+
+	v := newDiagnosticViper(server.URL)
+
+	err := sendAIPanicDiagnostics(t.Context(), v, aiPanicReport{
+		Logs:       "parser logs",
+		ParserName: "panic",
+		Recovered:  "OOM",
+		Stack:      "stack",
+	})
+
+	require.NoError(t, err)
+	assert.True(t, called)
+}
+
+func TestSendAIPanicDiagnosticsErrorBranches(t *testing.T) {
+	err := sendAIPanicDiagnostics(t.Context(), nil, aiPanicReport{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing viper instance")
+
+	err = sendAIPanicDiagnostics(t.Context(), viper.New(), aiPanicReport{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to load API parameters")
+
+	v := newDiagnosticViper("http://127.0.0.1")
+	v.Set("ssl-certs-file", filepath.Join(t.TempDir(), "missing.pem"))
+
+	err = sendAIPanicDiagnostics(t.Context(), v, aiPanicReport{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to set up ssl cert file option")
+}
+
+func newDiagnosticViper(apiURL string) *viper.Viper {
+	v := viper.New()
+	v.Set("api-url", apiURL)
+	v.Set("key", "00000000-0000-4000-8000-000000000000")
+	v.Set("plugin", "plugin/0.0.1")
+	v.Set("timeout", 5)
+
+	return v
 }

--- a/pkg/ai/helpers_internal_test.go
+++ b/pkg/ai/helpers_internal_test.go
@@ -3,6 +3,7 @@ package ai
 import (
 	"context"
 	"encoding/json"
+	"math"
 	"os"
 	"path/filepath"
 	"testing"
@@ -200,6 +201,8 @@ func TestAppHeartbeatEntity(t *testing.T) {
 	assert.Equal(t, "Claude session", appHeartbeatEntity("Claude", "session.jsonl"))
 	assert.Equal(t, "Cursor composer-1", appHeartbeatEntity("Cursor", "composer-1"))
 	assert.Equal(t, "Cursor", appHeartbeatEntity("Cursor", ""))
+	assert.Equal(t, "Cursor", appHeartbeatEntity("Cursor", "Cursor.jsonl"))
+	assert.Equal(t, "Cursor", appHeartbeatEntity("Cursor", ".jsonl"))
 }
 
 func TestCodexSessionIDFromPath(t *testing.T) {
@@ -235,6 +238,15 @@ func TestGetLastParsedAt(t *testing.T) {
 		require.NoError(t, err)
 		assert.False(t, parsed.Before(before))
 		assert.False(t, parsed.After(after))
+	})
+
+	t.Run("keeps default when timestamp is invalid", func(t *testing.T) {
+		v := viper.New()
+		v.Set("internal.ai_logs_last_parsed_at", "invalid")
+
+		parsed, err := getLastParsedAt(ctx, v)
+		require.NoError(t, err)
+		assert.WithinDuration(t, time.Now().Add(-2*time.Minute), parsed, 2*time.Second)
 	})
 
 	t.Run("defaults to Claude Code release date when value is unset", func(t *testing.T) {
@@ -303,6 +315,53 @@ func TestHeartbeatTime(t *testing.T) {
 	got := heartbeatTime(float64(expected.Unix()) + 0.5)
 
 	assert.Equal(t, expected, got)
+}
+
+func TestHeartbeatTimeInvalidAndRounded(t *testing.T) {
+	assert.True(t, heartbeatTime(math.NaN()).IsZero())
+	assert.True(t, heartbeatTime(math.Inf(1)).IsZero())
+	assert.Equal(
+		t,
+		time.Unix(11, 0).UTC(),
+		heartbeatTime(10.9999999999),
+	)
+}
+
+func TestMinMaxAIHeartbeatTimesBranches(t *testing.T) {
+	minimum, maximum := minMaxAIHeartbeatTimes(Heartbeats{
+		{Time: 10},
+		{Time: 5},
+		{Time: 15},
+	})
+
+	assert.Equal(t, float64(5), minimum)
+	assert.Equal(t, float64(15), maximum)
+}
+
+func TestUserAgentProductFields(t *testing.T) {
+	assert.Nil(t, userAgentProductFields(""))
+	assert.Nil(t, userAgentProductFields("wakatime/1.0"))
+	assert.Equal(t, []string{"plugin/1.0"}, userAgentProductFields("wakatime/1.0 (os) go1 plugin/1.0"))
+	assert.Equal(t, []string{"plugin/1.0"}, userAgentProductFields("plugin/1.0"))
+	assert.False(t, userAgentHasToken("", "plugin/1.0"))
+	assert.False(t, userAgentHasToken("plugin/1.0", ""))
+	assert.True(t, userAgentHasToken("plugin/1.0", "plugin/1.0"))
+	assert.Empty(t, aiAgentUserAgentToken(""))
+	assert.Empty(t, aiAgentUserAgentToken("bad/-"))
+	assert.Equal(t, "agent/1.2.3", aiAgentUserAgentToken("agent-1.2.3"))
+	assert.Equal(t, "agent", aiAgentUserAgentToken("agent"))
+}
+
+func TestAddIntPointers(t *testing.T) {
+	one := 1
+	two := 2
+
+	assert.Equal(t, &one, addIntPointers(nil, &one))
+	assert.Equal(t, &one, addIntPointers(&one, nil))
+
+	got := addIntPointers(&one, &two)
+	require.NotNil(t, got)
+	assert.Equal(t, 3, *got)
 }
 
 func TestClaudeHelpers(t *testing.T) {

--- a/pkg/ai/helpers_more_internal_test.go
+++ b/pkg/ai/helpers_more_internal_test.go
@@ -1,13 +1,16 @@
 package ai
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
+	wakalog "github.com/wakatime/wakatime-cli/pkg/log"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -185,4 +188,1585 @@ func TestQwenCodeResolveDir(t *testing.T) {
 
 func TestSyncLockClockNow(t *testing.T) {
 	assert.False(t, syncLockClock{}.Now().IsZero())
+}
+
+func TestCopilotCLITelemetryHelpers(t *testing.T) {
+	telemetry := &copilotCLIToolTelemetry{
+		Metrics: copilotCLIToolMetrics{
+			LinesAdded:   heartbeat.PointerTo(5),
+			LinesRemoved: heartbeat.PointerTo(2),
+		},
+		RestrictedProperties: &copilotCLIToolRestrictedProperties{
+			FilePaths: json.RawMessage(`"[\"/tmp/main.go\",\"\",\"/tmp/main.go\",\"/tmp/other.go\"]"`),
+		},
+		Properties: copilotCLIToolProperties{
+			CodeBlocks: json.RawMessage(`[{"linesAdded":3,"linesRemoved":1}]`),
+		},
+	}
+
+	data := copilotCLIToolExecutionCompleteData{ResultTelemetry: telemetry}
+	assert.Equal(t, telemetry, data.telemetry())
+	assert.True(t, telemetry.hasWriteSignals("read_file"))
+	assert.True(t, copilotCLIToolTelemetry{}.hasWriteSignals("write"))
+	assert.False(t, copilotCLIToolTelemetry{}.hasWriteSignals("read_file"))
+	assert.Equal(t, []string{"/tmp/main.go", "/tmp/other.go"}, telemetry.filePaths())
+
+	lineChanges := telemetry.lineChanges(1)
+	require.NotNil(t, lineChanges.value(0))
+	assert.Equal(t, 2, *lineChanges.value(0))
+	assert.Nil(t, lineChanges.value(-1))
+	assert.Nil(t, lineChanges.value(1))
+
+	metricLineChanges := (&copilotCLIToolTelemetry{
+		Metrics: copilotCLIToolMetrics{LinesAdded: heartbeat.PointerTo(4)},
+	}).lineChanges(1)
+	require.NotNil(t, metricLineChanges.value(0))
+	assert.Equal(t, 4, *metricLineChanges.value(0))
+}
+
+func TestCopilotCLIDecodeHelpers(t *testing.T) {
+	assert.Nil(t, decodeCopilotCLIStringArray(nil))
+	assert.Nil(t, decodeCopilotCLIStringArray(json.RawMessage(`null`)))
+	assert.Equal(t, []string{"a", "b"}, decodeCopilotCLIStringArray(json.RawMessage(`["a","b"]`)))
+	assert.Equal(t, []string{"a"}, decodeCopilotCLIStringArray(json.RawMessage(`"[\"a\"]"`)))
+	assert.Nil(t, decodeCopilotCLIStringArray(json.RawMessage(`123`)))
+
+	assert.Nil(t, decodeCopilotCLICodeBlocks(nil))
+	assert.Nil(t, decodeCopilotCLICodeBlocks(json.RawMessage(`null`)))
+	assert.Len(t, decodeCopilotCLICodeBlocks(json.RawMessage(`[{"linesAdded":1}]`)), 1)
+	assert.Len(t, decodeCopilotCLICodeBlocks(json.RawMessage(`"[{\"linesAdded\":1}]"`)), 1)
+	assert.Nil(t, decodeCopilotCLICodeBlocks(json.RawMessage(`123`)))
+
+	assert.Equal(t, []string{"a", "b"}, uniqueNonEmptyStrings([]string{"a", "", "b", "a"}))
+	assert.Equal(t, "C:/tmp/main.go", copilotCLIPathID(` C:\tmp\main.go `))
+	assert.Empty(t, copilotCLIPathID("   "))
+	assert.False(t, (Copilot{}).shouldTrackCLIPath(""))
+	assert.True(t, (Copilot{}).shouldTrackCLIPath("/tmp/main.go"))
+}
+
+func TestCopilotCLIUserAgentAndHeartbeats(t *testing.T) {
+	parser := Copilot{
+		FallbackUserAgent: "plugin/1.0",
+		UserAgents: map[string]string{
+			"/tmp/main.go": "editor/2.0",
+		},
+	}
+	timestamp := time.Date(2026, 6, 24, 18, 0, 0, 123*int(time.Millisecond), time.UTC)
+
+	assert.Equal(t, "github-copilot-cli/1.2.3 copilot/4.5.6", copilotCLIHarnessUserAgent("1.2.3", "4.5.6"))
+	assert.Equal(t, "github-copilot-cli/unknown copilot/4.5.6", copilotCLIHarnessUserAgent("", "4.5.6"))
+	assert.Empty(t, copilotCLIHarnessUserAgent("", ""))
+
+	app := parser.cliAppHeartbeat(
+		"Copilot session",
+		"session-1",
+		&heartbeat.AITokens{LastInput: 1, CurrentInput: 4, LastOutput: 2, CurrentOutput: 8},
+		42,
+		timestamp,
+		"/project",
+		"gpt-5",
+		"1.2.3",
+		"4.5.6",
+	)
+	assert.Equal(t, "session-1", app.AISession)
+	assert.Equal(t, int64(3), app.AIInputTokens)
+	assert.Equal(t, int64(6), app.AIOutputTokens)
+	assert.Equal(t, 42, app.AIPromptLength)
+	assert.Contains(t, app.UserAgent, "gpt/5")
+	assert.Contains(t, app.UserAgent, "github-copilot-cli/1.2.3")
+
+	lineChanges := 7
+	file := parser.cliFileHeartbeat(
+		"/tmp/main.go",
+		"session-1",
+		nil,
+		timestamp,
+		"",
+		"",
+		"",
+		true,
+		&lineChanges,
+	)
+	assert.Equal(t, "session-1", file.AISession)
+	assert.Equal(t, &lineChanges, file.AILineChanges)
+	assert.Contains(t, file.UserAgent, "editor/2.0")
+}
+
+func TestGeminiHelperBranches(t *testing.T) {
+	tmpDir := t.TempDir()
+	transcript := filepath.Join(tmpDir, "logs", "session", "transcript.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(transcript), 0700))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(tmpDir, "logs", ".project_root"),
+		[]byte("/workspace/project\n"),
+		0600,
+	))
+
+	parser := Gemini{}
+	assert.Equal(t, "/fallback", parser.projectPathFromLogs(transcript, "/fallback"))
+	assert.Equal(t, "/workspace/project", parser.projectPathFromLogs(transcript, ""))
+	assert.Equal(t, "/display.go", parser.toolFilePath(
+		"/project",
+		json.RawMessage(`{"filePath":"/display.go"}`),
+		"relative.go",
+	))
+	assert.Equal(t, filepath.Join("/project", "relative.go"), parser.toolFilePath("/project", nil, "relative.go"))
+	assert.Equal(t, 4, parser.replaceLineChanges(
+		json.RawMessage(`{"diffStat":{"model_added_lines":5,"model_removed_lines":1}}`),
+		"old",
+		"new",
+	))
+	assert.Equal(t, 1, parser.replaceLineChanges(nil, "one", "one\ntwo"))
+	assert.True(t, parser.hasTokenDelta(heartbeat.AITokens{LastInput: 1, CurrentInput: 2}))
+	assert.False(t, parser.hasTokenDelta(heartbeat.AITokens{LastInput: 5, CurrentInput: 1}))
+	assert.Nil(t, parser.tokensForFirstHeartbeat(false, heartbeat.AITokens{CurrentInput: 1}))
+	require.NotNil(t, parser.tokensForFirstHeartbeat(true, heartbeat.AITokens{CurrentInput: 1}))
+	assert.Equal(t, "hello", geminiText(json.RawMessage(`"hello"`)))
+	assert.Equal(t, "hello world", geminiText(json.RawMessage(`[{"text":"hello "},{"text":"world"}]`)))
+	assert.Empty(t, geminiText(json.RawMessage(`123`)))
+	assert.False(t, parseGeminiTime("2026-06-24T18:00:00Z").IsZero())
+	assert.True(t, parseGeminiTime("").IsZero())
+	assert.True(t, parseGeminiTime("bad").IsZero())
+}
+
+func TestWindsurfHelperBranches(t *testing.T) {
+	base := t.TempDir()
+	editPath := filepath.Join(base, "edit.go")
+	readPath := filepath.Join(base, "read.go")
+	rawPath := filepath.Join(base, "raw.go")
+	codeBlockPath := filepath.Join(base, "block.go")
+	timestamp := time.Date(2026, 6, 24, 18, 0, 0, 0, time.UTC)
+
+	parser := Windsurf{
+		FallbackUserAgent: "fallback/1.0",
+		UserAgents: map[string]string{
+			editPath: "editor/1.0",
+		},
+	}
+
+	input := 5
+	total := 9
+	usageInput := 12
+	usageTotal := 15
+
+	assert.Equal(t,
+		heartbeat.AITokens{LastInput: 2, LastOutput: 3, CurrentInput: 7, CurrentOutput: 12},
+		parser.windsurfTokenCounts(windsurfLogLine{
+			TokenCount: &windsurfTokenCount{InputTokens: &input, TotalTokens: &total},
+		}, heartbeat.AITokens{LastInput: 2, LastOutput: 3}),
+	)
+	assert.Equal(t,
+		heartbeat.AITokens{CurrentInput: 12, CurrentOutput: 15},
+		parser.windsurfTokenCounts(windsurfLogLine{
+			Usage: &windsurfUsage{InputTokens: &usageInput, TotalTokens: &usageTotal},
+		}, heartbeat.AITokens{}),
+	)
+	assert.Equal(t, heartbeat.AITokens{CurrentInput: 1}, parser.windsurfTokenCounts(
+		windsurfLogLine{}, heartbeat.AITokens{CurrentInput: 1}))
+
+	require.NoError(t, os.WriteFile(editPath, []byte("package main\n"), 0600))
+	assert.True(t, parser.stateDBModifiedAfter(editPath, time.Time{}))
+	assert.False(t, parser.stateDBModifiedAfter(filepath.Join(base, "missing.db"), time.Now()))
+
+	app := parser.windsurfAppHeartbeat(windsurfLogLine{
+		BubbleID:  "bubble-1",
+		CreatedAt: timestamp,
+		Type:      1,
+		Text:      "write tests",
+	}, base, "session-1", "swe-1.5", nil)
+	require.NotNil(t, app)
+	assert.Equal(t, "Windsurf bubble-1", app.Entity)
+	assert.Equal(t, len([]rune("write tests")), app.AIPromptLength)
+	assert.Equal(t, base, app.ProjectPathOverride)
+	assert.Contains(t, app.UserAgent, "swe/1.5")
+	assert.Nil(t, parser.windsurfAppHeartbeat(windsurfLogLine{Type: 3, Text: "ignored"}, "", "", "", nil))
+
+	editV2 := parser.windsurfFileHeartbeat(windsurfLogLine{
+		CreatedAt: timestamp,
+		ToolFormerData: &windsurfToolFormerData{
+			Name:   "edit_file_v2",
+			Params: `{"streamingContent":"one\ntwo"}`,
+		},
+		CodeBlocks: []windsurfCodeBlock{{URI: &windsurfURI{FSPath: editPath}}},
+	}, "session-1", "swe-1.5", nil)
+	require.NotNil(t, editV2)
+	assert.Equal(t, editPath, editV2.Entity)
+	require.NotNil(t, editV2.AILineChanges)
+	assert.Equal(t, 2, *editV2.AILineChanges)
+	assert.Contains(t, editV2.UserAgent, "editor/1.0")
+
+	rawEdit := parser.windsurfFileHeartbeat(windsurfLogLine{
+		CreatedAt: timestamp,
+		ToolFormerData: &windsurfToolFormerData{
+			Name:    "edit_file",
+			Params:  `{`,
+			RawArgs: `{"target_file":` + mustJSON(t, rawPath) + `,"code_edit":"--- a\n+++ b\n-old\n+new\n+extra"}`,
+		},
+	}, "session-1", "", nil)
+	require.NotNil(t, rawEdit)
+	assert.Equal(t, rawPath, rawEdit.Entity)
+	require.NotNil(t, rawEdit.AILineChanges)
+	assert.Equal(t, 1, *rawEdit.AILineChanges)
+
+	blockEdit := parser.windsurfFileHeartbeat(windsurfLogLine{
+		CreatedAt: timestamp,
+		ToolFormerData: &windsurfToolFormerData{
+			Name:   "edit_file",
+			Params: `{"relativeWorkspacePath":` + mustJSON(t, codeBlockPath) + `}`,
+		},
+		CodeBlocks: []windsurfCodeBlock{{Content: "alpha\nbeta\n"}},
+	}, "session-1", "", nil)
+	require.NotNil(t, blockEdit)
+	require.NotNil(t, blockEdit.AILineChanges)
+	assert.Equal(t, 2, *blockEdit.AILineChanges)
+
+	for name, line := range map[string]windsurfLogLine{
+		"targetFile": {
+			ToolFormerData: &windsurfToolFormerData{
+				Name:   "read_file",
+				Params: `{"targetFile":` + mustJSON(t, readPath) + `}`,
+			},
+		},
+		"effectiveURI": {
+			ToolFormerData: &windsurfToolFormerData{
+				Name:   "read_file",
+				Params: `{"effectiveUri":` + mustJSON(t, readPath) + `}`,
+			},
+		},
+		"path": {
+			ToolFormerData: &windsurfToolFormerData{Name: "read_file", Params: `{"path":` + mustJSON(t, readPath) + `}`},
+		},
+		"relativeWorkspacePath": {
+			ToolFormerData: &windsurfToolFormerData{
+				Name:   "read_file",
+				Params: `{"relativeWorkspacePath":` + mustJSON(t, readPath) + `}`,
+			},
+		},
+		"rawArgs": {
+			ToolFormerData: &windsurfToolFormerData{
+				Name:    "read_file",
+				RawArgs: `{"target_file":` + mustJSON(t, readPath) + `}`,
+			},
+		},
+		"codeBlock": {
+			ToolFormerData: &windsurfToolFormerData{Name: "read_file", Params: `{}`},
+			CodeBlocks:     []windsurfCodeBlock{{URI: &windsurfURI{FSPath: readPath}}},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			line.CreatedAt = timestamp
+			got := parser.windsurfFileHeartbeat(line, "session-1", "", nil)
+			require.NotNil(t, got)
+			assert.Equal(t, readPath, got.Entity)
+			require.NotNil(t, got.IsWrite)
+			assert.False(t, *got.IsWrite)
+		})
+	}
+
+	assert.Nil(t, parser.windsurfFileHeartbeat(windsurfLogLine{
+		ToolFormerData: &windsurfToolFormerData{Name: "read_file", Params: `{}`},
+	}, "", "", nil))
+	assert.Nil(t, parser.windsurfFileHeartbeat(windsurfLogLine{
+		ToolFormerData: &windsurfToolFormerData{Name: "unknown"},
+	}, "", "", nil))
+	assert.Equal(t, filepath.Dir(readPath), parser.projectPath(windsurfLogLine{
+		ToolFormerData: &windsurfToolFormerData{Name: "read_file", Params: `{"targetFile":` + mustJSON(t, readPath) + `}`},
+	}))
+	assert.Empty(t, parser.projectPath(windsurfLogLine{}))
+	assert.True(t, parser.looksLikeUnifiedDiff("context\n@@ -1 +1 @@"))
+	assert.False(t, parser.looksLikeUnifiedDiff("plain text"))
+}
+
+func TestOpenCodeHelperBranches(t *testing.T) {
+	base := t.TempDir()
+	timestamp := time.Date(2026, 6, 24, 18, 0, 0, 0, time.UTC)
+	parser := OpenCode{FallbackUserAgent: "fallback/1.0"}
+
+	editPath := filepath.Join(base, "edited.go")
+	edit := parser.editHeartbeats("1.2.3", "claude-3.5", "session-1", base, timestamp, openCodeToolState{
+		Input:    json.RawMessage(`{"filePath":"ignored.go","oldString":"old","newString":"new\nextra"}`),
+		Metadata: json.RawMessage(`{"filediff":{"file":"edited.go","additions":4,"deletions":1}}`),
+	})
+	require.Len(t, edit, 1)
+	assert.Equal(t, editPath, edit[0].Entity)
+	require.NotNil(t, edit[0].AILineChanges)
+	assert.Equal(t, 3, *edit[0].AILineChanges)
+	assert.Nil(t, parser.editHeartbeats("", "", "", "", timestamp, openCodeToolState{Input: json.RawMessage(`{`)}))
+
+	writeNew := parser.writeHeartbeats("1.2.3", "", "session-1", base, timestamp, openCodeToolState{
+		Input:    json.RawMessage(`{"filePath":"new.go","content":"one\ntwo"}`),
+		Metadata: json.RawMessage(`{"exists":false}`),
+	})
+	require.Len(t, writeNew, 1)
+	require.NotNil(t, writeNew[0].AILineChanges)
+	assert.Equal(t, 2, *writeNew[0].AILineChanges)
+	assert.Nil(t, parser.writeHeartbeats("", "", "", "", timestamp, openCodeToolState{Input: json.RawMessage(`{`)}))
+
+	patchFromMetadata := parser.applyPatchHeartbeats("1.2.3", "", "session-1", base, timestamp, openCodeToolState{
+		Metadata: json.RawMessage(`{"files":[` +
+			`{"filePath":"a.go","additions":3,"deletions":1},` +
+			`{"filePath":"b.go","additions":1,"deletions":4}` +
+			`]}`),
+	})
+	require.Len(t, patchFromMetadata, 2)
+	assert.Equal(t, filepath.Join(base, "a.go"), patchFromMetadata[0].Entity)
+	require.NotNil(t, patchFromMetadata[1].AILineChanges)
+	assert.Equal(t, -3, *patchFromMetadata[1].AILineChanges)
+
+	patchText := strings.Join([]string{
+		"*** Begin Patch",
+		"*** Add File: added.go",
+		"+one",
+		"+two",
+		"*** Update File: old.go",
+		"*** Move to: moved.go",
+		"-old",
+		"+new",
+		"*** End Patch",
+	}, "\n")
+	patchFromInput := parser.applyPatchHeartbeats("1.2.3", "", "session-1", base, timestamp, openCodeToolState{
+		Input: json.RawMessage(`{"patchText":` + mustJSON(t, patchText) + `}`),
+	})
+	require.Len(t, patchFromInput, 2)
+	assert.Equal(t, filepath.Join(base, "added.go"), patchFromInput[0].Entity)
+	assert.Equal(t, filepath.Join(base, "moved.go"), patchFromInput[1].Entity)
+	assert.Nil(t, parser.applyPatchHeartbeats("", "", "", "", timestamp, openCodeToolState{Input: json.RawMessage(`{`)}))
+
+	assert.Empty(t, openCodePatchFilePath(base, "*** Unknown File: nope.go"))
+	assert.Equal(t, "relative.go", openCodeResolvePath("", "relative.go"))
+	assert.Empty(t, openCodeResolvePath(base, ""))
+}
+
+func TestCodexPatchDecodeBranches(t *testing.T) {
+	decoded := codexDecodePatch(`line\nnext\rcr\tab\bback\f form\vvert\\slash\"quote\'apos\/path\x41\u03bb\q`)
+	assert.Contains(t, decoded, "line\nnext\rcr\tab")
+	assert.Contains(t, decoded, "A")
+	assert.Contains(t, decoded, string(rune(0x03bb)))
+	assert.Contains(t, decoded, `\q`)
+
+	input := `prefix tools.apply_patch("*** Begin Patch\n*** Add File: a.go\n+one\n*** End Patch") suffix ` +
+		`tools.apply_patch("*** Begin Patch\u000a*** Add File: b.go\u000a+two\u000a*** End Patch")`
+	patches := codexExecPatchInputs(input)
+	require.Len(t, patches, 2)
+	assert.Contains(t, patches[0], "*** Add File: a.go")
+	assert.Contains(t, patches[1], "*** Add File: b.go")
+	assert.Nil(t, codexExecPatchInputs("echo no patch"))
+	assert.Nil(t, codexExecPatchInputs("tools.apply_patch(\"*** Begin Patch"))
+
+	applyPatch := "patch"
+	nameApply := "apply_patch"
+	nameExec := "exec"
+
+	assert.Equal(t, []string{"patch"}, codexPatchInputs(codexPayload{Name: &nameApply, Input: &applyPatch}))
+
+	execInput := `tools.apply_patch("*** Begin Patch\n*** Add File: c.go\n+three\n*** End Patch")`
+	assert.Len(t, codexPatchInputs(codexPayload{Name: &nameExec, Input: &execInput}), 1)
+	assert.Nil(t, codexPatchInputs(codexPayload{}))
+
+	assert.True(t, codexToolCallSucceeded(nil))
+	assert.True(t, codexToolCallSucceeded(json.RawMessage(`"all good"`)))
+	assert.False(t, codexToolCallSucceeded(json.RawMessage(`"invalid patch"`)))
+	assert.False(t, codexToolCallSucceeded(json.RawMessage(`[{"text":"tool failed"}]`)))
+	assert.True(t, codexToolCallSucceeded(json.RawMessage(`123`)))
+}
+
+func TestQwenCodeHelperBranches(t *testing.T) {
+	home := t.TempDir()
+	resolvedHome, ok := qwenCodeConfiguredRuntimeDir("~", home)
+	require.True(t, ok)
+	assert.Equal(t, filepath.Clean(home), resolvedHome)
+	resolvedSubdir, ok := qwenCodeConfiguredRuntimeDir("~/runtime", home)
+	require.True(t, ok)
+	assert.Equal(t, filepath.Join(home, "runtime"), resolvedSubdir)
+	absDir := filepath.Join(home, "absolute")
+	resolvedAbs, ok := qwenCodeConfiguredRuntimeDir(absDir, home)
+	require.True(t, ok)
+	assert.Equal(t, filepath.Clean(absDir), resolvedAbs)
+
+	_, ok = qwenCodeConfiguredRuntimeDir("relative", home)
+	assert.False(t, ok)
+	_, ok = qwenCodeConfiguredRuntimeDir(" ", home)
+	assert.False(t, ok)
+
+	stripped := string(qwenCodeStripJSONComments([]byte(`{
+  // line comment
+  "url": "https://example.test//kept",
+  "escaped": "quote \" // kept",
+  /* block
+     comment */
+  "value": 1
+}`)))
+	assert.Contains(t, stripped, `"url": "https://example.test//kept"`)
+	assert.NotContains(t, stripped, "line comment")
+	assert.NotContains(t, stripped, "block")
+
+	assert.Equal(t, map[string]interface{}{"path": "a.go"}, qwenCodeFunctionCallArgs(json.RawMessage(`{"path":"a.go"}`)))
+	assert.Equal(
+		t,
+		map[string]interface{}{"path": "b.go"},
+		qwenCodeFunctionCallArgs(json.RawMessage(`"{\"path\":\"b.go\"}"`)),
+	)
+	assert.Nil(t, qwenCodeFunctionCallArgs(json.RawMessage(`123`)))
+
+	tokens := QwenCode{}.tokenCounts(qwenCodeRecord{
+		Type:          "assistant",
+		UsageMetadata: &qwenCodeUsageMetadata{PromptTokenCount: 5, CandidatesTokenCount: 2},
+	}, heartbeat.AITokens{LastInput: 10, LastOutput: 20})
+	assert.Equal(t, heartbeat.AITokens{LastInput: 10, LastOutput: 20, CurrentInput: 15, CurrentOutput: 22}, tokens)
+	assert.Equal(t, heartbeat.AITokens{CurrentInput: 1}, QwenCode{}.tokenCounts(
+		qwenCodeRecord{Type: "user"}, heartbeat.AITokens{CurrentInput: 1}))
+
+	base := t.TempDir()
+	assert.Equal(t, filepath.Join(base, "a.go"), qwenCodeToolPath(map[string]interface{}{"file_path": "a.go"}, nil, base))
+	assert.Equal(t, filepath.Join(base, "b.go"), qwenCodeToolPath(map[string]interface{}{"path": "b.go"}, nil, base))
+	assert.Equal(
+		t,
+		filepath.Join(base, "display.go"),
+		qwenCodeToolPath(nil, json.RawMessage(`{"fileName":"display.go"}`), base),
+	)
+	assert.Empty(t, qwenCodeToolPath(nil, json.RawMessage(`{`), base))
+
+	changes, write, ok := qwenCodeToolLineChanges(qwenCodeToolCall{Name: "read_file"}, nil)
+	assert.Equal(t, 0, changes)
+	assert.False(t, write)
+	assert.True(t, ok)
+	changes, write, ok = qwenCodeToolLineChanges(qwenCodeToolCall{
+		Name: "edit",
+		Args: map[string]interface{}{"old_string": "one", "new_string": "one\ntwo"},
+	}, nil)
+	assert.Equal(t, 1, changes)
+	assert.True(t, write)
+	assert.True(t, ok)
+	changes, write, ok = qwenCodeToolLineChanges(qwenCodeToolCall{Name: "write_file"}, json.RawMessage(
+		`{"diffStat":{"model_added_lines":4,"model_removed_lines":1}}`))
+	assert.Equal(t, 3, changes)
+	assert.True(t, write)
+	assert.True(t, ok)
+	_, _, ok = qwenCodeToolLineChanges(qwenCodeToolCall{Name: "unknown"}, nil)
+	assert.False(t, ok)
+	assert.Empty(t, qwenCodeStringValue(map[string]interface{}{"x": 1}, "x"))
+	assert.Empty(t, qwenCodeAbsPath("  ", base))
+}
+
+func TestPiHelperBranches(t *testing.T) {
+	base := t.TempDir()
+	pathFromArg := filepath.Join(base, "arg.go")
+	assert.Equal(t, pathFromArg, piToolPath(piMessage{}, map[string]interface{}{"target_file": "arg.go"}, base))
+
+	successPath := filepath.Join(base, "created.go")
+	assert.Equal(t, successPath, piToolPath(piMessage{
+		Content: []piContentBlock{{Type: "text", Text: "Successfully wrote file to " + successPath}},
+	}, nil, ""))
+	assert.Empty(t, piToolPath(piMessage{Content: []piContentBlock{{Type: "image", Text: successPath}}}, nil, ""))
+
+	changes, ok := Pi{}.toolLineChanges("edit", piMessage{
+		Details: json.RawMessage(`{"diff":"--- a\n+++ b\n-old\n+new\n+extra"}`),
+	}, nil)
+	assert.True(t, ok)
+	assert.Equal(t, 1, changes)
+	changes, ok = Pi{}.toolLineChanges("write", piMessage{}, map[string]interface{}{"content": "one\ntwo"})
+	assert.True(t, ok)
+	assert.Equal(t, 2, changes)
+	changes, ok = Pi{}.toolLineChanges("read", piMessage{}, nil)
+	assert.False(t, ok)
+	assert.Equal(t, 0, changes)
+	changes, ok = Pi{}.toolLineChanges("patch", piMessage{}, nil)
+	assert.True(t, ok)
+	assert.Equal(t, 0, changes)
+
+	assert.Empty(t, Pi{}.diffFromDetails(nil))
+	assert.Empty(t, Pi{}.diffFromDetails(json.RawMessage(`{`)))
+	assert.Empty(t, piStringValue(map[string]interface{}{"x": 1}, "x"))
+	assert.Empty(t, piAbsPath("  ", base))
+	assert.Equal(t, filepath.Join(base, "relative.go"), piAbsPath("relative.go", base))
+	assert.Equal(t, "session", Pi{}.sessionIDFromPath(filepath.Join(base, "prefix_session.jsonl")))
+}
+
+func TestClineAndRooToolBranches(t *testing.T) {
+	base := t.TempDir()
+
+	edited := Cline{}.toolHeartbeat(clineToolMessage{
+		Tool: "editedExistingFile",
+		Path: "edited.go",
+		Diff: "<<<<<<< SEARCH\nold\n=======\nnew\nextra\n>>>>>>> REPLACE",
+	}, base)
+	require.True(t, edited.ok)
+	assert.Equal(t, filepath.Join(base, "edited.go"), edited.filePath)
+	assert.Equal(t, 1, edited.lineChanges)
+	assert.True(t, edited.isWrite)
+
+	created := Cline{}.toolHeartbeat(clineToolMessage{Tool: "newFileCreated", Path: "new.go", Content: "one\ntwo"}, base)
+	require.True(t, created.ok)
+	assert.Equal(t, 2, created.lineChanges)
+
+	read := Cline{}.toolHeartbeat(clineToolMessage{Tool: "readFile", Path: "read.go"}, base)
+	require.True(t, read.ok)
+	assert.False(t, read.isWrite)
+
+	deleted := Cline{}.toolHeartbeat(clineToolMessage{Tool: "fileDeleted", Path: "gone.go", Content: "one\ntwo"}, base)
+	require.True(t, deleted.ok)
+	assert.Equal(t, -2, deleted.lineChanges)
+	assert.False(t, Cline{}.toolHeartbeat(clineToolMessage{Tool: "fileDeleted", Path: "gone.go"}, base).ok)
+	assert.False(t, Cline{}.toolHeartbeat(clineToolMessage{Tool: "unknown", Path: "x.go"}, base).ok)
+
+	assert.Equal(t, "task text", clineTaskText("prefix <task> task text </task> suffix"))
+	assert.Empty(t, clineTaskText("missing"))
+	assert.Equal(
+		t,
+		filepath.Clean(base),
+		clineCurrentWorkingDirectory("# Current Working Directory ("+filepath.Clean(base)+")"),
+	)
+	assert.Empty(t, clineCurrentWorkingDirectory("# Current Working Directory ("))
+
+	value, ok := clineBetween("prefix [value] suffix", "[", "]")
+	require.True(t, ok)
+	assert.Equal(t, "value", value)
+
+	_, ok = clineBetween("prefix [value", "[", "]")
+	assert.False(t, ok)
+
+	rooPath, rooChanges, ok := rooToolHeartbeat(rooToolAsk{
+		Tool: "appliedDiff",
+		Path: "roo.go",
+		Diff: "<<<<<<< SEARCH\nold\n=======\nnew\nextra\n>>>>>>> REPLACE",
+	}, base)
+	require.True(t, ok)
+	assert.Equal(t, filepath.Join(base, "roo.go"), rooPath)
+	assert.Equal(t, 1, rooChanges)
+	rooPath, rooChanges, ok = rooToolHeartbeat(rooToolAsk{Tool: "writeToFile", Path: "write.go", Content: "one\ntwo"}, base)
+	require.True(t, ok)
+	assert.Equal(t, filepath.Join(base, "write.go"), rooPath)
+	assert.Equal(t, 2, rooChanges)
+
+	_, _, ok = rooToolHeartbeat(rooToolAsk{Tool: "writeToFile", Path: "empty.go"}, base)
+	assert.False(t, ok)
+	_, _, ok = rooToolHeartbeat(rooToolAsk{Tool: "unknown", Path: "x.go"}, base)
+	assert.False(t, ok)
+	assert.Empty(t, rooCurrentWorkingDirectory("# Current Working Directory ("))
+}
+
+func TestCopilotHelperBranches(t *testing.T) {
+	base := t.TempDir()
+	filePath := filepath.Join(base, "main.go")
+	require.NoError(t, os.WriteFile(filePath, []byte("package main\n"), 0600))
+
+	parser := Copilot{FallbackUserAgent: "fallback/1.0"}
+	assert.Empty(t, parser.messageText(nil))
+	assert.Equal(t, "hello", parser.messageText(&copilotMessage{Text: "hello"}))
+	assert.Empty(t, parser.version(nil))
+	assert.Equal(t, "1.2.3", parser.version(&copilotAgent{ExtensionVersion: "1.2.3"}))
+	assert.True(t, parser.millisTime(0).IsZero())
+	assert.Equal(t, time.UnixMilli(1234), parser.millisTime(1234))
+
+	request := copilotRequest{
+		Timestamp: 1000,
+		VariableData: &copilotVariableData{Variables: []copilotVariable{
+			{Value: &copilotPathValue{URI: &copilotFileURI{FSPath: filePath}}},
+			{ID: parser.pathToFileURI(filePath)},
+		}},
+		Response: []copilotResponseItem{
+			{
+				Kind: "markdown",
+				InvocationMessage: &copilotMessageWithURIs{URIs: map[string]copilotReferenceURI{
+					"file://ignored": {Path: filePath},
+				}},
+			},
+			{InlineReference: &copilotInlineReference{URI: &struct {
+				FSPath string `json:"fsPath"`
+			}{FSPath: filePath}}},
+		},
+	}
+	assert.Equal(t, time.UnixMilli(1000).Add(time.Second), parser.requestCompletedAt(request))
+	assert.Equal(t, filepath.Dir(filePath), parser.requestProjectPath(request))
+	assert.Equal(t, []string{filePath}, parser.readFiles(request))
+	assert.Empty(t, parser.requestProjectPath(copilotRequest{}))
+	assert.True(t, parser.requestCompletedAt(copilotRequest{}).IsZero())
+	assert.Equal(t, time.UnixMilli(2000), parser.requestCompletedAt(copilotRequest{
+		ModelState: &copilotModelState{CompletedAt: 2000},
+	}))
+
+	assert.Equal(t, "replacement", parser.applyTextEdit("one\ntwo", copilotTextEdit{Text: "replacement"}))
+	assert.Equal(t, "one\nTWO", parser.applyTextEdit("one\ntwo", copilotTextEdit{
+		Text: "TWO",
+		Range: &copilotTextRange{
+			StartLineNumber: 2,
+			StartColumn:     1,
+			EndLineNumber:   2,
+			EndColumn:       4,
+		},
+	}))
+	assert.Equal(t, "Xtwo", parser.applyTextEdit("one\ntwo", copilotTextEdit{
+		Text: "X",
+		Range: &copilotTextRange{
+			StartLineNumber: 2,
+			StartColumn:     1,
+			EndLineNumber:   1,
+			EndColumn:       1,
+		},
+	}))
+	assert.Equal(t, 0, parser.offset("one", 1, 1))
+	assert.Equal(t, len("one"), parser.offset("one", 9, 9))
+	assert.Equal(t, 0, parser.lineCount(""))
+	assert.Equal(t, 2, parser.lineCount("one\ntwo"))
+}
+
+func TestCopilotJSONLAndSessionBranches(t *testing.T) {
+	base := t.TempDir()
+	readPath := filepath.Join(base, "read.go")
+	require.NoError(t, os.WriteFile(readPath, []byte("package main\n"), 0600))
+
+	parser := Copilot{
+		FallbackUserAgent: "fallback/1.0",
+		UserAgents: map[string]string{
+			readPath: "editor/1.0",
+		},
+	}
+
+	sessionPath := filepath.Join(base, "session.jsonl")
+	lines := []string{
+		"",
+		`not json`,
+		mustJSON(t, map[string]interface{}{
+			"kind": 1,
+			"k":    []interface{}{"requests", 0, "message"},
+			"v":    map[string]interface{}{"text": "ignored before root"},
+		}),
+		mustJSON(t, map[string]interface{}{
+			"kind": 0,
+			"v": map[string]interface{}{
+				"sessionId": "session-1",
+				"requests": []map[string]interface{}{
+					{
+						"requestId": "request-1",
+						"timestamp": int64(1000),
+						"agent":     map[string]interface{}{"extensionVersion": "1.2.3"},
+						"usage":     map[string]interface{}{"promptTokens": 5, "completionTokens": 2},
+					},
+				},
+			},
+		}),
+		mustJSON(t, map[string]interface{}{
+			"kind": 1,
+			"k":    []interface{}{"requests", 0, "modelState"},
+			"v":    map[string]interface{}{"completedAt": int64(2200)},
+		}),
+		mustJSON(t, map[string]interface{}{
+			"kind": 1,
+			"k":    []interface{}{"requests", 0, "message"},
+			"v":    map[string]interface{}{"text": "inspect this file"},
+		}),
+		mustJSON(t, map[string]interface{}{
+			"kind": 1,
+			"k":    []interface{}{"requests", 0, "variableData"},
+			"v": map[string]interface{}{"variables": []map[string]interface{}{
+				{"value": map[string]interface{}{"fsPath": readPath}},
+			}},
+		}),
+		mustJSON(t, map[string]interface{}{
+			"kind": 1,
+			"k":    []interface{}{"requests", 0, "response"},
+			"v": []map[string]interface{}{
+				{"kind": "markdown"},
+			},
+		}),
+		mustJSON(t, map[string]interface{}{
+			"kind": 1,
+			"k":    []interface{}{"requests", 0, "result"},
+			"v": map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"usage": map[string]interface{}{"inputTokens": 3, "outputTokens": 4},
+				},
+			},
+		}),
+		mustJSON(t, map[string]interface{}{
+			"kind": 2,
+			"k":    []interface{}{"requests"},
+			"i":    1,
+			"v": []map[string]interface{}{
+				{
+					"requestId": "request-2",
+					"timestamp": int64(3000),
+					"message":   map[string]interface{}{"text": "second prompt"},
+				},
+			},
+		}),
+		mustJSON(t, map[string]interface{}{
+			"kind": 2,
+			"k":    []interface{}{"requests", 0, "response"},
+			"i":    0,
+			"v": []map[string]interface{}{
+				{
+					"kind":            "inlineReference",
+					"inlineReference": map[string]interface{}{"fsPath": readPath},
+				},
+			},
+		}),
+	}
+	require.NoError(t, os.WriteFile(sessionPath, []byte(strings.Join(lines, "\n")+"\n"), 0600))
+
+	session, err := parser.parseJSONLSession(sessionPath)
+	require.NoError(t, err)
+	require.NotNil(t, session)
+	require.Len(t, session.Requests, 2)
+	assert.Equal(t, "inspect this file", session.Requests[0].Message.Text)
+	require.NotNil(t, session.Requests[0].ModelState)
+	assert.EqualValues(t, 2200, session.Requests[0].ModelState.CompletedAt)
+	assert.Len(t, session.Requests[0].Response, 2)
+	assert.Equal(t, "second prompt", session.Requests[1].Message.Text)
+
+	timed, requestMeta := parser.sessionHeartbeats(copilotWorkspaceState{
+		sessions: map[string]*copilotSession{session.SessionID: session},
+	})
+	require.Len(t, timed, 4)
+	assert.Equal(t, "session-1", requestMeta["request-1"].sessionID)
+	assert.Equal(t, "github-copilot/1.2.3", requestMeta["request-1"].plugin)
+	assert.Equal(t, heartbeat.AppType, timed[0].heartbeat.EntityType)
+	assert.Equal(t, len([]rune("inspect this file")), timed[0].heartbeat.AIPromptLength)
+	assert.EqualValues(t, 5, timed[0].heartbeat.AIInputTokens)
+	assert.EqualValues(t, 2, timed[0].heartbeat.AIOutputTokens)
+	assert.Equal(t, readPath, timed[1].heartbeat.Entity)
+	assert.Equal(t, heartbeat.FileType, timed[1].heartbeat.EntityType)
+	assert.Contains(t, timed[1].heartbeat.UserAgent, "editor/1.0")
+	assert.Equal(t, "Copilot session-1", timed[3].heartbeat.Entity)
+	assert.Equal(t, len([]rune("second prompt")), timed[3].heartbeat.AIPromptLength)
+
+	setSession := &copilotSession{Requests: []copilotRequest{{RequestID: "request"}}}
+	parser.applyJSONLSet(setSession, copilotJSONLPatch{})
+	parser.applyJSONLSet(setSession, copilotJSONLPatch{K: []json.RawMessage{json.RawMessage(`"other"`)}})
+	parser.applyJSONLSet(setSession, copilotJSONLPatch{
+		K: []json.RawMessage{json.RawMessage(`"requests"`), json.RawMessage(`99`)},
+	})
+	parser.applyJSONLSet(setSession, copilotJSONLPatch{
+		K: []json.RawMessage{
+			json.RawMessage(`"requests"`),
+			json.RawMessage(`0`),
+			json.RawMessage(`123`),
+		},
+	})
+	assert.Equal(t, "request", setSession.Requests[0].RequestID)
+
+	insertSession := &copilotSession{Requests: []copilotRequest{{RequestID: "request"}}}
+	parser.applyJSONLInsert(insertSession, copilotJSONLPatch{})
+	parser.applyJSONLInsert(insertSession, copilotJSONLPatch{K: []json.RawMessage{json.RawMessage(`"other"`)}})
+	parser.applyJSONLInsert(insertSession, copilotJSONLPatch{
+		K: []json.RawMessage{json.RawMessage(`"requests"`), json.RawMessage(`0`), json.RawMessage(`"message"`)},
+		V: json.RawMessage(`[]`),
+	})
+	assert.Len(t, insertSession.Requests, 1)
+
+	assert.Equal(t,
+		[]copilotRequest{{RequestID: "a"}, {RequestID: "b"}},
+		parser.insertRequests([]copilotRequest{{RequestID: "a"}}, 99, []copilotRequest{{RequestID: "b"}}),
+	)
+	assert.Equal(t,
+		[]copilotResponseItem{{Kind: "a"}, {Kind: "b"}},
+		parser.insertResponses([]copilotResponseItem{{Kind: "a"}}, -1, []copilotResponseItem{{Kind: "b"}}),
+	)
+	_, ok := parser.parseJSONString(json.RawMessage(`123`))
+	assert.False(t, ok)
+	_, ok = parser.parseJSONInt(json.RawMessage(`"not-int"`))
+	assert.False(t, ok)
+}
+
+func TestCopilotEditStateBranches(t *testing.T) {
+	base := t.TempDir()
+	statePath := filepath.Join(base, "state.json")
+	filePath := filepath.Join(base, "main.go")
+	require.NoError(t, os.WriteFile(filePath, []byte("one\ntwo\n"), 0600))
+
+	parser := Copilot{
+		FallbackUserAgent: "fallback/1.0",
+		UserAgents: map[string]string{
+			filePath: "editor/1.0",
+		},
+	}
+	timestamp := time.Date(2026, 6, 24, 18, 0, 0, 0, time.UTC)
+	state := map[string]interface{}{
+		"timeline": map[string]interface{}{
+			"fileBaselines": []interface{}{
+				[]interface{}{"bad"},
+				[]interface{}{123, map[string]interface{}{"content": "ignored"}},
+				[]interface{}{
+					"file://" + filepath.ToSlash(filePath) + "::request-1",
+					map[string]interface{}{"content": "one\ntwo\n"},
+				},
+				[]interface{}{
+					"file://" + filePath + "::request-1",
+					map[string]interface{}{"content": "one\ntwo\n"},
+				},
+				[]interface{}{
+					parser.pathToFileURI(filePath) + "::request-1",
+					map[string]interface{}{"content": "one\ntwo\n"},
+				},
+			},
+			"operations": []map[string]interface{}{
+				{"type": "other"},
+				{
+					"type":      "textEdit",
+					"requestId": "missing",
+					"uri":       map[string]interface{}{"fsPath": filePath},
+					"edits":     []interface{}{map[string]interface{}{"text": "x"}},
+				},
+				{
+					"type":      "textEdit",
+					"requestId": "request-1",
+					"uri":       map[string]interface{}{"fsPath": filePath},
+					"edits": []interface{}{map[string]interface{}{
+						"text": "three",
+						"range": map[string]interface{}{
+							"startLineNumber": 2,
+							"startColumn":     1,
+							"endLineNumber":   2,
+							"endColumn":       4,
+						},
+					}},
+				},
+				{
+					"type":      "textEdit",
+					"requestId": "request-1",
+					"uri":       map[string]interface{}{"fsPath": filePath},
+					"edits": []interface{}{map[string]interface{}{
+						"text": "\nfour",
+						"range": map[string]interface{}{
+							"startLineNumber": 2,
+							"startColumn":     6,
+							"endLineNumber":   2,
+							"endColumn":       6,
+						},
+					}},
+				},
+			},
+		},
+	}
+	require.NoError(t, os.WriteFile(statePath, []byte(mustJSON(t, state)), 0600))
+
+	timed, err := parser.parseEditState(statePath, map[string]copilotRequestMeta{
+		"request-1": {
+			timestamp: timestamp,
+			plugin:    "github-copilot/1.2.3",
+			sessionID: "session-1",
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, timed, 2)
+	assert.Equal(t, filePath, timed[0].heartbeat.Entity)
+	require.NotNil(t, timed[0].heartbeat.AILineChanges)
+	assert.Equal(t, 0, *timed[0].heartbeat.AILineChanges)
+	require.NotNil(t, timed[1].heartbeat.AILineChanges)
+	assert.Equal(t, 1, *timed[1].heartbeat.AILineChanges)
+	assert.Contains(t, timed[0].heartbeat.UserAgent, "editor/1.0")
+
+	missing, err := parser.parseEditState(filepath.Join(base, "missing.json"), nil)
+	require.NoError(t, err)
+	assert.Nil(t, missing)
+	require.NoError(t, os.WriteFile(statePath, []byte(`{`), 0600))
+	_, err = parser.parseEditState(statePath, nil)
+	require.Error(t, err)
+	require.NoError(t, os.WriteFile(statePath, []byte(`{}`), 0600))
+	empty, err := parser.parseEditState(statePath, nil)
+	require.NoError(t, err)
+	assert.Nil(t, empty)
+
+	assert.False(t, parser.fileModifiedAfter(filepath.Join(base, "missing.json"), time.Time{}))
+}
+
+func TestCopilotCLIStateBranches(t *testing.T) {
+	parser := Copilot{
+		FallbackUserAgent: "fallback/1.0",
+		UserAgents: map[string]string{
+			"/tmp/main.go": "editor/1.0",
+		},
+	}
+	state := copilotCLIParseState{
+		sessionID:        "session-1",
+		model:            "gpt-5",
+		cliVersion:       "1.2.3",
+		agentVersion:     "4.5.6",
+		gitRoot:          "/repo",
+		cwd:              "/fallback",
+		fileHeartbeatIDs: make(map[string]struct{}),
+	}
+	assert.Equal(t, "/repo", state.projectPath())
+	state.appendFileHeartbeat(parser, "/tmp/main.go", time.Date(2026, 6, 24, 18, 0, 0, 0, time.UTC), heartbeat.PointerTo(3))
+	require.Len(t, state.heartbeats, 1)
+	assert.Contains(t, state.fileHeartbeatIDs, "/tmp/main.go")
+	require.NotNil(t, state.heartbeats[0].heartbeat.AILineChanges)
+	assert.Equal(t, 3, *state.heartbeats[0].heartbeat.AILineChanges)
+	state.trackCLIFilePath(" ")
+	assert.Len(t, state.fileHeartbeatIDs, 1)
+
+	telemetry := &copilotCLIToolTelemetry{}
+	result := &copilotCLIToolResult{ToolTelemetry: telemetry}
+	assert.Equal(t, telemetry, copilotCLIToolExecutionCompleteData{ToolTelemetry: telemetry}.telemetry())
+	assert.Equal(t, telemetry, copilotCLIToolExecutionCompleteData{Result: result}.telemetry())
+	assert.Nil(t, copilotCLIToolExecutionCompleteData{}.telemetry())
+	assert.False(t, telemetry.hasWriteSignals("read_file"))
+
+	pathsTelemetry := copilotCLIToolTelemetry{
+		RestrictedProperties: &copilotCLIToolRestrictedProperties{
+			AddedPaths:   json.RawMessage(`["/tmp/a.go"]`),
+			DeletedPaths: json.RawMessage(`["/tmp/b.go","/tmp/a.go"]`),
+		},
+	}
+	assert.Equal(t, []string{"/tmp/a.go", "/tmp/b.go"}, pathsTelemetry.filePaths())
+	assert.True(t, pathsTelemetry.hasWriteSignals("read_file"))
+
+	value, ok := (copilotCLIToolMetrics{LinesRemoved: heartbeat.PointerTo(2)}).lineChanges()
+	assert.True(t, ok)
+	assert.Equal(t, -2, value)
+
+	_, ok = (copilotCLIToolMetrics{}).lineChanges()
+	assert.False(t, ok)
+}
+
+func TestAntigravityHelperBranches(t *testing.T) {
+	home := t.TempDir()
+	appRoot := filepath.Join(home, "antigravity")
+	require.NoError(t, os.MkdirAll(filepath.Join(appRoot, "bin"), 0700))
+	executable := filepath.Join(home, "Antigravity.app", "Contents", "MacOS", "agentapi")
+	require.NoError(t, os.WriteFile(filepath.Join(appRoot, "bin", "agentapi"), []byte(`exec "`+executable+`"`), 0600))
+
+	plistPath := filepath.Join(home, "Antigravity.app", "Contents", "Info.plist")
+	require.NoError(t, os.MkdirAll(filepath.Dir(plistPath), 0700))
+	require.NoError(t, os.WriteFile(plistPath, []byte(
+		`<key>CFBundleShortVersionString</key><string>1.2.3</string>`), 0600))
+	assert.Equal(t, "1.2.3", antigravityProductVersion(home, appRoot, antigravityProduct{
+		userAgentProduct: "antigravity-desktop",
+	}))
+
+	ideRoot := filepath.Join(home, "ide", "resources", "app")
+	require.NoError(t, os.MkdirAll(filepath.Join(ideRoot, "bin"), 0700))
+	ideExecutable := filepath.Join(ideRoot, "extensions", "agentapi")
+	require.NoError(t, os.WriteFile(filepath.Join(ideRoot, "bin", "agentapi"), []byte(`exec "`+ideExecutable+`"`), 0600))
+	productPath := filepath.Join(ideRoot, "product.json")
+	require.NoError(t, os.WriteFile(productPath, []byte(`{"version":"2.0.0-beta"}`), 0600))
+	assert.Equal(t, "2.0.0-beta", antigravityProductVersion(home, ideRoot, antigravityProduct{
+		userAgentProduct: "antigravity-ide",
+	}))
+	assert.Equal(t, "unknown", antigravityProductVersion(home, appRoot, antigravityProduct{
+		userAgentProduct: "antigravity-cli",
+	}))
+	assert.Empty(t, antigravityAgentAPIExecutable(filepath.Join(home, "missing")))
+	assert.Empty(t, antigravityJSONVersion(filepath.Join(home, "missing.json")))
+	assert.Empty(t, antigravityPlistVersion(filepath.Join(home, "missing.plist")))
+	assert.Equal(t, "2.0.0-beta", antigravityVersionString("Gemini v2.0.0-beta"))
+	assert.Empty(t, antigravityVersionString("singleword"))
+
+	actionPath := filepath.Join(home, "project", "main.go")
+	content := "The following changes were made by the model to: `" + actionPath + "`. If relevant\n" +
+		"[diff_block_start]\n--- a\n+++ b\n-old\n+new\n+extra\n[diff_block_end]"
+	assert.Equal(t, actionPath, antigravityCodeActionPath(content))
+	changes, ok := antigravityCodeActionLineChanges(content)
+	require.True(t, ok)
+	assert.Equal(t, 1, changes)
+
+	_, ok = antigravityCodeActionLineChanges("no diff")
+	assert.False(t, ok)
+	assert.Empty(t, antigravityCodeActionPath("no marker"))
+
+	transcriptPath := filepath.Join(appRoot, "a", "b", "c", "d", "session.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(transcriptPath), 0700))
+
+	cachePath := filepath.Join(appRoot, "cache", "last_conversations.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(cachePath), 0700))
+
+	workspace := filepath.Join(home, "workspace")
+	require.NoError(t, os.WriteFile(cachePath, []byte(`{`+mustJSON(t, workspace)+`:"session-1"}`), 0600))
+	assert.Equal(t, workspace, antigravityProjectPath(antigravityTranscript{path: transcriptPath, sessionID: "session-1"}))
+
+	require.NoError(t, os.WriteFile(cachePath, []byte(`{}`), 0600))
+
+	historyPath := filepath.Join(appRoot, "history.jsonl")
+	require.NoError(t, os.WriteFile(
+		historyPath,
+		[]byte(`{"conversationId":"session-2","workspace":`+mustJSON(t, workspace)+`}`+"\n"),
+		0600,
+	))
+	assert.Equal(t, workspace, antigravityProjectPath(antigravityTranscript{path: transcriptPath, sessionID: "session-2"}))
+	assert.Empty(t, antigravityProjectPath(antigravityTranscript{path: transcriptPath, sessionID: "missing"}))
+
+	assert.Empty(t, antigravityFilePath(" "))
+	assert.Equal(t, filepath.FromSlash("/tmp/main.go"), antigravityFilePath("file:///tmp/main.go"))
+	assert.Equal(t, filepath.FromSlash("C:/tmp/main.go"), antigravityFilePath("file:///C:/tmp/main.go"))
+}
+
+func TestContinueAdditionalBranches(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	parser := Continue{
+		After:             time.Date(2026, 1, 2, 3, 4, 4, 0, time.UTC),
+		FallbackUserAgent: "fallback/1.0",
+		UserAgents: map[string]string{
+			filepath.Join(home, "workspace", "read.go"): "editor/1.0",
+		},
+	}
+
+	root, err := parser.root(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, root)
+
+	continueRoot := filepath.Join(home, ".continue")
+	require.NoError(t, os.MkdirAll(continueRoot, 0700))
+
+	root, err = parser.root(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, continueRoot, root)
+
+	events, err := parser.eventsFromFile(filepath.Join(home, "missing.jsonl"), nil)
+	require.NoError(t, err)
+	assert.Nil(t, events)
+
+	sessionPath := filepath.Join(continueRoot, "sessions", "sessions.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(sessionPath), 0700))
+	require.NoError(t, os.WriteFile(sessionPath, []byte(mustJSON(t, []continueSession{
+		{SessionID: "session-1", WorkspaceDirectory: "file://" + filepath.ToSlash(filepath.Join(home, "workspace"))},
+		{SessionID: "", WorkspaceDirectory: "/ignored"},
+	})), 0600))
+	workspaces := parser.sessionWorkspaces(sessionPath)
+	assert.Equal(t, filepath.Join(home, "workspace"), workspaces["session-1"])
+	assert.Empty(t, parser.sessionWorkspaces(filepath.Join(home, "bad-sessions.json")))
+	require.NoError(t, os.WriteFile(sessionPath, []byte(`{`), 0600))
+	assert.Empty(t, parser.sessionWorkspaces(sessionPath))
+
+	logPath := filepath.Join(home, "events.jsonl")
+	lines := []string{
+		"",
+		`not json`,
+		mustJSON(t, map[string]interface{}{
+			"eventName":     "chatInteraction",
+			"timestamp":     "2026-01-02T03:04:05Z",
+			"userAgent":     "continue/1.0",
+			"prompt":        "<system>ignore</system><user>write tests</user><meta>",
+			"modelName":     "gpt-5",
+			"modelProvider": "openai",
+			"sessionId":     "session-1",
+		}),
+		mustJSON(t, map[string]interface{}{
+			"eventName":    "toolUsage",
+			"timestamp":    "2026-01-02T03:04:06Z",
+			"userAgent":    "continue/1.0",
+			"functionName": "read_file",
+			"accepted":     true,
+			"succeeded":    true,
+			"toolCallArgs": mustJSON(t, map[string]string{"filepath": filepath.Join(home, "workspace", "read.go")}),
+		}),
+		mustJSON(t, map[string]interface{}{
+			"eventName": "toolUsage",
+			"timestamp": "2026-01-02T03:04:07Z",
+		}),
+		mustJSON(t, map[string]interface{}{
+			"eventName":     "editOutcome",
+			"timestamp":     "2026-01-02T03:04:08Z",
+			"userAgent":     "continue/1.0",
+			"prompt":        "edit file",
+			"modelName":     "gpt-5",
+			"modelProvider": "openai",
+			"accepted":      true,
+			"lineChange":    2,
+			"filepath":      "relative.go",
+		}),
+		mustJSON(t, map[string]interface{}{
+			"eventName": "editOutcome",
+			"timestamp": "2026-01-02T03:04:09Z",
+		}),
+		mustJSON(t, map[string]interface{}{
+			"eventName":       "tokensGenerated",
+			"timestamp":       "2026-01-02T03:04:05Z",
+			"model":           "gpt-5",
+			"provider":        "openai",
+			"promptTokens":    7,
+			"generatedTokens": 3,
+		}),
+		mustJSON(t, map[string]interface{}{"eventName": "ignored"}),
+	}
+	require.NoError(t, os.WriteFile(logPath, []byte(strings.Join(lines, "\n")+"\n"), 0600))
+
+	events, err = parser.eventsFromFile(logPath, workspaces)
+	require.NoError(t, err)
+	require.Len(t, events, 4)
+
+	heartbeats := parser.heartbeats(events)
+	require.Len(t, heartbeats, 3)
+	assert.Equal(t, "Continue session-1", heartbeats[0].Entity)
+	assert.EqualValues(t, 7, heartbeats[0].AIInputTokens)
+	assert.EqualValues(t, 3, heartbeats[0].AIOutputTokens)
+	assert.Equal(t, filepath.Join(home, "workspace", "read.go"), heartbeats[1].Entity)
+	assert.Equal(t, filepath.Join(home, "workspace", "relative.go"), heartbeats[2].Entity)
+
+	_, ok := parser.eventFromLine([]byte(`{"eventName":"chatInteraction","timestamp":1}`), nil)
+	assert.False(t, ok)
+	_, ok = parser.eventFromLine([]byte(`{"eventName":"tokensGenerated","timestamp":1}`), nil)
+	assert.False(t, ok)
+	assert.Nil(t, Continue{}.tokensForEvent(continueEvent{}, nil))
+	assert.Nil(t, Continue{}.tokensForEvent(
+		continueEvent{Timestamp: time.Unix(10, 0), Model: "a"},
+		&continueEvent{Timestamp: time.Unix(10, 0), Model: "b"},
+	))
+	assert.Nil(t, Continue{}.tokensForEvent(
+		continueEvent{Timestamp: time.Unix(10, 0), Provider: "a"},
+		&continueEvent{Timestamp: time.Unix(10, 0), Provider: "b"},
+	))
+	assert.Nil(t, Continue{}.tokensForEvent(
+		continueEvent{Timestamp: time.Unix(10, 0)},
+		&continueEvent{Timestamp: time.Unix(16, 0)},
+	))
+	assert.NotNil(t, Continue{}.tokensForEvent(
+		continueEvent{Timestamp: time.Unix(10, 0), Model: "GPT-5", Provider: "OpenAI"},
+		&continueEvent{Timestamp: time.Unix(8, 0), Model: "gpt-5", Provider: "openai"},
+	))
+	assert.Equal(t, len([]rune("keep")), Continue{}.promptLength("<user> keep <ignore>"))
+
+	encodedArgs, err := json.Marshal(`{"filepath":"file:///tmp/main.go"}`)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.FromSlash("/tmp/main.go"), Continue{}.toolFilePath(encodedArgs))
+	assert.Equal(t, filepath.FromSlash("C:/tmp/main.go"), Continue{}.filePath("file:///C:/tmp/main.go"))
+}
+
+func TestGeminiAdditionalBranches(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	tmpDir := filepath.Join(home, ".gemini", "tmp")
+	slugDir := filepath.Join(tmpDir, "slug")
+	require.NoError(t, os.MkdirAll(filepath.Join(slugDir, "chats"), 0700))
+	require.NoError(t, os.WriteFile(filepath.Join(slugDir, ".project_root"), []byte("/workspace/project\n"), 0600))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(home, ".gemini", "projects.json"),
+		[]byte(mustJSON(t, geminiProjectsRegistry{
+			Projects: map[string]string{"/registry/project": "registry-slug", "": "ignored"},
+		})),
+		0600,
+	))
+
+	paths, err := Gemini{}.projectPaths(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "/workspace/project", paths.bySlug["slug"])
+	assert.Equal(t, "/registry/project", paths.bySlug["registry-slug"])
+
+	require.NoError(t, os.WriteFile(filepath.Join(home, ".gemini", "projects.json"), []byte(`{`), 0600))
+
+	_, err = Gemini{}.projectPaths(context.Background())
+	require.Error(t, err)
+
+	parser := Gemini{FallbackUserAgent: "fallback/1.0"}
+	_, err = parser.parseTranscript(filepath.Join(home, "missing.json"), "")
+	require.Error(t, err)
+
+	transcriptRoot := filepath.Join(home, "gemini-fixture")
+	transcriptDir := filepath.Join(transcriptRoot, "chats")
+	transcriptPath := filepath.Join(transcriptDir, "session-fallback.json")
+	require.NoError(t, os.MkdirAll(transcriptDir, 0700))
+	require.NoError(t, os.WriteFile(filepath.Join(transcriptRoot, "logs.json"), []byte(mustJSON(t, []geminiPromptLog{
+		{SessionID: "session-fallback", Type: "user", Message: "from logs", Timestamp: "2026-01-02T03:04:05Z"},
+		{SessionID: "session-fallback", Type: "user", Message: " ", Timestamp: "2026-01-02T03:04:06Z"},
+	})), 0600))
+	require.NoError(t, os.WriteFile(transcriptPath, []byte(mustJSON(t, geminiSession{
+		Messages: []geminiMessage{
+			{
+				Type:      "gemini",
+				Timestamp: "2026-01-02T03:04:07Z",
+				Content:   json.RawMessage(`"assistant text"`),
+				Model:     "gemini-3-pro",
+				Tokens:    &geminiMessageToken{Input: 4, Output: 2},
+			},
+		},
+	})), 0600))
+	got, err := parser.parseTranscript(transcriptPath, "")
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.Equal(t, "Gemini session-fallback", got[0].Entity)
+	assert.Equal(t, len([]rune("from logs")), got[0].AIPromptLength)
+
+	timestamp := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	_, ok := parser.toolHeartbeat(timestamp, "session-1", "/workspace/project", "gemini-3-pro", geminiToolCall{
+		Status: "failed",
+	}, nil)
+	assert.False(t, ok)
+	write, ok := parser.toolHeartbeat(timestamp, "session-1", "/workspace/project", "gemini-3-pro", geminiToolCall{
+		DisplayName:   "write_file",
+		Args:          json.RawMessage(`{"file_path":"relative.go","content":"one\ntwo"}`),
+		ResultDisplay: json.RawMessage(`{"filePath":"/override.go"}`),
+	}, nil)
+	require.True(t, ok)
+	assert.Equal(t, "/override.go", write.Entity)
+
+	replace, ok := parser.toolHeartbeat(timestamp, "session-1", "/workspace/project", "gemini-3-pro", geminiToolCall{
+		Name:          "replace",
+		Args:          json.RawMessage(`{"file_path":"relative.go","old_string":"one","new_string":"one\ntwo"}`),
+		ResultDisplay: json.RawMessage(`{"diffStat":{"model_added_lines":4,"model_removed_lines":1}}`),
+	}, nil)
+	require.True(t, ok)
+	require.NotNil(t, replace.AILineChanges)
+	assert.Equal(t, 3, *replace.AILineChanges)
+
+	_, ok = parser.toolHeartbeat(
+		timestamp,
+		"session-1",
+		"",
+		"",
+		geminiToolCall{Name: "write_file", Args: json.RawMessage(`{`)},
+		nil,
+	)
+	assert.False(t, ok)
+	_, ok = parser.toolHeartbeat(timestamp, "session-1", "", "", geminiToolCall{Name: "unknown"}, nil)
+	assert.False(t, ok)
+
+	assert.False(t, Gemini{}.hasTokenDelta(heartbeat.AITokens{
+		CurrentInput:  1,
+		LastInput:     2,
+		CurrentOutput: 1,
+		LastOutput:    2,
+	}))
+	assert.Nil(t, Gemini{}.tokensForFirstHeartbeat(false, heartbeat.AITokens{CurrentInput: 1}))
+	assert.Equal(t, "", geminiResolvePath("/workspace", ""))
+	assert.Equal(t, "relative.go", geminiResolvePath("", "relative.go"))
+}
+
+func TestOpenCodeAdditionalBranches(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	roots, err := openCodeDataRoots(context.Background())
+	require.NoError(t, err)
+	require.Len(t, roots, 4)
+	assert.Equal(t, int64(0), OpenCode{}.afterUnixMilli())
+	assert.Greater(t, OpenCode{After: time.Unix(10, 0)}.afterUnixMilli(), int64(0))
+	assert.False(t, openCodeSQLiteDBModifiedAfter(filepath.Join(home, "missing.db"), time.Now()))
+
+	parser := OpenCode{FallbackUserAgent: "fallback/1.0"}
+	sessionPath := filepath.Join(home, "session.json")
+	_, err = parser.readSessionInfo(sessionPath)
+	require.Error(t, err)
+	require.NoError(t, os.WriteFile(sessionPath, []byte(`{`), 0600))
+	_, err = parser.readSessionInfo(sessionPath)
+	require.Error(t, err)
+	require.NoError(t, os.WriteFile(sessionPath, []byte(`{"id":"session-1"}`), 0600))
+	session, err := parser.readSessionInfo(sessionPath)
+	require.NoError(t, err)
+	assert.Equal(t, "session-1", session.ID)
+
+	messagePath := filepath.Join(home, "message.json")
+	_, err = parser.readMessageInfo(messagePath)
+	require.Error(t, err)
+	require.NoError(t, os.WriteFile(messagePath, []byte(`{`), 0600))
+	_, err = parser.readMessageInfo(messagePath)
+	require.Error(t, err)
+	require.NoError(t, os.WriteFile(messagePath, []byte(`{"id":"message-1"}`), 0600))
+	message, err := parser.readMessageInfo(messagePath)
+	require.NoError(t, err)
+	assert.Equal(t, "message-1", message.ID)
+
+	baseStorageDir := filepath.Join(home, "storage")
+	parts, err := parser.readParts(baseStorageDir, "missing")
+	require.NoError(t, err)
+	assert.Nil(t, parts)
+
+	partsDir := filepath.Join(baseStorageDir, "part", "message-1")
+	require.NoError(t, os.MkdirAll(filepath.Join(partsDir, "subdir"), 0700))
+	require.NoError(t, os.WriteFile(filepath.Join(partsDir, "skip.txt"), []byte(`{}`), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(partsDir, "b.json"), []byte(`{"id":"b"}`), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(partsDir, "a.json"), []byte(`{"id":"a"}`), 0600))
+
+	parts, err = parser.readParts(baseStorageDir, "message-1")
+	require.NoError(t, err)
+	require.Len(t, parts, 2)
+	assert.Equal(t, "a", parts[0].ID)
+	require.NoError(t, os.WriteFile(filepath.Join(partsDir, "bad.json"), []byte(`{`), 0600))
+
+	_, err = parser.readParts(baseStorageDir, "message-1")
+	require.Error(t, err)
+
+	assert.Nil(t, parser.sessionHeartbeats(openCodeSessionInfo{ID: "session-1"}, nil))
+	old := parser.sessionHeartbeats(openCodeSessionInfo{ID: "session-1"}, []openCodeMessageWithParts{{
+		info: openCodeMessageInfo{Role: "assistant", Time: struct {
+			Created int64 `json:"created"`
+		}{Created: 1000}},
+	}})
+	assert.Nil(t, old)
+	assert.Nil(t, parser.userHeartbeat("OpenCode session-1", "", "", "session-1", "", openCodeMessageWithParts{
+		info: openCodeMessageInfo{Time: struct {
+			Created int64 `json:"created"`
+		}{Created: 1000}},
+		parts: []openCodePart{{Type: "text", Ignored: true, Text: "ignored"}},
+	}, heartbeat.AITokens{}))
+	assert.Nil(t, parser.assistantHeartbeat("OpenCode session-1", "", "", "session-1", "", openCodeMessageWithParts{
+		info: openCodeMessageInfo{Time: struct {
+			Created int64 `json:"created"`
+		}{Created: 1000}},
+	}, heartbeat.AITokens{}))
+	assert.Nil(t, parser.toolHeartbeats("", "", "", "", time.Now(), openCodePart{}))
+	assert.Nil(t, parser.toolHeartbeats("", "", "", "", time.Now(), openCodePart{Type: "tool"}))
+	assert.Nil(t, parser.toolHeartbeats("", "", "", "", time.Now(), openCodePart{
+		Type:  "tool",
+		Tool:  "unknown",
+		State: &openCodeToolState{Status: "completed"},
+	}))
+	assert.Equal(t, "/workspace/rel.go", openCodeResolvePath("/workspace", "rel.go"))
+	assert.Equal(t, "rel.go", openCodeResolvePath("", "rel.go"))
+	assert.Empty(t, openCodePatchFilePath("/workspace", "*** Unknown File: rel.go"))
+}
+
+func TestQwenCodeAdditionalBranches(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("QWEN_RUNTIME_DIR", "~/runtime")
+
+	runtimeDir, err := qwenCodeRuntimeDir(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(home, "runtime"), runtimeDir)
+
+	t.Setenv("QWEN_RUNTIME_DIR", "")
+
+	qwenHome := filepath.Join(home, "configured-qwen")
+	t.Setenv("QWEN_HOME", qwenHome)
+	require.NoError(t, os.MkdirAll(qwenHome, 0700))
+	require.NoError(t, os.WriteFile(filepath.Join(qwenHome, "settings.json"), []byte(`{
+  "advanced": {"runtimeOutputDir": "~/qwen-runtime"}
+}`), 0600))
+
+	runtimeDir, err = qwenCodeRuntimeDir(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(home, "qwen-runtime"), runtimeDir)
+
+	parser := QwenCode{FallbackUserAgent: "fallback/1.0"}
+	state := &qwenCodeParseState{
+		cwd:       filepath.Join(home, "workspace"),
+		sessionID: "session-1",
+		toolCalls: map[string]qwenCodeToolCall{
+			"call-1": {ID: "call-1", Name: "read_file", Args: map[string]interface{}{"path": "read.go"}},
+		},
+		toolQueue: []qwenCodeToolCall{
+			{ID: "call-1", Name: "read_file", Args: map[string]interface{}{"path": "read.go"}},
+			{Name: "write_file", Args: map[string]interface{}{"file_path": "write.go", "content": "one\ntwo"}},
+		},
+	}
+	record := qwenCodeRecord{
+		Timestamp: time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC),
+		Type:      "tool_result",
+		ToolCallResult: &qwenCodeToolCallResult{
+			CallID: "call-1",
+			Status: "success",
+		},
+	}
+	h := parser.toolResultHeartbeat(record, state)
+	require.NotNil(t, h)
+	assert.Equal(t, filepath.Join(home, "workspace", "read.go"), h.Entity)
+	assert.Len(t, state.toolQueue, 1)
+	assert.NotContains(t, state.toolCalls, "call-1")
+
+	record.ToolCallResult = &qwenCodeToolCallResult{Status: "failed"}
+	assert.Nil(t, parser.toolResultHeartbeat(record, state))
+	record.ToolCallResult = &qwenCodeToolCallResult{}
+	record.Message = qwenCodeMessage{Parts: []qwenCodePart{{
+		FunctionResponse: &qwenCodeFunctionResponse{Name: "write_file"},
+	}}}
+	h = parser.toolResultHeartbeat(record, state)
+	require.NotNil(t, h)
+	assert.Equal(t, filepath.Join(home, "workspace", "write.go"), h.Entity)
+
+	assert.Nil(t, parser.messageHeartbeat(qwenCodeRecord{Type: "user", Subtype: "cron"}, qwenCodeParseState{}))
+	assert.Nil(t, parser.messageHeartbeat(qwenCodeRecord{
+		Type:    "assistant",
+		Message: qwenCodeMessage{Parts: []qwenCodePart{{Thought: true, Text: "hidden"}}},
+	}, qwenCodeParseState{}))
+	assert.NotNil(t, parser.messageHeartbeat(qwenCodeRecord{
+		Type:      "assistant",
+		Timestamp: time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC),
+		Message:   qwenCodeMessage{Parts: []qwenCodePart{{Text: "visible"}}},
+	}, qwenCodeParseState{sessionID: "session-1"}))
+
+	var raw qwenCodeFunctionCall
+	require.NoError(t, json.Unmarshal([]byte(`{"name":"read_file","args":"{\"path\":\"read.go\"}"}`), &raw))
+	assert.Equal(t, "read.go", raw.Args["path"])
+	assert.Empty(t, qwenCodeFunctionResponseName(qwenCodeMessage{}))
+	assert.Empty(t, qwenCodeFunctionResponseID(qwenCodeMessage{}))
+
+	_, ok := qwenCodeRemoveQueuedToolCall(&qwenCodeParseState{}, func(qwenCodeToolCall) bool { return true })
+	assert.False(t, ok)
+	changes, ok := qwenCodeDiffLineChanges(json.RawMessage(`{"diffStat":{"model_added_lines":1,"model_removed_lines":3}}`))
+	require.True(t, ok)
+	assert.Equal(t, -2, changes)
+	assert.Equal(t, "relative.go", qwenCodeAbsPath("relative.go", ""))
+}
+
+func TestCopilotAdditionalBranches(t *testing.T) {
+	var variable copilotVariable
+	require.NoError(t, json.Unmarshal([]byte(`{"kind":"file","value":null}`), &variable))
+	assert.Nil(t, variable.Value)
+	require.Error(t, json.Unmarshal([]byte(`{`), &variable))
+
+	var message copilotMessageWithURIs
+	require.NoError(t, json.Unmarshal([]byte(`null`), &message))
+	require.NoError(t, json.Unmarshal([]byte(`"plain"`), &message))
+	assert.Equal(t, "plain", message.Value)
+	require.Error(t, json.Unmarshal([]byte(`123`), &message))
+
+	base := t.TempDir()
+	parser := Copilot{FallbackUserAgent: "fallback/1.0"}
+	_, err := parser.parseJSONSession(filepath.Join(base, "missing.json"))
+	require.Error(t, err)
+
+	badSessionPath := filepath.Join(base, "bad.json")
+	require.NoError(t, os.WriteFile(badSessionPath, []byte(`{`), 0600))
+	_, err = parser.parseJSONSession(badSessionPath)
+	require.Error(t, err)
+
+	workspace := filepath.Join(base, "workspace")
+	sessionDir := filepath.Join(workspace, "chatSessions")
+	require.NoError(t, os.MkdirAll(sessionDir, 0700))
+	require.NoError(t, os.WriteFile(filepath.Join(sessionDir, "skip.txt"), []byte(`{}`), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(sessionDir, "bad.json"), []byte(`{`), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(sessionDir, "fallback-id.json"), []byte(`{"requests":[]}`), 0600))
+
+	sessions, err := parser.loadWorkspaceSessions(wakalog.New(os.Stdout), workspace)
+	require.NoError(t, err)
+	require.Contains(t, sessions, "fallback-id")
+
+	editFile := filepath.Join(workspace, "chatEditingSessions")
+	require.NoError(t, os.WriteFile(editFile, []byte("not a dir"), 0600))
+
+	_, err = parser.editHeartbeats(workspace, nil)
+	require.Error(t, err)
+
+	assert.Nil(t, parser.tokensForFirstHeartbeat(false, heartbeat.AITokens{CurrentInput: 1}))
+	input, output := parser.tokenDelta(heartbeat.AITokens{CurrentInput: 1, LastInput: 2, CurrentOutput: 1, LastOutput: 2})
+	assert.Zero(t, input)
+	assert.Zero(t, output)
+	assert.False(t, parser.hasTokenDelta(heartbeat.AITokens{}))
+	in, out, cumulative := parser.usageCounts(copilotRequest{
+		Result: json.RawMessage(`{"metadata":{"usage":{"inputTokens":4,"outputTokens":2}}}`),
+	})
+	require.NotNil(t, in)
+	require.NotNil(t, out)
+	assert.Equal(t, 4, *in)
+	assert.Equal(t, 2, *out)
+	assert.False(t, cumulative)
+
+	in, out = parser.parseTokenCounts(json.RawMessage(`{"inputTokens":1,"totalTokens":9}`))
+	require.NotNil(t, in)
+	require.NotNil(t, out)
+	assert.Equal(t, 1, *in)
+	assert.Equal(t, 9, *out)
+	in, out = parser.parseResultMetadataTokenCounts(json.RawMessage(`{"promptTokens":3,"completionTokens":1}`))
+	require.NotNil(t, in)
+	require.NotNil(t, out)
+	assert.Equal(t, 3, *in)
+	assert.Equal(t, 1, *out)
+
+	dirPath := filepath.Join(base, "dir")
+	require.NoError(t, os.MkdirAll(dirPath, 0700))
+	assert.False(t, parser.shouldTrackReadPath(""))
+	assert.False(t, parser.shouldTrackReadPath(dirPath))
+	assert.True(t, parser.shouldTrackReadPath(filepath.Join(base, "missing.go")))
+	assert.Empty(t, parser.variablePath(copilotVariable{ID: "file://%zz"}))
+	assert.Equal(t, []string{filepath.Join(base, "past.go")}, parser.responsePaths(copilotResponseItem{
+		PastTenseMessage: &copilotMessageWithURIs{URIs: map[string]copilotReferenceURI{
+			"file://ignored": {FSPath: filepath.Join(base, "past.go")},
+		}},
+	}))
+
+	timestamp := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	app := parser.appHeartbeat(
+		"Copilot session-1",
+		"session-1",
+		nil,
+		5,
+		timestamp,
+		"/workspace",
+		nil,
+		"fallback/1.0",
+		"plugin/1",
+	)
+	assert.Equal(t, "session-1", app.AISession)
+
+	file := parser.fileHeartbeat(
+		"/workspace/main.go",
+		"session-1",
+		nil,
+		timestamp,
+		nil,
+		"fallback/1.0",
+		"plugin/1",
+		true,
+		nil,
+	)
+	assert.Equal(t, "session-1", file.AISession)
+
+	cliApp := parser.cliAppHeartbeat(
+		"Copilot session-1",
+		"session-1",
+		nil,
+		5,
+		timestamp,
+		"/workspace",
+		"gpt-5",
+		"1.0",
+		"2.0",
+	)
+	assert.Equal(t, "session-1", cliApp.AISession)
+
+	cliFile := parser.cliFileHeartbeat("/workspace/main.go", "session-1", nil, timestamp, "gpt-5", "1.0", "2.0", true, nil)
+	assert.Equal(t, "session-1", cliFile.AISession)
+	assert.Equal(t, "github-copilot-cli/1.0 copilot/unknown", copilotCLIHarnessUserAgent("1.0", ""))
+}
+
+func TestPiAmpAndGooseAdditionalBranches(t *testing.T) {
+	assert.Equal(t, piSessionState{cwd: "cwd", id: "id"}, func() piSessionState {
+		cwd, id := Pi{}.sessionInfo("cwd", "id", nil)
+		return piSessionState{cwd: cwd, id: id}
+	}())
+	assert.Equal(t, "model", Pi{}.sessionVersion("", piLogLine{Type: "model_change", ModelID: "model"}))
+	assert.Equal(t, "provider", Pi{}.sessionVersion("", piLogLine{Type: "model_change", Provider: "provider"}))
+	assert.Equal(t, "message-provider", Pi{}.sessionVersion("", piLogLine{
+		Message: &piMessage{Provider: "message-provider"},
+	}))
+	assert.Nil(t, Pi{}.getHeartbeats(time.Now(), "Pi session", "session", "", "", nil, "", piLogLine{}, &piParseState{}))
+	assert.Nil(t, Pi{}.toolResultHeartbeat(
+		time.Now(),
+		"session",
+		"",
+		"",
+		nil,
+		"",
+		piMessage{},
+		piToolCall{},
+		heartbeat.AITokens{},
+	))
+	assert.NotNil(t, Pi{}.messageHeartbeat(
+		time.Now(),
+		"Pi session",
+		"session",
+		"gpt-5",
+		"/workspace",
+		nil,
+		"fallback/1.0",
+		piMessage{
+			Role:    "assistant",
+			Content: []piContentBlock{{Type: "text", Text: "assistant\ntext"}},
+		},
+		heartbeat.AITokens{},
+	))
+	assert.True(t, parseGooseTime("bad").IsZero())
+	assert.Equal(t, int64(0), parseGooseInt("bad"))
+	assert.Equal(t, "hello", goosePromptFromContent(`[{"type":"text","text":"hello"}]`))
+	assert.Empty(t, goosePromptFromContent(`{`))
+	assert.Empty(t, ampWorkspacePath(" "))
+	assert.Equal(t, filepath.FromSlash("/tmp/main.go"), ampWorkspacePath("file:///tmp/main.go"))
+	assert.Equal(t, filepath.FromSlash("C:/tmp/main.go"), ampWorkspacePath("file:///C:/tmp/main.go"))
+	assert.Equal(t, ampProcessMetadata{}, ampSessionMetadata{}.process(123, time.Now()))
+	assert.Equal(t, "amp/unknown-high", ampAgentVersion("", "high"))
+}
+
+func mustJSON(t *testing.T, value interface{}) string {
+	t.Helper()
+
+	encoded, err := json.Marshal(value)
+	require.NoError(t, err)
+
+	return string(encoded)
 }

--- a/pkg/api/diagnostic_test.go
+++ b/pkg/api/diagnostic_test.go
@@ -79,3 +79,36 @@ func TestClient_SendDiagnostics(t *testing.T) {
 
 	assert.Equal(t, 1, numCalls)
 }
+
+func TestClient_SendDiagnostics_ErrorBranches(t *testing.T) {
+	c := api.NewClient("http://example.test")
+	err := c.SendDiagnostics(t.Context(), "vim", false, diagnostic.Diagnostic{Type: diagnostic.TypeUnknown})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown diagnostic type")
+
+	c = api.NewClient("%")
+	err = c.SendDiagnostics(t.Context(), "vim", false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create request")
+
+	url, router, closeServer := setupTestServer()
+	defer closeServer()
+
+	router.HandleFunc("/plugins/errors", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte("bad gateway"))
+	})
+
+	c = api.NewClient(url)
+	err = c.SendDiagnostics(t.Context(), "vim", false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid response status")
+
+	closedURL, _, closeClosedServer := setupTestServer()
+	closeClosedServer()
+
+	c = api.NewClient(closedURL)
+	err = c.SendDiagnostics(t.Context(), "vim", false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed making request")
+}

--- a/pkg/api/option_internal_test.go
+++ b/pkg/api/option_internal_test.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -147,6 +149,13 @@ func TestRequestCloneHelpers(t *testing.T) {
 	contents, err := io.ReadAll(cloned.Body)
 	require.NoError(t, err)
 	assert.Equal(t, "body", string(contents))
+
+	req.GetBody = func() (io.ReadCloser, error) {
+		return nil, errors.New("get body failed")
+	}
+
+	_, err = cloneRequest(req)
+	require.EqualError(t, err, "get body failed")
 }
 
 func TestShouldRetryProxyWithHTTP(t *testing.T) {
@@ -171,4 +180,21 @@ func TestTLSOptions(t *testing.T) {
 	require.NotNil(t, transport.TLSClientConfig)
 	assert.Equal(t, serverName, transport.TLSClientConfig.ServerName)
 	assert.NotNil(t, transport.TLSClientConfig.RootCAs)
+}
+
+func TestWithSSLCertFile(t *testing.T) {
+	certFile := filepath.Join(t.TempDir(), "ca.pem")
+	require.NoError(t, os.WriteFile(certFile, []byte("not a cert"), 0600))
+
+	opt, err := WithSSLCertFile(t.Context(), certFile)
+	require.NoError(t, err)
+	require.NotNil(t, opt)
+
+	client := NewClient("https://example.com", opt)
+	transport := client.client.Transport.(*http.Transport)
+	require.NotNil(t, transport.TLSClientConfig)
+	assert.NotNil(t, transport.TLSClientConfig.RootCAs)
+
+	_, err = WithSSLCertFile(t.Context(), certFile+".missing")
+	require.Error(t, err)
 }

--- a/pkg/filestats/filestats_test.go
+++ b/pkg/filestats/filestats_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/wakatime/wakatime-cli/pkg/filestats"
@@ -115,4 +116,34 @@ func TestWithDetection_MaxFileSizeExceeded(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
+}
+
+func TestWithDetection_SkipsUnsupportedInputs(t *testing.T) {
+	dir := t.TempDir()
+	existing := filepath.Join(dir, "existing.txt")
+	require.NoError(t, os.WriteFile(existing, []byte("one\n"), 0600))
+
+	opt := filestats.WithDetection()
+	handle := opt(func(_ context.Context, hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+		require.Len(t, hh, 6)
+		assert.Nil(t, hh[0].Lines)
+		assert.Nil(t, hh[1].Lines)
+		assert.Equal(t, 9, *hh[2].Lines)
+		assert.Nil(t, hh[3].Lines)
+		assert.Nil(t, hh[4].Lines)
+		assert.Nil(t, hh[5].Lines)
+
+		return []heartbeat.Result{{Status: 42}}, nil
+	})
+
+	result, err := handle(t.Context(), []heartbeat.Heartbeat{
+		{EntityType: heartbeat.AppType, Entity: "app"},
+		{EntityType: heartbeat.FileType, Entity: existing, IsUnsavedEntity: true},
+		{EntityType: heartbeat.FileType, Entity: existing, Lines: heartbeat.PointerTo(9)},
+		{EntityType: heartbeat.FileType, Entity: filepath.Join(dir, "missing.txt")},
+		{EntityType: heartbeat.FileType, Entity: dir},
+		{EntityType: heartbeat.FileType, Entity: "remote.go", LocalFile: filepath.Join(dir, "missing-local.txt")},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []heartbeat.Result{{Status: 42}}, result)
 }

--- a/pkg/heartbeat/format_test.go
+++ b/pkg/heartbeat/format_test.go
@@ -2,6 +2,7 @@ package heartbeat_test
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -54,6 +55,32 @@ func TestWithFormatting(t *testing.T) {
 	}, result)
 }
 
+func TestWithFormatting_SkipsNonFileAndRemote(t *testing.T) {
+	opt := heartbeat.WithFormatting()
+
+	input := []heartbeat.Heartbeat{
+		{
+			Entity:     "relative-app",
+			EntityType: heartbeat.AppType,
+		},
+		{
+			Entity:     "ssh://example.com/project/main.go",
+			EntityType: heartbeat.FileType,
+		},
+	}
+
+	handle := opt(func(_ context.Context, hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+		assert.Equal(t, input, hh)
+
+		return []heartbeat.Result{{Status: 201}}, nil
+	})
+
+	result, err := handle(t.Context(), input)
+	require.NoError(t, err)
+
+	assert.Equal(t, []heartbeat.Result{{Status: 201}}, result)
+}
+
 func TestFormat_NotFileType(t *testing.T) {
 	tests := map[string]heartbeat.EntityType{
 		"app":    heartbeat.AppType,
@@ -74,6 +101,65 @@ func TestFormat_NotFileType(t *testing.T) {
 			assert.Equal(t, "/unmodified", formatted.Entity)
 		})
 	}
+}
+
+func TestFormat_ProjectPathOverride(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("project path override realpath behavior is covered by Windows-specific formatting tests")
+	}
+
+	tmpDir := t.TempDir()
+	entity := filepath.Join(tmpDir, "main.go")
+	projectDir := filepath.Join(tmpDir, "project")
+	require.NoError(t, os.Mkdir(projectDir, 0700))
+	require.NoError(t, os.WriteFile(entity, []byte("package main\n"), 0600))
+
+	h := heartbeat.Heartbeat{
+		Entity:              entity,
+		EntityType:          heartbeat.FileType,
+		ProjectPathOverride: projectDir,
+	}
+
+	formatted := heartbeat.Format(t.Context(), h)
+
+	entityRealpath, err := realpath.Realpath(entity)
+	require.NoError(t, err)
+	projectRealpath, err := realpath.Realpath(projectDir)
+	require.NoError(t, err)
+
+	assert.Equal(t, entityRealpath, formatted.Entity)
+	assert.Equal(t, projectRealpath, formatted.ProjectPathOverride)
+}
+
+func TestFormat_MissingRealpathTargets(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("realpath failure branches are not used by Windows formatting")
+	}
+
+	tmpDir := t.TempDir()
+	missingEntity := filepath.Join(tmpDir, "missing.go")
+	formatted := heartbeat.Format(t.Context(), heartbeat.Heartbeat{
+		Entity:     missingEntity,
+		EntityType: heartbeat.FileType,
+	})
+
+	entityAbs, err := filepath.Abs(missingEntity)
+	require.NoError(t, err)
+	assert.Equal(t, entityAbs, formatted.Entity)
+
+	entity := filepath.Join(tmpDir, "main.go")
+	require.NoError(t, os.WriteFile(entity, []byte("package main\n"), 0600))
+
+	missingProject := filepath.Join(tmpDir, "missing-project")
+	formatted = heartbeat.Format(t.Context(), heartbeat.Heartbeat{
+		Entity:              entity,
+		EntityType:          heartbeat.FileType,
+		ProjectPathOverride: missingProject,
+	})
+
+	projectAbs, err := filepath.Abs(missingProject)
+	require.NoError(t, err)
+	assert.Equal(t, projectAbs, formatted.ProjectPathOverride)
 }
 
 func TestFormat_WindowsPath(t *testing.T) {

--- a/pkg/ini/ini_internal_test.go
+++ b/pkg/ini/ini_internal_test.go
@@ -1,0 +1,49 @@
+package ini
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInternalHelpers(t *testing.T) {
+	assert.Equal(t, "settings.api_key", sectionKey("settings", "api_key"))
+	assert.Equal(t, "api_key", sectionKey("DEFAULT", "api_key"))
+
+	sanitized := string(sanitizeMalformedSections([]byte("[good]\na=1\n[bad\nb=2\n[other]\nc=3")))
+	assert.Contains(t, sanitized, "[good]")
+	assert.NotContains(t, sanitized, "[bad")
+	assert.Contains(t, sanitized, "[other]")
+
+	missing := filepath.Join(t.TempDir(), "missing.cfg")
+	assert.False(t, fileExists(missing))
+	require.NoError(t, os.WriteFile(missing, []byte("x"), 0600))
+	assert.True(t, fileExists(missing))
+
+	clock := &mutexClock{delay: time.Millisecond}
+	assert.False(t, clock.Now().IsZero())
+
+	select {
+	case <-clock.After(time.Hour):
+	case <-time.After(time.Second):
+		t.Fatal("mutex clock did not fire")
+	}
+}
+
+func TestSalvageConfigBranches(t *testing.T) {
+	tmp := filepath.Join(t.TempDir(), "wakatime.cfg")
+	require.NoError(t, os.WriteFile(tmp, []byte("[settings]\napi_key = value\x00\n[broken\nignored = true\n"), 0600))
+
+	v := viper.New()
+	require.NoError(t, salvageConfig(v, tmp))
+	assert.Equal(t, "value", v.GetString("settings.api_key"))
+	assert.Empty(t, v.GetString("broken.ignored"))
+
+	err := salvageConfig(v, filepath.Join(t.TempDir(), "missing.cfg"))
+	require.Error(t, err)
+}

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -13,9 +13,8 @@ type Lexer interface {
 	Name() string
 }
 
-// RegisterAll registers all custom lexers.
-func RegisterAll() error {
-	var lexers = []Lexer{
+func customLexers() []Lexer {
+	return []Lexer{
 		ADL{},
 		AMPL{},
 		ActionScript3{},
@@ -304,8 +303,11 @@ func RegisterAll() error {
 		Zeek{},
 		Zephir{},
 	}
+}
 
-	for _, lexer := range lexers {
+// RegisterAll registers all custom lexers.
+func RegisterAll() error {
+	for _, lexer := range customLexers() {
 		found := lexer.Lexer()
 		if found == nil {
 			return fmt.Errorf("%q lexer not found", lexer.Name())

--- a/pkg/lexer/register_internal_test.go
+++ b/pkg/lexer/register_internal_test.go
@@ -3,7 +3,9 @@ package lexer
 import (
 	"testing"
 
+	"github.com/alecthomas/chroma/v2"
 	chromalexers "github.com/alecthomas/chroma/v2/lexers"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -11,4 +13,189 @@ func TestRegisterAll(t *testing.T) {
 	require.NoError(t, RegisterAll())
 	require.NotNil(t, chromalexers.Get(ADL{}.Name()))
 	require.NotNil(t, chromalexers.Get(Zephir{}.Name()))
+}
+
+func TestCustomLexersTokenise(t *testing.T) {
+	for _, customLexer := range customLexers() {
+		t.Run(customLexer.Name(), func(t *testing.T) {
+			lexer := customLexer.Lexer()
+			require.NotNil(t, lexer)
+			require.NotEmpty(t, customLexer.Name())
+
+			iterator, err := lexer.Tokenise(nil, "sample\n")
+			require.NoError(t, err)
+
+			var tokens int
+			for token := iterator(); token != chroma.EOF; token = iterator() {
+				tokens++
+			}
+
+			assert.Positive(t, tokens)
+		})
+	}
+}
+
+func TestCustomLexerAnalysers(t *testing.T) {
+	tests := map[string]struct {
+		Lexer    Lexer
+		Matching string
+		Other    string
+	}{
+		"easytrieve": {
+			Lexer: Easytrieve{},
+			Matching: "* header\n" +
+				"FILE INPUT\n" +
+				"JOB INPUT INPUT\n" +
+				"REPORT REPORT1\n" +
+				"PROC REPORT\n" +
+				"END-PROC\n",
+			Other: "plain text",
+		},
+		"xml": {
+			Lexer:    XML{},
+			Matching: "<?xml version=\"1.0\"?><root></root>",
+			Other:    "plain text",
+		},
+		"xslt": {
+			Lexer:    XSLT{},
+			Matching: "<?xml version=\"1.0\"?><xsl:stylesheet></xsl:stylesheet>",
+			Other:    "<?xml version=\"1.0\"?><root></root>",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			lexer := test.Lexer.Lexer()
+			require.NotNil(t, lexer)
+
+			assert.Positive(t, lexer.AnalyseText(test.Matching))
+			assert.Zero(t, lexer.AnalyseText(test.Other))
+		})
+	}
+}
+
+func TestCustomLexerAnalysersPlainText(t *testing.T) {
+	for _, customLexer := range customLexers() {
+		t.Run(customLexer.Name(), func(t *testing.T) {
+			lexer := customLexer.Lexer()
+			require.NotNil(t, lexer)
+
+			assert.NotPanics(t, func() {
+				_ = lexer.AnalyseText("plain text")
+			})
+		})
+	}
+}
+
+func TestCustomLexerAnalysersMatchingSamples(t *testing.T) {
+	tests := map[string]struct {
+		Lexer Lexer
+		Text  string
+	}{
+		"actionscript3": {
+			Lexer: ActionScript3{},
+			Text:  "var count:int = 1;",
+		},
+		"brainfuck": {
+			Lexer: Brainfuck{},
+			Text:  "++[>++<-].",
+		},
+		"coq": {
+			Lexer: Coq{},
+			Text:  "Theorem sample : True.",
+		},
+		"forth": {
+			Lexer: Forth{},
+			Text:  ": square dup * ;",
+		},
+		"fsharp": {
+			Lexer: FSharp{},
+			Text:  "let value = 1",
+		},
+		"gas": {
+			Lexer: Gas{},
+			Text:  ".section .text\n.globl _start",
+		},
+		"groff": {
+			Lexer: Groff{},
+			Text:  ".TH TEST 1",
+		},
+		"html": {
+			Lexer: HTML{},
+			Text:  "<!DOCTYPE html><html></html>",
+		},
+		"hy": {
+			Lexer: Hy{},
+			Text:  "(defn sample [] 1)",
+		},
+		"ini": {
+			Lexer: INI{},
+			Text:  "[settings]\nkey=value",
+		},
+		"make": {
+			Lexer: Makefile{},
+			Text:  "target:\n\tgo test ./...",
+		},
+		"matlab": {
+			Lexer: Matlab{},
+			Text:  "function y = f(x)\ny = x + 1;\nend",
+		},
+		"nasm": {
+			Lexer: NASM{},
+			Text:  "section .text\nglobal _start",
+		},
+		"objectivec": {
+			Lexer: ObjectiveC{},
+			Text:  "#import <Foundation/Foundation.h>\n@implementation Sample\n@end",
+		},
+		"prolog": {
+			Lexer: Prolog{},
+			Text:  "parent(alice, bob).",
+		},
+		"python": {
+			Lexer: Python{},
+			Text:  "import os\nprint(os.name)",
+		},
+		"python2": {
+			Lexer: Python2{},
+			Text:  "print 'hello'",
+		},
+		"qbasic": {
+			Lexer: QBasic{},
+			Text:  "10 PRINT \"HELLO\"",
+		},
+		"r": {
+			Lexer: R{},
+			Text:  "library(stats)\nvalue <- 1",
+		},
+		"tasm": {
+			Lexer: TASM{},
+			Text:  ".model small\n.code",
+		},
+		"turtle": {
+			Lexer: Turtle{},
+			Text:  "@prefix ex: <http://example.com/> .",
+		},
+		"vbnet": {
+			Lexer: VBNet{},
+			Text:  "Imports System\nModule Program\nEnd Module",
+		},
+		"verilog": {
+			Lexer: Verilog{},
+			Text:  "module top; endmodule",
+		},
+		"xml": {
+			Lexer: XML{},
+			Text:  "<?xml version=\"1.0\"?><root/>",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			lexer := test.Lexer.Lexer()
+			require.NotNil(t, lexer)
+
+			assert.GreaterOrEqual(t, lexer.AnalyseText(test.Text), float32(0))
+		})
+	}
 }

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -1,11 +1,15 @@
 package log_test
 
 import (
+	"bytes"
+	"context"
 	"testing"
 
 	"github.com/wakatime/wakatime-cli/pkg/log"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
 )
 
 func TestLog_IsMetricsEnabled(t *testing.T) {
@@ -42,4 +46,117 @@ func TestLog_SendDiagsOnErrors_Disabled(t *testing.T) {
 	logger := log.New(nil)
 
 	assert.False(t, logger.SendDiagsOnErrors())
+}
+
+func TestLoggerOutputAndSetOutput(t *testing.T) {
+	var first bytes.Buffer
+
+	logger := log.New(&first)
+
+	assert.Equal(t, &first, logger.Output())
+
+	logger.Infoln("first")
+	assert.Contains(t, first.String(), "first")
+
+	var second bytes.Buffer
+	logger.SetOutput(&second)
+
+	assert.Equal(t, &second, logger.Output())
+
+	logger.Infoln("second")
+	assert.Contains(t, second.String(), "second")
+	assert.NotContains(t, first.String(), "second")
+}
+
+func TestLoggerLoggingMethods(t *testing.T) {
+	var buffer bytes.Buffer
+
+	logger := log.New(&buffer, log.WithVerbose(true))
+
+	logger.Log(zapcore.InfoLevel, "plain log")
+	logger.Logf(zapcore.InfoLevel, "formatted %s", "log")
+	logger.Debugf("debug %s", "format")
+	logger.Infof("info %s", "format")
+	logger.Warnf("warn %s", "format")
+	logger.Errorf("error %s", "format")
+	logger.Debugln("debug line")
+	logger.Infoln("info line")
+	logger.Warnln("warn line")
+	logger.Errorln("error line")
+	logger.WithField("component", "test")
+	logger.Infoln("fielded")
+
+	output := buffer.String()
+	assert.Contains(t, output, "plain log")
+	assert.Contains(t, output, "formatted log")
+	assert.Contains(t, output, "debug format")
+	assert.Contains(t, output, "info format")
+	assert.Contains(t, output, "warn format")
+	assert.Contains(t, output, "error format")
+	assert.Contains(t, output, "debug line")
+	assert.Contains(t, output, "info line")
+	assert.Contains(t, output, "warn line")
+	assert.Contains(t, output, "error line")
+	assert.Contains(t, output, "fielded")
+	assert.Contains(t, output, `"component":"test"`)
+}
+
+func TestLoggerContextHelpers(t *testing.T) {
+	var buffer bytes.Buffer
+
+	logger := log.New(&buffer)
+
+	ctx := log.ToContext(context.Background(), logger)
+
+	assert.Equal(t, logger, log.Extract(ctx))
+
+	log.AddField(ctx, "request_id", "abc")
+	logger.Infoln("message")
+
+	assert.Contains(t, buffer.String(), `"request_id":"abc"`)
+	assert.NotNil(t, log.Extract(context.Background()))
+}
+
+func TestLoggerFlushClosesOutput(t *testing.T) {
+	writer := &closeTrackingWriter{}
+	logger := log.New(writer)
+
+	logger.Flush()
+
+	assert.True(t, writer.closed)
+}
+
+func TestDynamicWriteSyncer(t *testing.T) {
+	var first bytes.Buffer
+
+	syncer := log.NewDynamicWriteSyncer(zapcore.AddSync(&first))
+
+	n, err := syncer.Write([]byte("first"))
+	require.NoError(t, err)
+	assert.Equal(t, len("first"), n)
+	assert.Equal(t, "first", first.String())
+
+	var second bytes.Buffer
+	syncer.SetWriter(zapcore.AddSync(&second))
+
+	n, err = syncer.Write([]byte("second"))
+	require.NoError(t, err)
+	assert.Equal(t, len("second"), n)
+	assert.Equal(t, "second", second.String())
+	assert.Equal(t, "first", first.String())
+
+	require.NoError(t, syncer.Sync())
+}
+
+type closeTrackingWriter struct {
+	closed bool
+}
+
+func (*closeTrackingWriter) Write(p []byte) (int, error) {
+	return len(p), nil
+}
+
+func (w *closeTrackingWriter) Close() error {
+	w.closed = true
+	return nil
 }

--- a/pkg/log/setup/setup_test.go
+++ b/pkg/log/setup/setup_test.go
@@ -2,6 +2,7 @@ package setup_test
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/wakatime/wakatime-cli/pkg/log/setup"
@@ -31,4 +32,33 @@ func TestLogging(t *testing.T) {
 	assert.True(t, logger.SendDiagsOnErrors())
 	assert.True(t, logger.IsMetricsEnabled())
 	assert.True(t, logger.IsVerboseEnabled())
+}
+
+func TestLogging_ToStdout(t *testing.T) {
+	v := vipertools.MustNew()
+	v.Set("log-to-stdout", true)
+
+	logger, err := setup.Logging(t.Context(), v)
+	require.NoError(t, err)
+
+	assert.NotNil(t, logger)
+	assert.False(t, logger.SendDiagsOnErrors())
+	assert.False(t, logger.IsMetricsEnabled())
+	assert.False(t, logger.IsVerboseEnabled())
+}
+
+func TestLogging_CreatesLogDirectory(t *testing.T) {
+	logFile := filepath.Join(t.TempDir(), "nested", "wakatime.log")
+
+	v := vipertools.MustNew()
+	v.Set("log-file", logFile)
+
+	logger, err := setup.Logging(t.Context(), v)
+	require.NoError(t, err)
+
+	assert.NotNil(t, logger)
+
+	info, err := os.Stat(filepath.Dir(logFile))
+	require.NoError(t, err)
+	assert.True(t, info.IsDir())
 }

--- a/pkg/offline/legacy_test.go
+++ b/pkg/offline/legacy_test.go
@@ -48,3 +48,15 @@ func TestQueueFilepathLegacy(t *testing.T) {
 		})
 	}
 }
+
+func TestQueueFilepathLegacy_ConfiguredFile(t *testing.T) {
+	expected := filepath.Join(t.TempDir(), "legacy.bdb")
+
+	v := viper.New()
+	v.Set("offline-queue-file-legacy", expected)
+
+	queueFilepath, err := offline.QueueFilepathLegacy(t.Context(), v)
+	require.NoError(t, err)
+
+	assert.Equal(t, expected, queueFilepath)
+}

--- a/pkg/offline/offline_internal_test.go
+++ b/pkg/offline/offline_internal_test.go
@@ -1,0 +1,134 @@
+package offline
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
+	bolt "go.etcd.io/bbolt"
+)
+
+func TestQueueMethodsReadOnlyTransactionErrors(t *testing.T) {
+	db := openTestQueueDB(t)
+	defer db.Close()
+
+	require.NoError(t, db.View(func(tx *bolt.Tx) error {
+		queue := NewQueue(tx)
+
+		_, err := queue.Count()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to create/load bucket")
+
+		_, err = queue.PopMany(1)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to create/load bucket")
+
+		err = queue.PushMany([]heartbeat.Heartbeat{{Entity: "main.go"}})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to create/load bucket")
+
+		_, err = queue.ReadMany(1)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to create/load bucket")
+
+		_, err = queue.DeleteDuplicates()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to create/load bucket")
+
+		return nil
+	}))
+}
+
+func TestQueueInvalidJSONErrors(t *testing.T) {
+	tests := map[string]func(*Queue) error{
+		"pop": func(queue *Queue) error {
+			_, err := queue.PopMany(1)
+			return err
+		},
+		"read": func(queue *Queue) error {
+			_, err := queue.ReadMany(1)
+			return err
+		},
+		"dedupe": func(queue *Queue) error {
+			_, err := queue.DeleteDuplicates()
+			return err
+		},
+	}
+
+	for name, run := range tests {
+		t.Run(name, func(t *testing.T) {
+			db := openTestQueueDB(t)
+			defer db.Close()
+
+			require.NoError(t, db.Update(func(tx *bolt.Tx) error {
+				bucket, err := tx.CreateBucketIfNotExists([]byte(dbBucket))
+				require.NoError(t, err)
+
+				return bucket.Put([]byte("1"), []byte("{"))
+			}))
+
+			require.NoError(t, db.Update(func(tx *bolt.Tx) error {
+				err := run(NewQueue(tx))
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "failed to json unmarshal heartbeat data")
+
+				return nil
+			}))
+		})
+	}
+}
+
+func TestQueueDeleteDuplicatesRemovesNearbyHeartbeat(t *testing.T) {
+	db := openTestQueueDB(t)
+	defer db.Close()
+
+	h1 := heartbeat.Heartbeat{Entity: "main.go", EntityType: heartbeat.FileType, Time: 10, UserAgent: "test/1"}
+	h2 := heartbeat.Heartbeat{Entity: "main.go", EntityType: heartbeat.FileType, Time: 10.5, UserAgent: "test/1"}
+	h3 := heartbeat.Heartbeat{Entity: "main.go", EntityType: heartbeat.FileType, Time: 30, UserAgent: "test/1"}
+
+	require.NoError(t, db.Update(func(tx *bolt.Tx) error {
+		queue := NewQueue(tx)
+		require.NoError(t, queue.PushMany([]heartbeat.Heartbeat{h1, h2, h3}))
+
+		deleted, err := queue.DeleteDuplicates()
+		require.NoError(t, err)
+		assert.Equal(t, 1, deleted)
+
+		remaining, err := queue.ReadMany(10)
+		require.NoError(t, err)
+		assert.Len(t, remaining, 2)
+
+		return nil
+	}))
+}
+
+func TestResetCorruptDBHelpers(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "missing.bdb")
+	backup, err := resetCorruptDB(missing)
+	require.NoError(t, err)
+	assert.Empty(t, backup)
+
+	resetErr := resetCorruptDBError(missing, assert.AnError)
+	assert.True(t, resetErr.Reset)
+	assert.Contains(t, resetErr.Error(), "corrupt db file already removed")
+
+	dbPath := filepath.Join(t.TempDir(), "offline.bdb")
+	require.NoError(t, os.WriteFile(dbPath, []byte("corrupt"), 0600))
+	backup, err = resetCorruptDB(dbPath)
+	require.NoError(t, err)
+	assert.NotEmpty(t, backup)
+	assert.NoFileExists(t, dbPath)
+	assert.FileExists(t, backup)
+}
+
+func openTestQueueDB(t *testing.T) *bolt.DB {
+	t.Helper()
+
+	db, err := bolt.Open(filepath.Join(t.TempDir(), "offline.bdb"), 0600, nil)
+	require.NoError(t, err)
+
+	return db
+}

--- a/pkg/offline/offline_test.go
+++ b/pkg/offline/offline_test.go
@@ -55,6 +55,18 @@ func TestQueueFilepath(t *testing.T) {
 	}
 }
 
+func TestQueueFilepath_ConfiguredFile(t *testing.T) {
+	expected := filepath.Join(t.TempDir(), "queue.bdb")
+
+	v := viper.New()
+	v.Set("offline-queue-file", expected)
+
+	queueFilepath, err := offline.QueueFilepath(t.Context(), v)
+	require.NoError(t, err)
+
+	assert.Equal(t, expected, queueFilepath)
+}
+
 func TestWithQueue(t *testing.T) {
 	// setup
 	f, err := os.CreateTemp(t.TempDir(), "")
@@ -385,6 +397,30 @@ func TestWithQueue_HandleLeftovers(t *testing.T) {
 	assert.JSONEq(t, string(dataJs), stored[1].Heartbeat)
 }
 
+func TestWithQueue_BadRequestDoesNotRequeue(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "")
+	require.NoError(t, err)
+
+	defer f.Close()
+
+	handle := offline.WithQueue(f.Name())(func(_ context.Context, hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+		require.Len(t, hh, 1)
+
+		return []heartbeat.Result{{
+			Status: http.StatusBadRequest,
+			Errors: []string{"bad entity"},
+		}}, nil
+	})
+
+	results, err := handle(t.Context(), []heartbeat.Heartbeat{testHeartbeats()[0]})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	count, err := offline.CountHeartbeats(t.Context(), f.Name())
+	require.NoError(t, err)
+	assert.Zero(t, count)
+}
+
 func TestWithSync(t *testing.T) {
 	// setup
 	f, err := os.CreateTemp(t.TempDir(), "")
@@ -461,6 +497,52 @@ func TestWithSync(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, stored, 0)
+}
+
+func TestWithSync_OpenError(t *testing.T) {
+	handle := offline.WithSync(t.TempDir(), 1)(func(_ context.Context, _ []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+		t.Fatal("next handler should not be called")
+
+		return nil, nil
+	})
+
+	results, err := handle(t.Context(), nil)
+	require.Error(t, err)
+	assert.Nil(t, results)
+	assert.Contains(t, err.Error(), "failed to sync offline heartbeats")
+}
+
+func TestSync_RequeuesOnHandlerError(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "")
+	require.NoError(t, err)
+
+	defer f.Close()
+
+	db, err := bolt.Open(f.Name(), 0600, nil)
+	require.NoError(t, err)
+
+	dataGo, err := os.ReadFile("testdata/heartbeat_go.json")
+	require.NoError(t, err)
+
+	insertHeartbeatRecords(t, db, "heartbeats", []heartbeatRecord{{
+		ID:        "1592868367.219124-12-file-coding-wakatime-cli-heartbeat-/tmp/main.go-true",
+		Heartbeat: string(dataGo),
+	}})
+	require.NoError(t, db.Close())
+
+	err = offline.Sync(t.Context(), f.Name(), 1)(
+		func(_ context.Context, hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+			require.Len(t, hh, 1)
+
+			return nil, errors.New("api unavailable")
+		},
+	)
+	require.EqualError(t, err, "api unavailable")
+
+	queued, err := offline.ReadHeartbeats(t.Context(), f.Name(), 10)
+	require.NoError(t, err)
+	require.Len(t, queued, 1)
+	assert.Equal(t, "/tmp/main.go", queued[0].Entity)
 }
 
 func TestSync_MultipleRequests(t *testing.T) {

--- a/pkg/params/params_internal_test.go
+++ b/pkg/params/params_internal_test.go
@@ -1,10 +1,14 @@
 package params
 
 import (
+	"net/url"
 	"regexp"
+	"runtime"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/spf13/viper"
 	"github.com/wakatime/wakatime-cli/pkg/ini"
 	"github.com/wakatime/wakatime-cli/pkg/regex"
 	"github.com/wakatime/wakatime-cli/pkg/vipertools"
@@ -156,4 +160,194 @@ func TestNormalizeURL(t *testing.T) {
 			assert.Equal(t, test.Expected, result)
 		})
 	}
+}
+
+func TestLoadAPIKeyPatternsBranches(t *testing.T) {
+	v := viper.New()
+	v.Set("project_api_key.(?", "00000000-0000-4000-8000-000000000000")
+	v.Set("project_api_key./same", "00000000-0000-4000-8000-000000000000")
+	v.Set("project_api_key./custom", "11111111-1111-4111-8111-111111111111")
+
+	patterns, err := loadAPIKeyPatterns(t.Context(), v, "00000000-0000-4000-8000-000000000000")
+	require.NoError(t, err)
+	require.Len(t, patterns, 1)
+	assert.Equal(t, "11111111-1111-4111-8111-111111111111", patterns[0].APIKey)
+
+	v = viper.New()
+	v.Set("project_api_key./bad", "invalid")
+
+	_, err = loadAPIKeyPatterns(t.Context(), v, "00000000-0000-4000-8000-000000000000")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid api key format")
+}
+
+func TestLoadAPIURLPatternsBranches(t *testing.T) {
+	defaultURL, err := url.Parse("https://api.wakatime.com/api/v1")
+	require.NoError(t, err)
+
+	v := viper.New()
+	v.Set("api_urls.(?", "https://ignored.example|11111111-1111-4111-8111-111111111111")
+	v.Set("api_urls./default", "|00000000-0000-4000-8000-000000000000")
+	v.Set(
+		"api_urls./custom",
+		"https://custom.example/api/v1/users/current/heartbeats.bulk|11111111-1111-4111-8111-111111111111",
+	)
+	v.Set("api_urls./invalidurl", "%|11111111-1111-4111-8111-111111111111")
+
+	patterns, err := loadAPIURLPatterns(t.Context(), v, defaultURL, "00000000-0000-4000-8000-000000000000")
+	require.NoError(t, err)
+	require.Len(t, patterns, 2)
+
+	var urls []string
+	for _, pattern := range patterns {
+		urls = append(urls, pattern.APIURL)
+	}
+
+	assert.ElementsMatch(t, []string{
+		"https://api.wakatime.com/api/v1",
+		"https://custom.example/api/v1",
+	}, urls)
+
+	v = viper.New()
+	v.Set("api_urls./badkey", "https://custom.example|invalid")
+
+	_, err = loadAPIURLPatterns(t.Context(), v, defaultURL, "00000000-0000-4000-8000-000000000000")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid api key format in api_urls")
+
+	emptyURL := &url.URL{}
+	v = viper.New()
+	v.Set("api_urls./empty", "|00000000-0000-4000-8000-000000000000")
+	patterns, err = loadAPIURLPatterns(t.Context(), v, emptyURL, "00000000-0000-4000-8000-000000000000")
+	require.NoError(t, err)
+	assert.Empty(t, patterns)
+}
+
+func TestParseExtraHeartbeatErrorBranches(t *testing.T) {
+	base := ExtraHeartbeat{
+		Category: "coding",
+		Entity:   "main.go",
+		Time:     float64(1),
+		Type:     "file",
+	}
+
+	tests := map[string]struct {
+		Heartbeat ExtraHeartbeat
+		Contains  string
+	}{
+		"category": {
+			Heartbeat: withExtraHeartbeat(base, func(h *ExtraHeartbeat) { h.Category = "bad" }),
+			Contains:  "failed to parse category",
+		},
+		"entity type": {
+			Heartbeat: withExtraHeartbeat(base, func(h *ExtraHeartbeat) { h.Type = "bad" }),
+			Contains:  "invalid entity type",
+		},
+		"cursor": {
+			Heartbeat: withExtraHeartbeat(base, func(h *ExtraHeartbeat) { h.CursorPosition = "bad" }),
+			Contains:  "failed to convert cursorpos to int",
+		},
+		"is write": {
+			Heartbeat: withExtraHeartbeat(base, func(h *ExtraHeartbeat) { h.IsWrite = "bad" }),
+			Contains:  "failed to convert is write to bool",
+		},
+		"line number": {
+			Heartbeat: withExtraHeartbeat(base, func(h *ExtraHeartbeat) { h.LineNumber = "bad" }),
+			Contains:  "failed to convert lineno to int",
+		},
+		"lines": {
+			Heartbeat: withExtraHeartbeat(base, func(h *ExtraHeartbeat) { h.Lines = "bad" }),
+			Contains:  "failed to convert lines to int",
+		},
+		"time": {
+			Heartbeat: withExtraHeartbeat(base, func(h *ExtraHeartbeat) { h.Time = "bad" }),
+			Contains:  "failed to convert time to float64",
+		},
+		"timestamp": {
+			Heartbeat: withExtraHeartbeat(base, func(h *ExtraHeartbeat) {
+				h.Time = nil
+				h.Timestamp = "bad"
+			}),
+			Contains: "failed to convert timestamp to float64",
+		},
+		"missing timestamp": {
+			Heartbeat: withExtraHeartbeat(base, func(h *ExtraHeartbeat) { h.Time = nil }),
+			Contains:  "no valid timestamp",
+		},
+		"is unsaved entity": {
+			Heartbeat: withExtraHeartbeat(base, func(h *ExtraHeartbeat) { h.IsUnsavedEntity = "bad" }),
+			Contains:  "failed to convert is_unsaved_entity to bool",
+		},
+		"ai line changes": {
+			Heartbeat: withExtraHeartbeat(base, func(h *ExtraHeartbeat) { h.AILineChanges = "bad" }),
+			Contains:  "failed to convert ai_line_changes to int",
+		},
+		"human line changes": {
+			Heartbeat: withExtraHeartbeat(base, func(h *ExtraHeartbeat) { h.HumanLineChanges = "bad" }),
+			Contains:  "failed to convert human_line_changes to int",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := parseExtraHeartbeat(test.Heartbeat)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), test.Contains)
+		})
+	}
+}
+
+func TestParseExtraHeartbeatsBranches(t *testing.T) {
+	heartbeats, err := parseExtraHeartbeats(t.Context(), "")
+	require.NoError(t, err)
+	assert.Nil(t, heartbeats)
+
+	_, err = parseExtraHeartbeats(t.Context(), "{")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to json decode")
+
+	_, err = parseExtraHeartbeats(t.Context(), `[{"category":"bad"}]`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse category")
+}
+
+func TestParamsStringAndHelperBranches(t *testing.T) {
+	assert.Contains(t, (Params{}).String(), "api params:")
+	assert.Equal(t, "unknown", FlagReadOrder(99).String())
+	assert.Nil(t, mustParseIntegerNumber(t, nil))
+	assert.Equal(t, 3, *mustParseIntegerNumber(t, float64(3)))
+	assert.Equal(t, "first", firstNonEmptyString("", "first", "second"))
+	assert.Equal(t, "", firstNonEmptyString("", ""))
+}
+
+func withExtraHeartbeat(base ExtraHeartbeat, update func(*ExtraHeartbeat)) ExtraHeartbeat {
+	update(&base)
+
+	return base
+}
+
+func mustParseIntegerNumber(t *testing.T, value any) *int {
+	t.Helper()
+
+	parsed, err := parseIntegerNumber(value)
+	require.NoError(t, err)
+
+	return parsed
+}
+
+func TestReadAPIKeyFromCommandBranches(t *testing.T) {
+	key, err := readAPIKeyFromCommand("  ")
+	require.NoError(t, err)
+	assert.Empty(t, key)
+
+	if runtime.GOOS == "windows" {
+		return
+	}
+
+	key, err = readAPIKeyFromCommand(`printf 'waka_key'`)
+	require.NoError(t, err)
+	assert.Equal(t, "waka_key", strings.TrimSpace(key))
+
+	_, err = readAPIKeyFromCommand("exit 7")
+	require.Error(t, err)
 }

--- a/pkg/project/project_internal_test.go
+++ b/pkg/project/project_internal_test.go
@@ -148,3 +148,41 @@ func TestInterpolateProjectPlaceholder_VCSProjectTakesPrecedenceOverFolder(t *te
 
 	assert.Equal(t, "prefix-vcs-name", result)
 }
+
+func TestProjectHelperBranches(t *testing.T) {
+	tmpDir := t.TempDir()
+	childDir := filepath.Join(tmpDir, "child", "grandchild")
+	require.NoError(t, os.MkdirAll(childDir, 0700))
+
+	marker := filepath.Join(tmpDir, ".marker")
+	require.NoError(t, os.WriteFile(marker, []byte("ok"), 0600))
+
+	found, ok := FindFileOrDirectory(t.Context(), childDir, ".marker")
+	require.True(t, ok)
+	assert.Equal(t, marker, found)
+
+	found, ok = FindFileOrDirectory(t.Context(), tmpDir, ".missing")
+	assert.False(t, ok)
+	assert.Empty(t, found)
+
+	assert.True(t, isRootPath(""))
+	assert.True(t, isRootPath("."))
+	assert.Equal(t, "", firstNonEmptyString("", ""))
+	assert.Equal(t, "second", firstNonEmptyString("", "second", "third"))
+	assert.Empty(t, FormatProjectFolder(t.Context(), ""))
+	assert.Equal(
+		t,
+		"template/{project}",
+		interpolateProjectPlaceholder("template/{project}", "", string(filepath.Separator)),
+	)
+	assert.Positive(t, CountSlashesInProjectFolder(filepath.Join(tmpDir, "child")))
+	assert.Equal(
+		t,
+		"repo",
+		resolveSvnInfo(map[string]string{
+			"Repository Root": "https://svn.example.com/team/repo\r",
+		}, "Repository Root"),
+	)
+	assert.Equal(t, "branch", resolveSvnInfo(map[string]string{"URL": `https://svn.example.com\team\branch`}, "URL"))
+	assert.Empty(t, resolveSvnInfo(map[string]string{}, "URL"))
+}

--- a/pkg/regex/regex_test.go
+++ b/pkg/regex/regex_test.go
@@ -1,6 +1,8 @@
 package regex_test
 
 import (
+	"context"
+	"regexp"
 	"testing"
 
 	"github.com/wakatime/wakatime-cli/pkg/regex"
@@ -39,4 +41,29 @@ func TestMustCompile(t *testing.T) {
 			assert.Equal(t, pattern, r.String())
 		})
 	}
+}
+
+func TestMustCompilePanicsOnInvalidPattern(t *testing.T) {
+	assert.Panics(t, func() {
+		regex.MustCompile(`(?`)
+	})
+}
+
+func TestRegexpWrapMethods(t *testing.T) {
+	wrapped := regex.NewRegexpWrap(regexp.MustCompile(`^hello (.+)$`))
+
+	assert.True(t, wrapped.MatchString(context.Background(), "hello world"))
+	assert.False(t, wrapped.MatchString(context.Background(), "goodbye world"))
+	assert.Equal(t, []string{"hello world", "world"}, wrapped.FindStringSubmatch(context.Background(), "hello world"))
+	assert.Equal(t, `^hello (.+)$`, wrapped.String())
+}
+
+func TestRegexp2WrapMethods(t *testing.T) {
+	wrapped, err := regex.Compile(`^hello (.+)(?=!)`)
+	require.NoError(t, err)
+
+	assert.True(t, wrapped.MatchString(context.Background(), "hello world!"))
+	assert.False(t, wrapped.MatchString(context.Background(), "hello world"))
+	assert.Equal(t, []string{"hello world", "world"}, wrapped.FindStringSubmatch(context.Background(), "hello world!"))
+	assert.Nil(t, wrapped.FindStringSubmatch(context.Background(), "hello world"))
 }

--- a/pkg/remote/remote_internal_test.go
+++ b/pkg/remote/remote_internal_test.go
@@ -1,10 +1,19 @@
 package remote
 
 import (
+	"bytes"
+	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/kevinburke/ssh_config"
+	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
+	"github.com/wakatime/wakatime-cli/pkg/log"
+
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestShouldDownloadFileFallback(t *testing.T) {
@@ -20,4 +29,177 @@ func TestContains(t *testing.T) {
 func TestClientUser(t *testing.T) {
 	assert.Equal(t, "explicit", Client{User: "explicit"}.user())
 	assert.Empty(t, Client{}.user())
+}
+
+func TestClientUserFromSSHConfig(t *testing.T) {
+	withSSHConfig(t, `
+Host original
+  User original-user
+Host derived
+  User derived-user
+`)
+
+	assert.Equal(t, "original-user", Client{OriginalHost: "original", Host: "derived"}.user())
+	assert.Equal(t, "derived-user", Client{OriginalHost: "alias", Host: "derived"}.user())
+}
+
+func TestClientStrictHostKeyChecking(t *testing.T) {
+	withSSHConfig(t, `
+Host original
+  StrictHostKeyChecking accept-new
+Host derived
+  StrictHostKeyChecking off
+`)
+
+	assert.Equal(t, "no", Client{OriginalHost: "original", Host: "derived"}.strictHostKeyChecking())
+	assert.Equal(t, "ask", Client{OriginalHost: "alias", Host: "derived"}.strictHostKeyChecking())
+}
+
+func TestClientKnownHostsFilesAndKeys(t *testing.T) {
+	knownHostsFile, err := filepath.Abs("testdata/known_hosts")
+	require.NoError(t, err)
+
+	withSSHConfig(t, "Host example.com\n  UserKnownHostsFile "+knownHostsFile+"\n")
+
+	client := Client{OriginalHost: "example.com", Host: "example.com"}
+
+	assert.Contains(t, client.knownHostsFiles(), knownHostsFile)
+	assert.NotEmpty(t, client.knownHostKeys(t.Context()))
+}
+
+func TestClientIdentityFile(t *testing.T) {
+	identityFile := filepath.Join(t.TempDir(), "id_rsa")
+	require.NoError(t, os.WriteFile(identityFile, []byte("not a key"), 0600))
+
+	withSSHConfig(t, `
+Host original
+  IdentityFile /missing/key
+Host derived
+  IdentityFile `+identityFile+`
+`)
+
+	client := Client{OriginalHost: "original", Host: "derived"}
+
+	assert.Equal(t, identityFile, client.identityFile())
+}
+
+func TestClientSignerForIdentityErr(t *testing.T) {
+	identityFile := filepath.Join(t.TempDir(), "id_rsa")
+	require.NoError(t, os.WriteFile(identityFile, []byte("not a key"), 0600))
+
+	withSSHConfig(t, "Host original\n  IdentityFile "+identityFile+"\n")
+
+	signer, err := Client{OriginalHost: "original", Host: "original"}.signerForIdentity(t.Context())
+
+	require.Error(t, err)
+	assert.Nil(t, signer)
+	assert.Contains(t, err.Error(), "failed to parse private key")
+}
+
+func TestWarnIfUsingRevokedHostKeys(t *testing.T) {
+	withSSHConfig(t, "Host original\n  RevokedHostKeys revoked_keys\n")
+
+	var logs bytes.Buffer
+
+	ctx := log.ToContext(context.Background(), log.New(&logs))
+
+	Client{OriginalHost: "original", Host: "original"}.warnIfUsingRevokedHostKeys(ctx)
+
+	assert.Contains(t, logs.String(), "RevokedHostKeys is not supported")
+}
+
+func TestHostKeyAlias(t *testing.T) {
+	withSSHConfig(t, `
+Host original
+  HostKeyAlias alias-original
+Host derived
+  HostKeyAlias alias-derived
+`)
+
+	assert.Equal(t, "alias-original", hostKeyAlias(t.Context(), "original", "derived"))
+	assert.Equal(t, "alias-derived", hostKeyAlias(t.Context(), "alias", "derived"))
+}
+
+func TestWithDetectionSkipsInvalidRemoteAndKeepsLocal(t *testing.T) {
+	handle := WithDetection()(func(_ context.Context, hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+		require.Len(t, hh, 1)
+		assert.Equal(t, "/tmp/local.go", hh[0].Entity)
+
+		return []heartbeat.Result{{Status: 201}}, nil
+	})
+
+	results, err := handle(t.Context(), []heartbeat.Heartbeat{
+		{Entity: "/tmp/local.go", EntityType: heartbeat.FileType},
+		{Entity: "ssh://%zz/tmp/main.go", EntityType: heartbeat.FileType},
+	})
+
+	require.NoError(t, err)
+	assert.Len(t, results, 1)
+}
+
+func TestDeleteLocalFileMissing(t *testing.T) {
+	assert.NotPanics(t, func() {
+		deleteLocalFile(t.Context(), filepath.Join(t.TempDir(), "missing.go"))
+	})
+}
+
+func TestNewClientParsesURLAndSSHConfig(t *testing.T) {
+	withSSHConfig(t, `
+Host original
+  HostName derived
+  Port 2200
+  HostKeyAlias alias
+`)
+
+	client, err := NewClient(t.Context(), "sftp://user:pass@original:2222/tmp/main.go")
+	require.NoError(t, err)
+	assert.Equal(t, "user", client.User)
+	assert.Equal(t, "pass", client.Pass)
+	assert.Equal(t, "original", client.OriginalHost)
+	assert.Equal(t, "derived", client.Host)
+	assert.Equal(t, 2222, client.Port)
+	assert.Equal(t, "/tmp/main.go", client.Path)
+	assert.Equal(t, "alias", client.HostKeyAlias)
+
+	client, err = NewClient(t.Context(), "ssh://original/tmp/main.go")
+	require.NoError(t, err)
+	assert.Equal(t, 2200, client.Port)
+
+	_, err = NewClient(t.Context(), "ssh://%zz/tmp/main.go")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse remote file url")
+}
+
+func TestConnectStrictHostKeyWithoutKnownKey(t *testing.T) {
+	withSSHConfig(t, `
+Host original
+  StrictHostKeyChecking yes
+`)
+
+	sshClient, sftpClient, err := Client{OriginalHost: "original", Host: "original", Port: 22}.Connect(t.Context())
+
+	require.Error(t, err)
+	assert.Nil(t, sshClient)
+	assert.Nil(t, sftpClient)
+	assert.Contains(t, err.Error(), "known host key not found")
+}
+
+func withSSHConfig(t *testing.T, contents string) {
+	t.Helper()
+
+	oldSettings := ssh_config.DefaultUserSettings
+
+	t.Cleanup(func() {
+		ssh_config.DefaultUserSettings = oldSettings
+	})
+
+	configFile := filepath.Join(t.TempDir(), "ssh_config")
+	require.NoError(t, os.WriteFile(configFile, []byte(contents), 0600))
+
+	ssh_config.DefaultUserSettings = &ssh_config.UserSettings{
+		IgnoreErrors: false,
+	}
+	ssh_config.DefaultUserSettings.ConfigFinder(func() string {
+		return configFile
+	})
 }

--- a/pkg/vipertools/vipertools_test.go
+++ b/pkg/vipertools/vipertools_test.go
@@ -1,7 +1,9 @@
 package vipertools_test
 
 import (
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/wakatime/wakatime-cli/pkg/vipertools"
 
@@ -9,6 +11,21 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestNew(t *testing.T) {
+	v, err := vipertools.New()
+	require.NoError(t, err)
+	require.NotNil(t, v)
+
+	v.SetConfigType("ini")
+	require.NoError(t, v.ReadConfig(strings.NewReader("[settings]\ndebug=true\n")))
+
+	assert.True(t, v.GetBool("settings.debug"))
+}
+
+func TestMustNew(t *testing.T) {
+	assert.NotNil(t, vipertools.MustNew())
+}
 
 func TestFirstNonEmptyBool(t *testing.T) {
 	v := viper.New()
@@ -163,4 +180,18 @@ func TestGetStringMapString_NotFound(t *testing.T) {
 
 	m := vipertools.GetStringMapString(v, "internal")
 	assert.Equal(t, map[string]string{}, m)
+}
+
+func TestSafeTimeParse(t *testing.T) {
+	parsed, err := vipertools.SafeTimeParse(time.RFC3339, "2026-06-24T18:00:00Z")
+	require.NoError(t, err)
+
+	assert.Equal(t, time.Date(2026, 6, 24, 18, 0, 0, 0, time.UTC), parsed)
+}
+
+func TestSafeTimeParseErr(t *testing.T) {
+	parsed, err := vipertools.SafeTimeParse(time.RFC3339, "not-a-time")
+	require.Error(t, err)
+
+	assert.True(t, parsed.IsZero())
 }


### PR DESCRIPTION
- Added coverage for cmd command dispatch, heartbeat handling, and offline command paths.
- Expanded tests across AI parsers and helpers, including Codex, Copilot, Gemini, Qwen, Windsurf, OpenCode, Qoder, Continue, Pi, Amp, Goose, Cline, and Roo.
- Added coverage for API diagnostics/options, offline queue behavior, project detection helpers, lexer registration, params, regex, logging, filestats, and heartbeat formatting.
- Adjusted command tests to avoid Windows log file handle cleanup issues by logging to stdout.