### PR TITLE
fix: prevent permanent backoff by capping retries and resetting stale state

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -239,14 +239,21 @@ func RunCmd(ctx context.Context, v *viper.Viper, verbose bool, sendDiagsOnErrors
 }
 
 // RunCmdWithOfflineSync runs a command function and exits with the exit code
-// returned by the command function. If command run was successful, it will execute
-// offline sync command afterwards. Will send diagnostic on any errors or panics.
+// returned by the command function. It will always execute offline sync afterwards,
+// regardless of whether the command succeeded or failed. Will send diagnostic on
+// any errors or panics.
 func RunCmdWithOfflineSync(ctx context.Context, v *viper.Viper, verbose bool, sendDiagsOnErrors bool, cmd cmdFn) error {
-	if err := runCmd(ctx, v, verbose, sendDiagsOnErrors, cmd); err != nil {
-		return err
+	heartbeatErr := runCmd(ctx, v, verbose, sendDiagsOnErrors, cmd)
+
+	// always attempt offline sync, even when heartbeat command fails,
+	// to ensure queued heartbeats are drained when the API becomes reachable
+	syncErr := runCmd(ctx, v, verbose, sendDiagsOnErrors, offlinesync.RunWithRateLimiting)
+
+	if heartbeatErr != nil {
+		return heartbeatErr
 	}
 
-	return runCmd(ctx, v, verbose, sendDiagsOnErrors, offlinesync.RunWithRateLimiting)
+	return syncErr
 }
 
 // runCmd contains the main logic of RunCmd.

--- a/pkg/backoff/backoff.go
+++ b/pkg/backoff/backoff.go
@@ -19,6 +19,8 @@ import (
 const (
 	// maxBackoff sets the maximum seconds we will rate limit before retrying to send.
 	maxBackoffSecs = 3600
+	// maxRetries sets the maximum number of retries before resetting backoff state.
+	maxRetries = 10
 	// factor is the total seconds to be multiplied by.
 	factor = 15
 )
@@ -54,8 +56,14 @@ func WithBackoff(config Config) heartbeat.HandleOption {
 
 			results, err := next(ctx, hh)
 			if err != nil {
+				// cap retries at maxRetries to prevent unbounded growth
+				newRetries := config.Retries + 1
+				if newRetries > maxRetries {
+					newRetries = maxRetries
+				}
+
 				// error response, increment backoff
-				if updateErr := updateBackoffSettings(ctx, config.V, config.Retries+1, time.Now()); updateErr != nil {
+				if updateErr := updateBackoffSettings(ctx, config.V, newRetries, time.Now()); updateErr != nil {
 					logger.Warnf("failed to update backoff settings: %s", updateErr)
 				}
 
@@ -94,6 +102,16 @@ func shouldBackoff(ctx context.Context, retries int, at time.Time) bool {
 			retries,
 			at.Format(ini.DateFormat),
 			duration.String(),
+		)
+
+		return false
+	}
+
+	// safety reset: if backoff_at is older than 24 hours, force reset
+	if time.Since(at) > 24*time.Hour {
+		logger.Debugf(
+			"backoff_at is older than 24 hours (since %s), resetting backoff state",
+			at.Format(ini.DateFormat),
 		)
 
 		return false

--- a/pkg/backoff/backoff_internal_test.go
+++ b/pkg/backoff/backoff_internal_test.go
@@ -43,6 +43,22 @@ func TestShouldBackoff_NegateBackoff(t *testing.T) {
 	assert.False(t, should)
 }
 
+func TestShouldBackoff_StaleBackoffResetsAfter24Hours(t *testing.T) {
+	at := time.Now().Add(-25 * time.Hour)
+
+	should := shouldBackoff(t.Context(), 3, at)
+
+	assert.False(t, should)
+}
+
+func TestShouldBackoff_StaleBackoffActiveWithin24Hours(t *testing.T) {
+	at := time.Now().Add(-30 * time.Second)
+
+	should := shouldBackoff(t.Context(), 3, at)
+
+	assert.True(t, should)
+}
+
 func TestUpdateBackoffSettings(t *testing.T) {
 	tmpFile, err := os.CreateTemp(t.TempDir(), "wakatime")
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

Three fixes to prevent WakaTime from permanently stopping sync after temporary network outages or API failures.

**Fixes #1283**

## Changes

### 1. Cap backoff retries at 10 (`pkg/backoff/backoff.go`)
- Added `maxRetries = 10` constant
- `WithBackoff` now caps retries at 10 when incrementing, preventing unbounded growth of the retry counter (which previously grew to 2839+ in issue #1283)

### 2. Add 24-hour safety reset in `shouldBackoff()` (`pkg/backoff/backoff.go`)
- If `backoff_at` is older than 24 hours, force-return `false` to reset backoff state
- This handles edge cases where backoff state was never properly cleared (e.g., system clock jumps, corrupted state)
- Note: The existing `parsed.After(time.Now())` check in `loadBackoffParams` already handles future dates; this adds a complementary check for stale past dates

### 3. Always run offline sync (`cmd/run.go`)
- `RunCmdWithOfflineSync` now always runs `offlinesync.RunWithRateLimiting`, even when the heartbeat command fails
- Previously, if heartbeat failed (e.g., due to backoff), offline sync was skipped entirely, so queued heartbeats could never drain even when the API became reachable

## Root Cause

The bug was a combination of:
1. `shouldBackoff()` logging "will reset" but never actually resetting backoff state when `backoffSeconds > maxBackoffSecs`
2. No cap on retry counter growth
3. Offline sync being skipped when heartbeat fails, creating a deadlock where heartbeats accumulate but never drain

## Testing

- Added 2 tests for the 24-hour stale backoff reset (`TestShouldBackoff_StaleBackoffResetsAfter24Hours`, `TestShouldBackoff_StaleBackoffActiveWithin24Hours`)
- All existing tests pass
- `go build ./...` succeeds