### PR TITLE
Improve test coverage edge cases

### DIFF
--- a/pkg/ai/ai_internal_test.go
+++ b/pkg/ai/ai_internal_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -166,6 +167,29 @@ func TestSendAIPanicDiagnosticsErrorBranches(t *testing.T) {
 	err = sendAIPanicDiagnostics(t.Context(), v, aiPanicReport{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to set up ssl cert file option")
+
+	v = newDiagnosticViper("http://127.0.0.1")
+	v.Set("proxy", "%")
+
+	err = sendAIPanicDiagnostics(t.Context(), v, aiPanicReport{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to set up proxy option")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer server.Close()
+
+	v = newDiagnosticViper(server.URL)
+	v.Set("no-ssl-verify", true)
+	require.NoError(t, sendAIPanicDiagnostics(t.Context(), v, aiPanicReport{}))
+
+	certFile := filepath.Join(t.TempDir(), "ca.pem")
+	require.NoError(t, os.WriteFile(certFile, []byte("not a cert"), 0600))
+
+	v = newDiagnosticViper(server.URL)
+	v.Set("ssl-certs-file", certFile)
+	require.NoError(t, sendAIPanicDiagnostics(t.Context(), v, aiPanicReport{}))
 }
 
 func newDiagnosticViper(apiURL string) *viper.Viper {

--- a/pkg/ai/helpers_more_internal_test.go
+++ b/pkg/ai/helpers_more_internal_test.go
@@ -2,6 +2,7 @@ package ai
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -668,6 +669,126 @@ func TestCodexPatchDecodeBranches(t *testing.T) {
 	assert.False(t, codexToolCallSucceeded(json.RawMessage(`"invalid patch"`)))
 	assert.False(t, codexToolCallSucceeded(json.RawMessage(`[{"text":"tool failed"}]`)))
 	assert.True(t, codexToolCallSucceeded(json.RawMessage(`123`)))
+}
+
+func TestCodexAdditionalHelperBranches(t *testing.T) {
+	base := t.TempDir()
+	parser := Codex{FallbackUserAgent: "fallback/1.0"}
+
+	assert.Empty(t, codexStripHarnessPrefix("   "))
+	assert.Empty(t, codexStripHarnessPrefix("<bad"))
+	assert.Empty(t, codexStripHarnessPrefix("</bad>"))
+	assert.Empty(t, codexStripHarnessPrefix("<tag>missing close"))
+	assert.Equal(t, "request", codexUserMessageText("<system>ignore</system> request"))
+	assert.Equal(t, "actual request", codexUserMessageText(strings.Join([]string{
+		"# Context from my IDE setup:",
+		"ignored",
+		"## My request for Codex:",
+		"actual request",
+	}, "\n")))
+
+	assert.Empty(t, codexFilePath(base, "*** Unknown File: main.go"))
+	assert.Empty(t, codexFilePath(base, "*** Add File: "))
+	assert.Equal(t, filepath.Join(base, "main.go"), codexFilePath(base, "*** Add File: main.go"))
+	assert.Equal(t, "/tmp/main.go", codexFilePath(base, "*** Delete File: /tmp/main.go"))
+	assert.Empty(t, codexMoveFilePath(base, "*** Move from: old.go"))
+	assert.Empty(t, codexMoveFilePath(base, "*** Move to: "))
+	assert.Equal(t, filepath.Join(base, "new.go"), codexMoveFilePath(base, "*** Move to: new.go"))
+	assert.Equal(t, "/tmp/new.go", codexMoveFilePath(base, "*** Move to: /tmp/new.go"))
+
+	assert.Empty(t, codexSourceEditor("", ""))
+	assert.Equal(t, "codex-cli/unknown", codexSourceEditor("cli", ""))
+	assert.Equal(t, "codex-cli/1.2.3", codexSourceEditor("cli", "1.2.3"))
+	assert.Equal(t, "vs-code-wakatime/unknown", codexSourceEditor(" VS Code ", ""))
+	assert.Empty(t, codexSourceProduct(" / \\ "))
+
+	callID := "call-1"
+	payloadType := "custom_tool_call"
+	name := "apply_patch"
+	input := "*** Begin Patch\n*** Add File: main.go\n+one\n*** End Patch"
+	state := &codexParseState{pendingPatches: map[string]codexPendingPatch{}}
+	session := codexSessionState{cwd: base, id: "session-1", version: "0.1.0", source: "cli"}
+
+	heartbeats, handled := parser.handlePendingPatch(codexLogLine{}, session, state)
+	assert.False(t, handled)
+	assert.Nil(t, heartbeats)
+
+	heartbeats, handled = parser.handlePendingPatch(codexLogLine{Payload: &codexPayload{
+		Type: &payloadType,
+	}}, session, state)
+	assert.False(t, handled)
+	assert.Nil(t, heartbeats)
+
+	emptyCallID := " "
+	heartbeats, handled = parser.handlePendingPatch(codexLogLine{Payload: &codexPayload{
+		Type:   &payloadType,
+		CallID: &emptyCallID,
+	}}, session, state)
+	assert.False(t, handled)
+	assert.Nil(t, heartbeats)
+
+	heartbeats, handled = parser.handlePendingPatch(codexLogLine{Payload: &codexPayload{
+		Type:   &payloadType,
+		CallID: &callID,
+		Name:   &name,
+		Input:  &input,
+	}}, session, state)
+	assert.True(t, handled)
+	assert.Nil(t, heartbeats)
+	assert.Contains(t, state.pendingPatches, callID)
+
+	unknownType := "unknown"
+	heartbeats, handled = parser.handlePendingPatch(codexLogLine{Payload: &codexPayload{
+		Type:   &unknownType,
+		CallID: &callID,
+	}}, session, state)
+	assert.False(t, handled)
+	assert.Nil(t, heartbeats)
+
+	endType := "patch_apply_end"
+	success := false
+	heartbeats, handled = parser.handlePendingPatch(codexLogLine{Payload: &codexPayload{
+		Type:    &endType,
+		CallID:  &callID,
+		Success: &success,
+	}}, session, state)
+	assert.True(t, handled)
+	assert.Nil(t, heartbeats)
+	assert.NotContains(t, state.pendingPatches, callID)
+
+	state.pendingPatches[callID] = codexPendingPatch{
+		inputs:            []string{input},
+		cwd:               base,
+		sessionID:         "session-1",
+		fallbackUserAgent: "fallback/1.0",
+	}
+	outputType := "custom_tool_call_output"
+	heartbeats, handled = parser.handlePendingPatch(codexLogLine{Payload: &codexPayload{
+		Type:   &outputType,
+		CallID: &callID,
+		Output: json.RawMessage(`"invalid patch"`),
+	}}, session, state)
+	assert.True(t, handled)
+	assert.Nil(t, heartbeats)
+	assert.NotContains(t, state.pendingPatches, callID)
+
+	state.pendingPatches[callID] = codexPendingPatch{
+		inputs:            []string{input},
+		cwd:               base,
+		sessionID:         "session-1",
+		fallbackUserAgent: "fallback/1.0",
+	}
+	heartbeats, handled = parser.handlePendingPatch(codexLogLine{
+		Timestamp: time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC),
+		Payload: &codexPayload{
+			Type:   &outputType,
+			CallID: &callID,
+			Output: json.RawMessage(`"done"`),
+		},
+	}, session, state)
+	assert.True(t, handled)
+	require.NotEmpty(t, heartbeats)
+	assert.Equal(t, filepath.Join(base, "main.go"), heartbeats[0].Entity)
 }
 
 func TestQwenCodeHelperBranches(t *testing.T) {
@@ -1610,6 +1731,126 @@ func TestOpenCodeAdditionalBranches(t *testing.T) {
 	assert.Empty(t, openCodePatchFilePath("/workspace", "*** Unknown File: rel.go"))
 }
 
+func TestOpenCodeLegacyAndSQLiteBranches(t *testing.T) {
+	parser := OpenCode{FallbackUserAgent: "fallback/1.0", After: time.UnixMilli(2000)}
+
+	dataRoot := t.TempDir()
+	sessionsDir := filepath.Join(dataRoot, "storage", "session")
+	require.NoError(t, os.MkdirAll(filepath.Join(sessionsDir, "ignored-dir"), 0700))
+	require.NoError(t, os.WriteFile(filepath.Join(sessionsDir, "ignored.txt"), []byte(`{}`), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(sessionsDir, "bad.json"), []byte(`{`), 0600))
+
+	_, err := parser.parseLegacyRoot(dataRoot)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to walk OpenCode sessions directory")
+
+	require.NoError(t, os.Remove(filepath.Join(sessionsDir, "bad.json")))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(sessionsDir, "old.json"),
+		[]byte(`{"id":"old","time":{"updated":1000}}`),
+		0600,
+	))
+	require.NoError(t, os.WriteFile(filepath.Join(sessionsDir, "zero.json"), []byte(`{"id":"zero"}`), 0600))
+
+	legacy, err := parser.parseLegacyRoot(dataRoot)
+	require.NoError(t, err)
+	assert.Nil(t, legacy)
+
+	_, err = parser.parseLegacySession(filepath.Join(dataRoot, "missing.json"))
+	require.Error(t, err)
+
+	messageDataRoot := t.TempDir()
+	sessionPath := filepath.Join(messageDataRoot, "storage", "session", "session.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(sessionPath), 0700))
+	require.NoError(t, os.WriteFile(sessionPath, []byte(`{"id":"session-1"}`), 0600))
+	require.NoError(t, os.MkdirAll(filepath.Join(messageDataRoot, "message"), 0700))
+	require.NoError(t, os.WriteFile(filepath.Join(messageDataRoot, "message", "session-1"), []byte("file"), 0600))
+
+	_, err = parser.parseLegacySession(sessionPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read OpenCode messages directory")
+
+	require.NoError(t, os.Remove(filepath.Join(messageDataRoot, "message", "session-1")))
+	require.NoError(t, os.MkdirAll(filepath.Join(messageDataRoot, "message", "session-1", "subdir"), 0700))
+	require.NoError(t, os.WriteFile(filepath.Join(messageDataRoot, "message", "session-1", "bad.json"), []byte(`{`), 0600))
+
+	_, err = parser.parseLegacySession(sessionPath)
+	require.Error(t, err)
+
+	require.NoError(t, os.WriteFile(
+		filepath.Join(messageDataRoot, "message", "session-1", "bad.json"),
+		[]byte(`{"id":"message-1","role":"user","time":{"created":3000}}`),
+		0600,
+	))
+	require.NoError(t, os.MkdirAll(filepath.Join(messageDataRoot, "part", "message-1"), 0700))
+	require.NoError(t, os.WriteFile(filepath.Join(messageDataRoot, "part", "message-1", "bad.json"), []byte(`{`), 0600))
+
+	_, err = parser.parseLegacySession(sessionPath)
+	require.Error(t, err)
+
+	dbPath := filepath.Join(t.TempDir(), "opencode.db")
+
+	db := openOpenCodeTestDB(t, dbPath)
+	defer db.Close()
+
+	_, err = queryOpenCodeSQLiteSessions(context.Background(), db, dbPath)
+	require.Error(t, err)
+
+	require.NoError(t, execOpenCodeSQL(db, `
+CREATE TABLE session (id TEXT, directory TEXT, version TEXT);
+CREATE TABLE message (id TEXT, session_id TEXT, data TEXT, time_created INTEGER);
+CREATE TABLE part (id TEXT, message_id TEXT, session_id TEXT, data TEXT, time_created INTEGER);
+INSERT INTO message VALUES ('bad-json', 's1', '123', 3000);
+INSERT INTO message VALUES ('old-by-payload', 's1', '{"id":"old","time":{"created":1000}}', 3000);
+INSERT INTO message VALUES ('m1', 's1', '{"role":"user"}', 3000);
+INSERT INTO message VALUES ('other-seed', 'other', '{"id":"other","sessionID":"other"}', 1900);
+INSERT INTO message VALUES ('bad-seed', 's1', '123', 1800);
+INSERT INTO message VALUES ('zero-seed', 's1', '{"id":"zero-seed"}', 0);
+INSERT INTO message VALUES ('seed', 's1', '{"id":"seed","sessionID":"s1"}', 1600);
+INSERT INTO part VALUES ('skip', 'unknown', 's1', '{"type":"text","text":"skip"}', 3000);
+INSERT INTO part VALUES ('bad-part', 'm1', 's1', '123', 3001);
+INSERT INTO part VALUES ('p1', 'm1', 's1', '{"type":"text","text":"hello"}', 3002);
+`))
+
+	messagesBySession, messageIDs, err := parser.querySQLiteMessages(context.Background(), db, dbPath)
+	require.NoError(t, err)
+	assert.Contains(t, messageIDs, "m1")
+	require.NoError(t, queryOpenCodeSQLiteParts(context.Background(), db, dbPath, messagesBySession, messageIDs))
+
+	heartbeats, err := parser.parseSQLiteDB(context.Background(), dbPath)
+	require.NoError(t, err)
+	require.NotEmpty(t, heartbeats)
+	assert.Equal(t, "OpenCode s1", heartbeats[0].Entity)
+
+	missingMessageDB := openOpenCodeTestDB(t, filepath.Join(t.TempDir(), "missing-message.db"))
+	defer missingMessageDB.Close()
+
+	require.NoError(t, execOpenCodeSQL(missingMessageDB, `CREATE TABLE session (id TEXT, directory TEXT, version TEXT);`))
+	_, _, err = parser.querySQLiteMessages(context.Background(), missingMessageDB, "missing-message.db")
+	require.Error(t, err)
+
+	missingPartPath := filepath.Join(t.TempDir(), "missing-part.db")
+
+	missingPartDB := openOpenCodeTestDB(t, missingPartPath)
+	defer missingPartDB.Close()
+
+	require.NoError(t, execOpenCodeSQL(missingPartDB, `
+CREATE TABLE session (id TEXT, directory TEXT, version TEXT);
+CREATE TABLE message (id TEXT, session_id TEXT, data TEXT, time_created INTEGER);
+INSERT INTO message VALUES ('m1', 's1', '{"role":"user"}', 3000);
+`))
+
+	_, err = parser.parseSQLiteDB(context.Background(), missingPartPath)
+	require.Error(t, err)
+
+	require.Error(t, parser.querySQLiteSeedMessages(
+		context.Background(),
+		missingMessageDB,
+		"missing-message.db",
+		map[string][]openCodeMessageWithParts{"s1": nil},
+	))
+}
+
 func TestQwenCodeAdditionalBranches(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -1869,4 +2110,19 @@ func mustJSON(t *testing.T, value interface{}) string {
 	require.NoError(t, err)
 
 	return string(encoded)
+}
+
+func openOpenCodeTestDB(t *testing.T, dbPath string) *sql.DB {
+	t.Helper()
+
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+
+	return db
+}
+
+func execOpenCodeSQL(db *sql.DB, statement string) error {
+	_, err := db.Exec(statement)
+
+	return err
 }

--- a/pkg/api/endpoints_internal_test.go
+++ b/pkg/api/endpoints_internal_test.go
@@ -1,0 +1,89 @@
+package api
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEndpointReadAndParseErrors(t *testing.T) {
+	t.Run("today read error", func(t *testing.T) {
+		c := clientWithResponse(http.StatusOK, errorReadCloser{})
+
+		_, err := c.Today(t.Context())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to read response body")
+	})
+
+	t.Run("today parse error", func(t *testing.T) {
+		c := clientWithResponse(http.StatusOK, io.NopCloser(strings.NewReader(`{`)))
+
+		_, err := c.Today(t.Context())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse results")
+	})
+
+	t.Run("goal read error", func(t *testing.T) {
+		c := clientWithResponse(http.StatusOK, errorReadCloser{})
+
+		_, err := c.Goal(t.Context(), "goal")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to read response body")
+	})
+
+	t.Run("goal parse error", func(t *testing.T) {
+		c := clientWithResponse(http.StatusOK, io.NopCloser(strings.NewReader(`{`)))
+
+		_, err := c.Goal(t.Context(), "goal")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse results")
+	})
+
+	t.Run("file experts read error", func(t *testing.T) {
+		c := clientWithResponse(http.StatusOK, errorReadCloser{})
+
+		_, err := c.FileExperts(t.Context(), []heartbeat.Heartbeat{{APIKey: "key", Entity: "main.go"}})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed reading response body")
+	})
+
+	t.Run("file experts parse error", func(t *testing.T) {
+		c := clientWithResponse(http.StatusOK, io.NopCloser(strings.NewReader(`{`)))
+
+		_, err := c.FileExperts(t.Context(), []heartbeat.Heartbeat{{APIKey: "key", Entity: "main.go"}})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse results")
+	})
+}
+
+func TestParseEndpointResponsesInvalidJSON(t *testing.T) {
+	_, err := ParseStatusBarResponse([]byte(`{`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse json response body")
+
+	_, err = ParseGoalResponse([]byte(`{`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse json response body")
+
+	_, err = ParseFileExpertsResponse([]byte(`{`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse json response body")
+}
+
+func clientWithResponse(status int, body io.ReadCloser) *Client {
+	c := NewClient(BaseURL)
+	c.doFunc = func(*Client, *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: status,
+			Body:       body,
+		}, nil
+	}
+
+	return c
+}

--- a/pkg/api/heartbeat_internal_test.go
+++ b/pkg/api/heartbeat_internal_test.go
@@ -1,223 +1,110 @@
 package api
 
 import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestGroupByAPIURLAndKey(t *testing.T) {
-	tests := map[string]struct {
-		Input    []heartbeat.Heartbeat
-		Expected map[string][]heartbeat.Heartbeat
-	}{
-		"empty slice": {
-			Input:    []heartbeat.Heartbeat{},
-			Expected: map[string][]heartbeat.Heartbeat{},
-		},
-		"single heartbeat": {
-			Input: []heartbeat.Heartbeat{
-				{
-					Entity: "/path/to/file.go",
-					APIURL: "https://api.wakatime.com/api/v1",
-					APIKey: "00000000-0000-4000-8000-000000000000",
-				},
-			},
-			Expected: map[string][]heartbeat.Heartbeat{
-				"https://api.wakatime.com/api/v1|00000000-0000-4000-8000-000000000000": {
-					{
-						Entity: "/path/to/file.go",
-						APIURL: "https://api.wakatime.com/api/v1",
-						APIKey: "00000000-0000-4000-8000-000000000000",
-					},
-				},
-			},
-		},
-		"multiple heartbeats same url and key": {
-			Input: []heartbeat.Heartbeat{
-				{
-					Entity: "/path/to/file1.go",
-					APIURL: "https://api.wakatime.com/api/v1",
-					APIKey: "00000000-0000-4000-8000-000000000000",
-				},
-				{
-					Entity: "/path/to/file2.go",
-					APIURL: "https://api.wakatime.com/api/v1",
-					APIKey: "00000000-0000-4000-8000-000000000000",
-				},
-			},
-			Expected: map[string][]heartbeat.Heartbeat{
-				"https://api.wakatime.com/api/v1|00000000-0000-4000-8000-000000000000": {
-					{
-						Entity: "/path/to/file1.go",
-						APIURL: "https://api.wakatime.com/api/v1",
-						APIKey: "00000000-0000-4000-8000-000000000000",
-					},
-					{
-						Entity: "/path/to/file2.go",
-						APIURL: "https://api.wakatime.com/api/v1",
-						APIKey: "00000000-0000-4000-8000-000000000000",
-					},
-				},
-			},
-		},
-		"multiple heartbeats different urls": {
-			Input: []heartbeat.Heartbeat{
-				{
-					Entity: "/path/to/file1.go",
-					APIURL: "https://api.wakatime.com/api/v1",
-					APIKey: "00000000-0000-4000-8000-000000000000",
-				},
-				{
-					Entity: "/path/to/file2.go",
-					APIURL: "https://custom.example.com/api/v1",
-					APIKey: "00000000-0000-4000-8000-000000000001",
-				},
-			},
-			Expected: map[string][]heartbeat.Heartbeat{
-				"https://api.wakatime.com/api/v1|00000000-0000-4000-8000-000000000000": {
-					{
-						Entity: "/path/to/file1.go",
-						APIURL: "https://api.wakatime.com/api/v1",
-						APIKey: "00000000-0000-4000-8000-000000000000",
-					},
-				},
-				"https://custom.example.com/api/v1|00000000-0000-4000-8000-000000000001": {
-					{
-						Entity: "/path/to/file2.go",
-						APIURL: "https://custom.example.com/api/v1",
-						APIKey: "00000000-0000-4000-8000-000000000001",
-					},
-				},
-			},
-		},
-		"same url different keys": {
-			Input: []heartbeat.Heartbeat{
-				{
-					Entity: "/path/to/file1.go",
-					APIURL: "https://api.wakatime.com/api/v1",
-					APIKey: "00000000-0000-4000-8000-000000000000",
-				},
-				{
-					Entity: "/path/to/file2.go",
-					APIURL: "https://api.wakatime.com/api/v1",
-					APIKey: "00000000-0000-4000-8000-000000000001",
-				},
-			},
-			Expected: map[string][]heartbeat.Heartbeat{
-				"https://api.wakatime.com/api/v1|00000000-0000-4000-8000-000000000000": {
-					{
-						Entity: "/path/to/file1.go",
-						APIURL: "https://api.wakatime.com/api/v1",
-						APIKey: "00000000-0000-4000-8000-000000000000",
-					},
-				},
-				"https://api.wakatime.com/api/v1|00000000-0000-4000-8000-000000000001": {
-					{
-						Entity: "/path/to/file2.go",
-						APIURL: "https://api.wakatime.com/api/v1",
-						APIKey: "00000000-0000-4000-8000-000000000001",
-					},
-				},
-			},
-		},
-		"mixed grouping": {
-			Input: []heartbeat.Heartbeat{
-				{
-					Entity: "/work/file1.go",
-					APIURL: "https://work.example.com/api/v1",
-					APIKey: "00000000-0000-4000-8000-000000000001",
-				},
-				{
-					Entity: "/home/file1.go",
-					APIURL: "https://api.wakatime.com/api/v1",
-					APIKey: "00000000-0000-4000-8000-000000000000",
-				},
-				{
-					Entity: "/work/file2.go",
-					APIURL: "https://work.example.com/api/v1",
-					APIKey: "00000000-0000-4000-8000-000000000001",
-				},
-				{
-					Entity: "/home/file2.go",
-					APIURL: "https://api.wakatime.com/api/v1",
-					APIKey: "00000000-0000-4000-8000-000000000000",
-				},
-			},
-			Expected: map[string][]heartbeat.Heartbeat{
-				"https://work.example.com/api/v1|00000000-0000-4000-8000-000000000001": {
-					{
-						Entity: "/work/file1.go",
-						APIURL: "https://work.example.com/api/v1",
-						APIKey: "00000000-0000-4000-8000-000000000001",
-					},
-					{
-						Entity: "/work/file2.go",
-						APIURL: "https://work.example.com/api/v1",
-						APIKey: "00000000-0000-4000-8000-000000000001",
-					},
-				},
-				"https://api.wakatime.com/api/v1|00000000-0000-4000-8000-000000000000": {
-					{
-						Entity: "/home/file1.go",
-						APIURL: "https://api.wakatime.com/api/v1",
-						APIKey: "00000000-0000-4000-8000-000000000000",
-					},
-					{
-						Entity: "/home/file2.go",
-						APIURL: "https://api.wakatime.com/api/v1",
-						APIKey: "00000000-0000-4000-8000-000000000000",
-					},
-				},
-			},
-		},
-	}
+type errorReadCloser struct{}
 
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
-			result := groupByAPIURLAndKey(test.Input)
-
-			assert.Equal(t, test.Expected, result)
-		})
-	}
+func (errorReadCloser) Read([]byte) (int, error) {
+	return 0, errors.New("read failed")
 }
 
-func TestSortKeys(t *testing.T) {
-	tests := map[string]struct {
-		Input    map[string][]heartbeat.Heartbeat
-		Expected []string
-	}{
-		"empty map": {
-			Input:    map[string][]heartbeat.Heartbeat{},
-			Expected: []string{},
-		},
-		"single key": {
-			Input: map[string][]heartbeat.Heartbeat{
-				"https://api.wakatime.com/api/v1|key1": {},
-			},
-			Expected: []string{"https://api.wakatime.com/api/v1|key1"},
-		},
-		"multiple keys sorted": {
-			Input: map[string][]heartbeat.Heartbeat{
-				"https://z.example.com/api/v1|key1": {},
-				"https://a.example.com/api/v1|key2": {},
-				"https://m.example.com/api/v1|key3": {},
-			},
-			Expected: []string{
-				"https://a.example.com/api/v1|key2",
-				"https://m.example.com/api/v1|key3",
-				"https://z.example.com/api/v1|key1",
-			},
-		},
-	}
+func (errorReadCloser) Close() error {
+	return nil
+}
 
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
-			result := sortKeys(test.Input)
+func TestParseHeartbeatResponsesBranches(t *testing.T) {
+	_, err := ParseHeartbeatResponses(t.Context(), []byte(`{`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse json response body")
 
-			assert.Equal(t, test.Expected, result)
-		})
-	}
+	_, err = ParseHeartbeatResponses(t.Context(), []byte(`{"responses":[[{}, "bad"]]}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed parsing result #0")
+
+	_, err = parseHeartbeatResponse(t.Context(), []json.RawMessage{jsonRaw(`{}`), jsonRaw(`"bad"`)})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse json status")
+
+	_, err = parseHeartbeatResponse(t.Context(), []json.RawMessage{jsonRaw(`{`), jsonRaw(`201`)})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse json heartbeat")
+
+	_, err = parseHeartbeatResponse(t.Context(), []json.RawMessage{jsonRaw(`{`), jsonRaw(`500`)})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse result errors")
+
+	result, err := parseHeartbeatResponse(t.Context(), []json.RawMessage{
+		jsonRaw(`{"errors":{"dependencies":["skip"],"entity":["bad","missing"]}}`),
+		jsonRaw(`400`),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 400, result.Status)
+	assert.Equal(t, []string{"entity: bad missing"}, result.Errors)
+}
+
+func TestClientSendHeartbeatsInternalBranches(t *testing.T) {
+	t.Run("response body read error", func(t *testing.T) {
+		c := NewClient(BaseURL)
+		c.doFunc = func(*Client, *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusCreated,
+				Body:       errorReadCloser{},
+			}, nil
+		}
+
+		_, err := c.SendHeartbeats(t.Context(), []heartbeat.Heartbeat{{APIKey: "key"}})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed reading response body")
+	})
+
+	t.Run("parse response error", func(t *testing.T) {
+		c := NewClient(BaseURL)
+		c.doFunc = func(*Client, *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusCreated,
+				Body:       io.NopCloser(strings.NewReader(`{`)),
+			}, nil
+		}
+
+		_, err := c.SendHeartbeats(t.Context(), []heartbeat.Heartbeat{{APIKey: "key"}})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed parsing results")
+	})
+
+	t.Run("extra results are not assigned heartbeats", func(t *testing.T) {
+		c := NewClient(BaseURL)
+		c.doFunc = func(*Client, *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusCreated,
+				Body: io.NopCloser(strings.NewReader(`{"responses":[` +
+					`[{"data":{"id":"first"}},201],` +
+					`[{"data":{"id":"extra"}},201]` +
+					`]}`)),
+			}, nil
+		}
+
+		input := heartbeat.Heartbeat{APIKey: "key", Entity: "main.go"}
+		results, err := c.SendHeartbeats(context.Background(), []heartbeat.Heartbeat{input})
+		require.NoError(t, err)
+		require.Len(t, results, 2)
+		assert.Equal(t, input, results[0].Heartbeat)
+		assert.Empty(t, results[1].Heartbeat)
+	})
+}
+
+func jsonRaw(value string) json.RawMessage {
+	return json.RawMessage(value)
 }

--- a/pkg/api/option_internal_test.go
+++ b/pkg/api/option_internal_test.go
@@ -198,3 +198,54 @@ func TestWithSSLCertFile(t *testing.T) {
 	_, err = WithSSLCertFile(t.Context(), certFile+".missing")
 	require.Error(t, err)
 }
+
+func TestOptionErrorBranches(t *testing.T) {
+	_, err := WithAuth(BasicAuth{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to retrieve auth header value")
+
+	noop, err := WithNTLM("invalid")
+	require.Error(t, err)
+	assert.NotNil(t, noop)
+	assert.Contains(t, err.Error(), "invalid ntlm credentials format")
+
+	noop, err = WithNTLMRequestRetry(t.Context(), "invalid")
+	require.Error(t, err)
+	assert.NotNil(t, noop)
+	assert.Contains(t, err.Error(), "invalid ntlm credentials format")
+
+	_, err = WithProxy("%")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse proxy url")
+
+	client := NewClient("https://example.com")
+	transport := LazyCreateNewTransport(nil)
+	require.NotNil(t, transport)
+	assert.NotSame(t, client.client.Transport, transport)
+
+	opt, err := WithProxy("http://proxy.example.com")
+	require.NoError(t, err)
+	opt(client)
+}
+
+func TestWithProxyHTTPSFallbackNonReplayableBody(t *testing.T) {
+	client := NewClient("https://example.com")
+	client.doFunc = func(*Client, *http.Request) (*http.Response, error) {
+		return nil, errors.New("proxyconnect tcp: server gave HTTP response to HTTPS client")
+	}
+
+	opt, err := WithProxy("https://proxy.example.com")
+	require.NoError(t, err)
+	opt(client)
+
+	req, err := http.NewRequest(
+		http.MethodPost,
+		"https://example.com",
+		io.NopCloser(strings.NewReader("body")),
+	)
+	require.NoError(t, err)
+
+	err = doAndClose(t, client, req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "proxyconnect tcp")
+}

--- a/pkg/deps/deps_internal_test.go
+++ b/pkg/deps/deps_internal_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/alecthomas/chroma/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -47,4 +48,294 @@ func TestParseDependencies_Error(t *testing.T) {
 
 	require.EqualError(t, err, "failed")
 	assert.Nil(t, dependencies)
+}
+
+func TestParserStateMachineBranches(t *testing.T) {
+	t.Run("javascript", func(t *testing.T) {
+		p := &ParserJavaScript{}
+		p.init()
+
+		p.processKeywordReserved("import")
+		p.processPunctuation(";")
+		assert.Equal(t, StateJavaScriptUnknown, p.State)
+
+		p.processKeywordReserved("import")
+		p.processLiteralStringSingle(`"../pkg/example.ts"`)
+		assert.Equal(t, []string{"example"}, p.Output)
+
+		p.processKeywordReserved("const")
+		assert.Equal(t, StateJavaScriptUnknown, p.State)
+	})
+
+	t.Run("python", func(t *testing.T) {
+		p := &ParserPython{}
+		p.init()
+
+		p.append("")
+		p.append("os")
+		p.append("requests.sessions")
+		assert.Equal(t, []string{"requests"}, p.Output)
+
+		p.processKeywordNamespace("import")
+		p.processNameNamespace("numpy")
+		p.processOperator(",")
+		assert.Equal(t, []string{"requests", "numpy"}, p.Output)
+
+		p.processKeywordNamespace("import")
+		p.processNameNamespace("pandas")
+		p.processKeyword("as")
+		assert.Equal(t, []string{"requests", "numpy", "pandas"}, p.Output)
+
+		p.processKeywordNamespace("from")
+		p.processNameNamespace("collections")
+		p.processText("\n")
+		assert.Equal(t, StatePythonUnknown, p.State)
+
+		p.processKeywordNamespace("class")
+		p.processOperator(".")
+		p.processText(" ")
+		assert.Equal(t, StatePythonUnknown, p.State)
+	})
+
+	t.Run("go", func(t *testing.T) {
+		p := &ParserGo{}
+		p.init()
+
+		p.processKeywordNamespace("import")
+		p.processLiteralString(`"fmt"`)
+		assert.Empty(t, p.Output)
+
+		p.processLiteralString(`"github.com/wakatime/wakatime-cli"`)
+		assert.Equal(t, []string{"github.com/wakatime/wakatime-cli"}, p.Output)
+
+		p.processNameFunction()
+		assert.Equal(t, StateGoUnknown, p.State)
+
+		p.processKeywordNamespace("func")
+		assert.Equal(t, StateGoUnknown, p.State)
+	})
+
+	t.Run("vbnet", func(t *testing.T) {
+		p := &ParserVbNet{}
+		p.init()
+
+		p.append("")
+		p.append("System.Text")
+		assert.Empty(t, p.Output)
+
+		p.processKeyword("Imports")
+		p.processName("Newtonsoft")
+		p.processName(".")
+		p.processName("Json")
+		p.processText("\n")
+		assert.Equal(t, []string{"Newtonsoft"}, p.Output)
+
+		p.processKeyword("Imports")
+		p.processName("Alias")
+		p.processOperator("=")
+		p.processName("Custom")
+		p.processPunctuation(".")
+		p.processName("Lib")
+		p.processText("\n")
+		assert.Equal(t, []string{"Newtonsoft", "Custom"}, p.Output)
+
+		p.processOperator("=")
+		p.processPunctuation(".")
+		assert.Equal(t, StateVbNetUnknown, p.State)
+	})
+
+	t.Run("php", func(t *testing.T) {
+		p := &ParserPHP{}
+		p.init()
+
+		p.append("")
+		p.append("app")
+		assert.Empty(t, p.Output)
+
+		p.processKeyword("include")
+		p.processLiteralStringSingle("vendor/autoload.php")
+		assert.Contains(t, p.Output, "vendor/autoload.php")
+
+		p.processKeyword("include")
+		p.processLiteralStringSingle(`'`)
+		assert.Equal(t, StatePHPInclude, p.State)
+
+		p.processLiteralStringDouble("config/bootstrap.php")
+		assert.Contains(t, p.Output, "'config/bootstrap.php'")
+
+		p.processKeyword("use")
+		p.processNameOther(`Vendor\Package\ClassName`)
+		assert.Contains(t, p.Output, "Vendor")
+
+		p.processKeyword("use")
+		p.processKeyword("function")
+		p.processNameFunction(`Helpers\run`)
+		assert.Contains(t, p.Output, "Helpers")
+
+		p.processKeyword("as")
+		p.processPunctuation(",")
+		assert.Equal(t, StatePHPUse, p.State)
+
+		p.processPunctuation(";")
+		assert.Equal(t, StatePHPUnknown, p.State)
+
+		p.processToken(chroma.Token{Type: chroma.Comment, Value: "x"})
+		assert.Equal(t, StatePHPUnknown, p.State)
+	})
+
+	t.Run("c", func(t *testing.T) {
+		p := &ParserC{}
+		p.init()
+
+		p.append("")
+		p.append("stdio.h")
+		assert.Empty(t, p.Output)
+
+		p.processCommentPreprocFile("<ignored.h>")
+		assert.Empty(t, p.Output)
+
+		p.processCommentPreproc(" include")
+		p.processCommentPreprocFile("<vendor/lib.h>")
+		assert.Equal(t, []string{"vendor"}, p.Output)
+		assert.Equal(t, StateCUnknown, p.State)
+
+		p.processCommentPreproc("include")
+		p.processCommentPreprocFile("#")
+		assert.Equal(t, []string{"vendor"}, p.Output)
+	})
+
+	t.Run("cpp", func(t *testing.T) {
+		p := &ParserCPP{}
+		p.init()
+
+		p.append("")
+		p.append("iostream")
+		assert.Empty(t, p.Output)
+
+		p.processCommentPreprocFile("<ignored.hpp>")
+		assert.Empty(t, p.Output)
+
+		p.processCommentPreproc("include")
+		p.processCommentPreprocFile(`"boost/asio.hpp"`)
+		assert.Equal(t, []string{"boost"}, p.Output)
+		assert.Equal(t, StateCPPUnknown, p.State)
+
+		p.processCommentPreproc("include")
+		p.processCommentPreprocFile("\n")
+		assert.Equal(t, []string{"boost"}, p.Output)
+	})
+
+	t.Run("java", func(t *testing.T) {
+		p := &ParserJava{}
+		p.init()
+
+		p.append("java.util")
+		p.append(" ")
+		assert.Empty(t, p.Output)
+
+		p.processKeywordNamespace("class")
+		assert.Equal(t, StateJavaUnknown, p.State)
+
+		p.processKeywordNamespace("import")
+		p.processNameNamespace("static")
+		p.processNameNamespace("com")
+		p.processPunctuation(".")
+		p.processName("example")
+		p.processPunctuation(".")
+		p.processNameAttribute("*")
+		p.processPunctuation(";")
+		assert.Equal(t, []string{"example"}, p.Output)
+
+		p.State = StateJavaImportFinished
+		p.processKeywordNamespace("org.example.library")
+		assert.Equal(t, []string{"example", "example.library"}, p.Output)
+	})
+
+	t.Run("json", func(t *testing.T) {
+		p := &ParserJSON{}
+		p.init()
+
+		p.processFilename("package.json")
+		assert.Equal(t, []string{"npm"}, p.Output)
+
+		p.processPunctuation("{")
+		p.processNameTag(`"dependencies"`)
+		p.processPunctuation("{")
+		p.processNameTag(`"github.com/wakatime/wakatime-cli"`)
+		p.processPunctuation("}")
+		assert.Equal(t, StateJSONUnknown, p.State)
+		assert.Equal(t, []string{"npm", "github.com/wakatime/wakatime-cli"}, p.Output)
+	})
+
+	t.Run("csharp", func(t *testing.T) {
+		p := &ParserCSharp{}
+		p.init()
+
+		p.append("")
+		p.append("System.Text")
+		assert.Empty(t, p.Output)
+
+		p.processName("Ignored")
+		assert.Equal(t, StateCSharpUnknown, p.State)
+
+		p.processKeyword("using")
+		p.processName("Alias")
+		p.processPunctuation("=")
+		p.processName("Newtonsoft")
+		p.processPunctuation(".")
+		p.processName("Json")
+		p.processPunctuation(";")
+		assert.Equal(t, []string{"Newtonsoft"}, p.Output)
+		assert.Equal(t, StateCSharpUnknown, p.State)
+	})
+
+	t.Run("kotlin", func(t *testing.T) {
+		p := &ParserKotlin{}
+		p.init()
+
+		p.append("java.util")
+		p.append("kotlinx.coroutines.*")
+		assert.Equal(t, []string{"kotlinx.coroutines"}, p.Output)
+
+		p.processKeyword("import")
+		p.processNameNamespace("com.example.lib")
+		assert.Equal(t, []string{"kotlinx.coroutines", "com.example"}, p.Output)
+
+		p.processKeyword("class")
+		assert.Equal(t, StateKotlinUnknown, p.State)
+		p.processToken(chroma.Token{Type: chroma.Punctuation, Value: ";"})
+		assert.Equal(t, StateKotlinUnknown, p.State)
+	})
+
+	t.Run("rust", func(t *testing.T) {
+		p := &ParserRust{}
+		p.init()
+
+		p.processKeyword("crate")
+		p.processName("ignored")
+		assert.Empty(t, p.Output)
+
+		p.processKeyword("extern")
+		p.processKeyword("crate")
+		p.processName(" serde ")
+		assert.Equal(t, []string{"serde"}, p.Output)
+		assert.Equal(t, StateRustUnknown, p.State)
+	})
+
+	t.Run("swift", func(t *testing.T) {
+		p := &ParserSwift{}
+		p.init()
+
+		p.append("Foundation")
+		assert.Empty(t, p.Output)
+
+		p.processKeywordDeclaration("import")
+		p.processNameClass("Combine")
+		assert.Equal(t, []string{"Combine"}, p.Output)
+
+		p.processKeywordDeclaration("class")
+		assert.Equal(t, StateSwiftUnknown, p.State)
+		p.processNameClass("Ignored")
+		assert.Equal(t, StateSwiftUnknown, p.State)
+	})
 }

--- a/pkg/file/read_test.go
+++ b/pkg/file/read_test.go
@@ -133,6 +133,13 @@ func TestReadLines_NonFile(t *testing.T) {
 	assert.ErrorContains(t, err, "failed to open file \"non-file\"")
 }
 
+func TestReadLines_EmptyPath(t *testing.T) {
+	lines, err := file.ReadLines(t.Context(), "", 10)
+
+	assert.Nil(t, lines)
+	assert.EqualError(t, err, "filepath cannot be empty")
+}
+
 func TestCountLines(t *testing.T) {
 	tmpDir := t.TempDir()
 
@@ -173,4 +180,11 @@ func TestCountLines_NonFile(t *testing.T) {
 
 	assert.Empty(t, lines)
 	assert.ErrorContains(t, err, "failed to open file \"non-file\"")
+}
+
+func TestCountLines_EmptyPath(t *testing.T) {
+	lines, err := file.CountLines(t.Context(), "")
+
+	assert.Empty(t, lines)
+	assert.EqualError(t, err, "filepath cannot be empty")
 }

--- a/pkg/language/language_internal_test.go
+++ b/pkg/language/language_internal_test.go
@@ -3,6 +3,8 @@ package language
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
@@ -43,4 +45,33 @@ func TestDetectLanguage_Error(t *testing.T) {
 
 	require.EqualError(t, err, "failed")
 	assert.Equal(t, heartbeat.LanguageUnknown, language)
+}
+
+func TestDetectChromaCustomizedFallbackBranches(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	lang, weight, ok := detectChromaCustomized(t.Context(), filepath.Join(tmpDir, "unknown.nope"), false)
+	assert.False(t, ok)
+	assert.Equal(t, heartbeat.LanguageUnknown, lang)
+	assert.Zero(t, weight)
+
+	lang, weight, ok = detectChromaCustomized(t.Context(), filepath.Join(tmpDir, "missing.nope"), true)
+	assert.False(t, ok)
+	assert.Equal(t, heartbeat.LanguageUnknown, lang)
+	assert.Zero(t, weight)
+
+	emptyFile := filepath.Join(tmpDir, "empty.nope")
+	require.NoError(t, os.WriteFile(emptyFile, nil, 0600))
+	lang, weight, ok = detectChromaCustomized(t.Context(), emptyFile, true)
+	assert.False(t, ok)
+	assert.Equal(t, heartbeat.LanguageUnknown, lang)
+	assert.Zero(t, weight)
+
+	contentFile := filepath.Join(tmpDir, "script.nope")
+	require.NoError(t, os.WriteFile(contentFile, []byte("#!/usr/bin/env python\nprint('x')\n"), 0600))
+
+	lang, _, ok = detectChromaCustomized(t.Context(), contentFile, true)
+	if ok {
+		assert.NotEqual(t, heartbeat.LanguageUnknown, lang)
+	}
 }

--- a/pkg/output/output_test.go
+++ b/pkg/output/output_test.go
@@ -39,4 +39,6 @@ func TestOutput_String(t *testing.T) {
 			assert.Equal(t, value, out.String())
 		})
 	}
+
+	assert.Empty(t, output.Output(99).String())
 }


### PR DESCRIPTION
Added/expanded coverage in:

- AI parser diagnostics and OpenCode helper branches
- API heartbeat/endpoints/options error paths
- dependency parser state machines
- file/language/output edge cases