### PR TITLE
Fix Cursor token-only AI rows

### DIFF
--- a/pkg/ai/cursor.go
+++ b/pkg/ai/cursor.go
@@ -34,9 +34,12 @@ type (
 	}
 
 	cursorUsage struct {
-		InputTokens  *int `json:"input_tokens"`
-		OutputTokens *int `json:"output_tokens"`
-		TotalTokens  *int `json:"total_tokens"`
+		InputTokens       *int `json:"input_tokens"`
+		OutputTokens      *int `json:"output_tokens"`
+		TotalTokens       *int `json:"total_tokens"`
+		InputTokensCamel  *int `json:"inputTokens"`
+		OutputTokensCamel *int `json:"outputTokens"`
+		TotalTokensCamel  *int `json:"totalTokens"`
 	}
 
 	cursorToolFormerData struct {
@@ -193,18 +196,30 @@ func (Cursor) cursorTokenCounts(line cursorLogLine, previous heartbeat.AITokens)
 	}
 
 	current := previous
-	if line.Usage.InputTokens != nil {
-		current.CurrentInput = int64(*line.Usage.InputTokens)
+	if inputTokens := cursorFirstInt(line.Usage.InputTokens, line.Usage.InputTokensCamel); inputTokens != nil {
+		current.CurrentInput = int64(*inputTokens)
 	}
 
+	outputTokens := cursorFirstInt(line.Usage.OutputTokens, line.Usage.OutputTokensCamel)
+	totalTokens := cursorFirstInt(line.Usage.TotalTokens, line.Usage.TotalTokensCamel)
 	switch {
-	case line.Usage.OutputTokens != nil:
-		current.CurrentOutput = int64(*line.Usage.OutputTokens)
-	case line.Usage.TotalTokens != nil:
-		current.CurrentOutput = int64(*line.Usage.TotalTokens)
+	case outputTokens != nil:
+		current.CurrentOutput = int64(*outputTokens)
+	case totalTokens != nil:
+		current.CurrentOutput = int64(*totalTokens)
 	}
 
 	return current
+}
+
+func cursorFirstInt(values ...*int) *int {
+	for _, value := range values {
+		if value != nil {
+			return value
+		}
+	}
+
+	return nil
 }
 
 func (Cursor) stateDBModifiedAfter(dbPath string, after time.Time) bool {
@@ -286,6 +301,8 @@ WHERE json_valid(value)
     OR json_extract(value, '$.modelConfig') IS NOT NULL
     OR json_extract(value, '$.selectedModel') IS NOT NULL
     OR json_extract(value, '$.selectedChatModel') IS NOT NULL
+    OR json_extract(value, '$.tokenCount') IS NOT NULL
+    OR json_extract(value, '$.usage') IS NOT NULL
   )
 ORDER BY json_extract(value, '$.createdAt') ASC;
 `, cursorRecentBubbleRowLimit)

--- a/pkg/ai/cursor_internal_test.go
+++ b/pkg/ai/cursor_internal_test.go
@@ -29,6 +29,21 @@ func TestCursorHelpers(t *testing.T) {
 		assert.False(t, Cursor{}.looksLikeUnifiedDiff("plain text"))
 		assert.Equal(t, 1, Cursor{}.lineChangesFromDiff("--- a\n+++ b\n-old\n+new\n+extra"))
 	})
+
+	t.Run("token counts accept camel case usage", func(t *testing.T) {
+		input := 7
+		total := 11
+
+		assert.Equal(t,
+			heartbeat.AITokens{CurrentInput: 7, CurrentOutput: 11},
+			Cursor{}.cursorTokenCounts(cursorLogLine{
+				Usage: &cursorUsage{
+					InputTokensCamel: &input,
+					TotalTokensCamel: &total,
+				},
+			}, heartbeat.AITokens{}),
+		)
+	})
 }
 
 func TestCursorHeartbeatFallbacks(t *testing.T) {

--- a/pkg/ai/cursor_test.go
+++ b/pkg/ai/cursor_test.go
@@ -109,6 +109,17 @@ func TestCursorParse(t *testing.T) {
 			},
 		},
 		{
+			Key: "bubbleId:composer-1:token-count",
+			Value: map[string]any{
+				"_v":        3,
+				"createdAt": "2026-03-15T23:35:20Z",
+				"tokenCount": map[string]any{
+					"inputTokens":  4,
+					"outputTokens": 3,
+				},
+			},
+		},
+		{
 			Key: "bubbleId:composer-1:assistant",
 			Value: map[string]any{
 				"_v":        3,
@@ -229,6 +240,8 @@ func TestCursorParse(t *testing.T) {
 	assert.Nil(t, got[3].AILineChanges)
 	assert.Zero(t, got[3].AIPromptLength)
 	assert.Equal(t, filepath.Dir(diffPath), got[3].ProjectPathOverride)
+	assert.Equal(t, int64(4), got[3].AIInputTokens)
+	assert.Equal(t, int64(3), got[3].AIOutputTokens)
 	require.NotNil(t, got[3].IsWrite)
 	assert.False(t, *got[3].IsWrite)
 	assert.Equal(t, float64(time.Date(2026, 3, 15, 23, 35, 30, 0, time.UTC).Unix()), got[3].Time)


### PR DESCRIPTION
## Summary
- include Cursor SQLite rows that contain only `tokenCount` or `usage` so token deltas are not skipped before heartbeat generation
- support both snake_case and camelCase Cursor `usage` token fields
- add regression coverage for token-only Cursor rows being attached to the next assistant/app heartbeat

## Root Cause
Cursor can persist token usage in rows that do not include text, model metadata, or completed tool call data. The CLI query filtered those rows out before parsing, so the per-bubble token state never advanced and later Cursor heartbeats were emitted without AI token counts.

## Validation
- `go test ./pkg/ai -run 'TestCursor'`
- `go test ./pkg/ai`

Fixes wakatime/vscode-wakatime#489.
