### PR TITLE
Preserve Cursor tokens across zero placeholders

### DIFF
--- a/pkg/ai/cursor.go
+++ b/pkg/ai/cursor.go
@@ -179,18 +179,24 @@ func (g Cursor) Parse(ctx context.Context) (Heartbeats, error) {
 
 func (Cursor) cursorTokenCounts(line cursorLogLine, previous heartbeat.AITokens) heartbeat.AITokens {
 	if line.TokenCount != nil {
+		if line.TokenCount.isZero() {
+			return previous
+		}
+
 		current := previous
 		if inputTokens := cursorFirstInt(line.TokenCount.InputTokens, line.TokenCount.InputTokensSnake); inputTokens != nil {
-			current.CurrentInput = previous.LastInput + int64(*inputTokens)
+			if *inputTokens != 0 {
+				current.CurrentInput = previous.LastInput + int64(*inputTokens)
+			}
 		}
 
 		outputTokens := cursorFirstInt(line.TokenCount.OutputTokens, line.TokenCount.OutputTokensSnake)
 
 		totalTokens := cursorFirstInt(line.TokenCount.TotalTokens, line.TokenCount.TotalTokensSnake)
 		switch {
-		case outputTokens != nil:
+		case outputTokens != nil && *outputTokens != 0:
 			current.CurrentOutput = previous.LastOutput + int64(*outputTokens)
-		case totalTokens != nil:
+		case totalTokens != nil && *totalTokens != 0:
 			current.CurrentOutput = previous.LastOutput + int64(*totalTokens)
 		}
 
@@ -201,22 +207,66 @@ func (Cursor) cursorTokenCounts(line cursorLogLine, previous heartbeat.AITokens)
 		return previous
 	}
 
+	if line.Usage.isZero() {
+		return previous
+	}
+
 	current := previous
 	if inputTokens := cursorFirstInt(line.Usage.InputTokens, line.Usage.InputTokensCamel); inputTokens != nil {
-		current.CurrentInput = int64(*inputTokens)
+		if *inputTokens != 0 {
+			current.CurrentInput = int64(*inputTokens)
+		}
 	}
 
 	outputTokens := cursorFirstInt(line.Usage.OutputTokens, line.Usage.OutputTokensCamel)
 
 	totalTokens := cursorFirstInt(line.Usage.TotalTokens, line.Usage.TotalTokensCamel)
 	switch {
-	case outputTokens != nil:
+	case outputTokens != nil && *outputTokens != 0:
 		current.CurrentOutput = int64(*outputTokens)
-	case totalTokens != nil:
+	case totalTokens != nil && *totalTokens != 0:
 		current.CurrentOutput = int64(*totalTokens)
 	}
 
 	return current
+}
+
+func (c cursorTokenCount) isZero() bool {
+	return cursorAllIntsZero(
+		c.InputTokens,
+		c.OutputTokens,
+		c.TotalTokens,
+		c.InputTokensSnake,
+		c.OutputTokensSnake,
+		c.TotalTokensSnake,
+	)
+}
+
+func (u cursorUsage) isZero() bool {
+	return cursorAllIntsZero(
+		u.InputTokens,
+		u.OutputTokens,
+		u.TotalTokens,
+		u.InputTokensCamel,
+		u.OutputTokensCamel,
+		u.TotalTokensCamel,
+	)
+}
+
+func cursorAllIntsZero(values ...*int) bool {
+	hasValue := false
+	for _, value := range values {
+		if value == nil {
+			continue
+		}
+
+		hasValue = true
+		if *value != 0 {
+			return false
+		}
+	}
+
+	return hasValue
 }
 
 func cursorFirstInt(values ...*int) *int {

--- a/pkg/ai/cursor_internal_test.go
+++ b/pkg/ai/cursor_internal_test.go
@@ -59,6 +59,52 @@ func TestCursorHelpers(t *testing.T) {
 			}, heartbeat.AITokens{LastInput: 3, LastOutput: 5}),
 		)
 	})
+
+	t.Run("zero token counts preserve pending tokens", func(t *testing.T) {
+		zero := 0
+		output := 4
+		previous := heartbeat.AITokens{
+			LastInput:     3,
+			LastOutput:    5,
+			CurrentInput:  10,
+			CurrentOutput: 16,
+		}
+
+		assert.Equal(t,
+			previous,
+			Cursor{}.cursorTokenCounts(cursorLogLine{
+				TokenCount: &cursorTokenCount{
+					InputTokens:  &zero,
+					OutputTokens: &zero,
+				},
+			}, previous),
+		)
+
+		assert.Equal(t,
+			heartbeat.AITokens{
+				LastInput:     3,
+				LastOutput:    5,
+				CurrentInput:  10,
+				CurrentOutput: 9,
+			},
+			Cursor{}.cursorTokenCounts(cursorLogLine{
+				TokenCount: &cursorTokenCount{
+					InputTokens:  &zero,
+					OutputTokens: &output,
+				},
+			}, previous),
+		)
+
+		assert.Equal(t,
+			previous,
+			Cursor{}.cursorTokenCounts(cursorLogLine{
+				Usage: &cursorUsage{
+					InputTokensCamel:  &zero,
+					OutputTokensCamel: &zero,
+				},
+			}, previous),
+		)
+	})
 }
 
 func TestCursorHeartbeatFallbacks(t *testing.T) {

--- a/pkg/ai/cursor_test.go
+++ b/pkg/ai/cursor_test.go
@@ -126,6 +126,10 @@ func TestCursorParse(t *testing.T) {
 				"type":      2,
 				"text":      "I updated the implementation",
 				"createdAt": "2026-03-15T23:35:30Z",
+				"tokenCount": map[string]any{
+					"inputTokens":  0,
+					"outputTokens": 0,
+				},
 			},
 		},
 		{


### PR DESCRIPTION
## Summary
- treat Cursor tokenCount/usage objects containing only zero values as placeholders
- preserve pending token state when Cursor writes zero token placeholders on later rows
- add regression coverage for zero placeholders following token-only Cursor rows

## Root Cause
Recent Cursor state rows on this machine include tokenCount objects, but those objects are often placeholders like {"inputTokens":0,"outputTokens":0}. When a real token-only row is followed by a text/tool row carrying a zero placeholder, the parser overwrites the pending token state before emitting the next heartbeat. The result is a Cursor heartbeat without AI token deltas even though a prior row contained usable token data.

## Validation
- go test ./pkg/ai -run 'Cursor' -count=1
- go test ./...

Related to wakatime/vscode-wakatime#489.