### PR TITLE
Use cumulative token counts

### DIFF
--- a/pkg/ai/cursor.go
+++ b/pkg/ai/cursor.go
@@ -186,7 +186,7 @@ func (Cursor) cursorTokenCounts(line cursorLogLine, previous heartbeat.AITokens)
 		current := previous
 		if inputTokens := cursorFirstInt(line.TokenCount.InputTokens, line.TokenCount.InputTokensSnake); inputTokens != nil {
 			if *inputTokens != 0 {
-				current.CurrentInput = previous.LastInput + int64(*inputTokens)
+				current.CurrentInput = cumulativeTokenCount(current.LastInput, current.CurrentInput, *inputTokens)
 			}
 		}
 
@@ -195,9 +195,9 @@ func (Cursor) cursorTokenCounts(line cursorLogLine, previous heartbeat.AITokens)
 		totalTokens := cursorFirstInt(line.TokenCount.TotalTokens, line.TokenCount.TotalTokensSnake)
 		switch {
 		case outputTokens != nil && *outputTokens != 0:
-			current.CurrentOutput = previous.LastOutput + int64(*outputTokens)
+			current.CurrentOutput = cumulativeTokenCount(current.LastOutput, current.CurrentOutput, *outputTokens)
 		case totalTokens != nil && *totalTokens != 0:
-			current.CurrentOutput = previous.LastOutput + int64(*totalTokens)
+			current.CurrentOutput = cumulativeTokenCount(current.LastOutput, current.CurrentOutput, *totalTokens)
 		}
 
 		return current
@@ -229,6 +229,15 @@ func (Cursor) cursorTokenCounts(line cursorLogLine, previous heartbeat.AITokens)
 	}
 
 	return current
+}
+
+func cumulativeTokenCount(last int64, current int64, value int) int64 {
+	next := int64(value)
+	if next < last || next < current {
+		return current
+	}
+
+	return next
 }
 
 func (c cursorTokenCount) isZero() bool {

--- a/pkg/ai/cursor_internal_test.go
+++ b/pkg/ai/cursor_internal_test.go
@@ -45,12 +45,12 @@ func TestCursorHelpers(t *testing.T) {
 		)
 	})
 
-	t.Run("token counts accept snake case token count", func(t *testing.T) {
+	t.Run("token counts treat snake case token count as cumulative", func(t *testing.T) {
 		input := 7
 		output := 11
 
 		assert.Equal(t,
-			heartbeat.AITokens{LastInput: 3, LastOutput: 5, CurrentInput: 10, CurrentOutput: 16},
+			heartbeat.AITokens{LastInput: 3, LastOutput: 5, CurrentInput: 7, CurrentOutput: 11},
 			Cursor{}.cursorTokenCounts(cursorLogLine{
 				TokenCount: &cursorTokenCount{
 					InputTokensSnake:  &input,
@@ -85,7 +85,23 @@ func TestCursorHelpers(t *testing.T) {
 				LastInput:     3,
 				LastOutput:    5,
 				CurrentInput:  10,
-				CurrentOutput: 9,
+				CurrentOutput: 16,
+			},
+			Cursor{}.cursorTokenCounts(cursorLogLine{
+				TokenCount: &cursorTokenCount{
+					InputTokens:  &zero,
+					OutputTokens: &output,
+				},
+			}, previous),
+		)
+
+		output = 20
+		assert.Equal(t,
+			heartbeat.AITokens{
+				LastInput:     3,
+				LastOutput:    5,
+				CurrentInput:  10,
+				CurrentOutput: 20,
 			},
 			Cursor{}.cursorTokenCounts(cursorLogLine{
 				TokenCount: &cursorTokenCount{

--- a/pkg/ai/cursor_test.go
+++ b/pkg/ai/cursor_test.go
@@ -114,8 +114,8 @@ func TestCursorParse(t *testing.T) {
 				"_v":        3,
 				"createdAt": "2026-03-15T23:35:20Z",
 				"tokenCount": map[string]any{
-					"inputTokens":  4,
-					"outputTokens": 3,
+					"inputTokens":  12,
+					"outputTokens": 8,
 				},
 			},
 		},
@@ -220,8 +220,8 @@ func TestCursorParse(t *testing.T) {
 	require.NotNil(t, got[1].AILineChanges)
 	assert.Equal(t, 3, *got[1].AILineChanges)
 	assert.Zero(t, got[1].AIPromptLength)
-	assert.Equal(t, int64(8), got[1].AIInputTokens)
-	assert.Equal(t, int64(5), got[1].AIOutputTokens)
+	assert.Equal(t, int64(5), got[1].AIInputTokens)
+	assert.Equal(t, int64(4), got[1].AIOutputTokens)
 	require.NotNil(t, got[1].IsWrite)
 	assert.True(t, *got[1].IsWrite)
 	assert.Equal(t, float64(time.Date(2026, 3, 15, 23, 34, 39, 0, time.UTC).Unix()), got[1].Time)

--- a/pkg/ai/helpers_more_internal_test.go
+++ b/pkg/ai/helpers_more_internal_test.go
@@ -452,10 +452,17 @@ func TestWindsurfHelperBranches(t *testing.T) {
 	usageTotal := 15
 
 	assert.Equal(t,
-		heartbeat.AITokens{LastInput: 2, LastOutput: 3, CurrentInput: 7, CurrentOutput: 12},
+		heartbeat.AITokens{LastInput: 2, LastOutput: 3, CurrentInput: 5, CurrentOutput: 9},
 		parser.windsurfTokenCounts(windsurfLogLine{
 			TokenCount: &windsurfTokenCount{InputTokens: &input, TotalTokens: &total},
 		}, heartbeat.AITokens{LastInput: 2, LastOutput: 3}),
+	)
+	zero := 0
+	assert.Equal(t,
+		heartbeat.AITokens{LastInput: 2, LastOutput: 3, CurrentInput: 5, CurrentOutput: 9},
+		parser.windsurfTokenCounts(windsurfLogLine{
+			TokenCount: &windsurfTokenCount{InputTokens: &zero, OutputTokens: &zero},
+		}, heartbeat.AITokens{LastInput: 2, LastOutput: 3, CurrentInput: 5, CurrentOutput: 9}),
 	)
 	assert.Equal(t,
 		heartbeat.AITokens{CurrentInput: 12, CurrentOutput: 15},

--- a/pkg/ai/windsurf.go
+++ b/pkg/ai/windsurf.go
@@ -157,16 +157,23 @@ func (g Windsurf) Parse(ctx context.Context) (Heartbeats, error) {
 
 func (Windsurf) windsurfTokenCounts(line windsurfLogLine, previous heartbeat.AITokens) heartbeat.AITokens {
 	if line.TokenCount != nil {
+		if line.TokenCount.isZero() {
+			return previous
+		}
+
 		current := previous
 		if line.TokenCount.InputTokens != nil {
-			current.CurrentInput = previous.LastInput + int64(*line.TokenCount.InputTokens)
+			current.CurrentInput = cumulativeTokenCount(
+				current.LastInput, current.CurrentInput, *line.TokenCount.InputTokens)
 		}
 
 		switch {
 		case line.TokenCount.OutputTokens != nil:
-			current.CurrentOutput = previous.LastOutput + int64(*line.TokenCount.OutputTokens)
+			current.CurrentOutput = cumulativeTokenCount(
+				current.LastOutput, current.CurrentOutput, *line.TokenCount.OutputTokens)
 		case line.TokenCount.TotalTokens != nil:
-			current.CurrentOutput = previous.LastOutput + int64(*line.TokenCount.TotalTokens)
+			current.CurrentOutput = cumulativeTokenCount(
+				current.LastOutput, current.CurrentOutput, *line.TokenCount.TotalTokens)
 		}
 
 		return current
@@ -189,6 +196,10 @@ func (Windsurf) windsurfTokenCounts(line windsurfLogLine, previous heartbeat.AIT
 	}
 
 	return current
+}
+
+func (c windsurfTokenCount) isZero() bool {
+	return cursorAllIntsZero(c.InputTokens, c.OutputTokens, c.TotalTokens)
 }
 
 func (Windsurf) stateDBModifiedAfter(dbPath string, after time.Time) bool {

--- a/pkg/ai/windsurf_test.go
+++ b/pkg/ai/windsurf_test.go
@@ -37,6 +37,26 @@ func TestWindsurfParse(t *testing.T) {
 
 	createWindsurfDB(t, dbPath, []windsurfTestRow{
 		{
+			Key: "bubbleId:cascade-1:old-edit",
+			Value: map[string]any{
+				"_v":        3,
+				"type":      2,
+				"createdAt": "2026-04-20T11:58:00Z",
+				"toolFormerData": map[string]any{
+					"status": "completed",
+					"name":   "edit_file_v2",
+					"params": fmt.Sprintf(
+						`{"relativeWorkspacePath":%q,"streamingContent":"skip"}`,
+						editedPath,
+					),
+				},
+				"tokenCount": map[string]any{
+					"inputTokens":  3,
+					"outputTokens": 1,
+				},
+			},
+		},
+		{
 			Key: "bubbleId:cascade-1:user",
 			Value: map[string]any{
 				"_v":        3,
@@ -61,8 +81,8 @@ func TestWindsurfParse(t *testing.T) {
 					),
 				},
 				"tokenCount": map[string]any{
-					"inputTokens":  5,
-					"outputTokens": 2,
+					"inputTokens":  8,
+					"outputTokens": 3,
 				},
 			},
 		},


### PR DESCRIPTION
Token counts in heartbeats are cumulative. We send the number of tokens since used since the last heartbeat, not the total tokens used.