### PR TITLE
feat(framework): detect JS/TS framework from nearest package.json

### DIFF
--- a/cmd/handler/option.go
+++ b/cmd/handler/option.go
@@ -6,6 +6,7 @@ import (
 	"github.com/wakatime/wakatime-cli/pkg/fileexperts"
 	"github.com/wakatime/wakatime-cli/pkg/filestats"
 	"github.com/wakatime/wakatime-cli/pkg/filter"
+	"github.com/wakatime/wakatime-cli/pkg/framework"
 	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
 	"github.com/wakatime/wakatime-cli/pkg/language"
 	"github.com/wakatime/wakatime-cli/pkg/params"
@@ -81,6 +82,13 @@ func WithLanguageDetection() Preprocessor {
 		return language.WithDetection(language.Config{
 			GuessLanguage: params.Heartbeat.GuessLanguage,
 		})
+	}
+}
+
+// WithFrameworkDetection returns a Preprocessor that applies framework detection to heartbeats.
+func WithFrameworkDetection() Preprocessor {
+	return func(_ params.Params) heartbeat.HandleOption {
+		return framework.WithDetection()
 	}
 }
 

--- a/cmd/heartbeat/heartbeat.go
+++ b/cmd/heartbeat/heartbeat.go
@@ -212,6 +212,7 @@ func initHandleOptions() []handler.Preprocessor {
 		handler.WithAPIKeyReplacing(),
 		handler.WithFileStatsDetection(),
 		handler.WithLanguageDetection(),
+		handler.WithFrameworkDetection(),
 		handler.WithDependencyDetection(),
 		handler.WithCategoryDetection(),
 		handler.WithProjectDetection(),

--- a/pkg/framework/framework.go
+++ b/pkg/framework/framework.go
@@ -1,0 +1,199 @@
+// Package framework detects the JavaScript/TypeScript framework used by a project, by
+// inspecting the "dependencies" and "devDependencies" of the nearest package.json file.
+package framework
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/wakatime/wakatime-cli/pkg/file"
+	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
+	"github.com/wakatime/wakatime-cli/pkg/log"
+)
+
+// packageJSONFilename is the name of the npm package manifest file used to detect frameworks.
+const packageJSONFilename = "package.json"
+
+// Framework represents a JavaScript/TypeScript framework that can be detected from a
+// package.json dependency.
+type Framework struct {
+	// Name is the human readable framework name reported on the heartbeat.
+	Name string
+	// Dependency is the package name looked up in "dependencies" and "devDependencies".
+	Dependency string
+}
+
+// frameworks is the registry of detectable frameworks, ordered from most to least specific.
+// Meta-frameworks (Next.js, Nuxt, SvelteKit, Remix, Qwik, Astro) are listed before the base
+// libraries they are commonly built on top of (React, Vue, Svelte), so a project depending on
+// both is attributed to the more specific framework. Adding support for another framework only
+// requires appending an entry here.
+//
+// nolint:gochecknoglobals
+var frameworks = []Framework{
+	{Name: "Next.js", Dependency: "next"},
+	{Name: "Nuxt", Dependency: "nuxt"},
+	{Name: "SvelteKit", Dependency: "@sveltejs/kit"},
+	{Name: "Remix", Dependency: "@remix-run/react"},
+	{Name: "Qwik", Dependency: "@builder.io/qwik"},
+	{Name: "Astro", Dependency: "astro"},
+	{Name: "NestJS", Dependency: "@nestjs/core"},
+	{Name: "Angular", Dependency: "@angular/core"},
+	{Name: "SolidJS", Dependency: "solid-js"},
+	{Name: "Preact", Dependency: "preact"},
+	{Name: "React", Dependency: "react"},
+	{Name: "Vue", Dependency: "vue"},
+	{Name: "Svelte", Dependency: "svelte"},
+}
+
+// supportedLanguages restricts framework detection to languages where a JS/TS framework is
+// meaningful. Files detected as any other language are left untouched, even if a package.json
+// happens to be nearby.
+//
+// nolint:gochecknoglobals
+var supportedLanguages = map[string]struct{}{
+	heartbeat.LanguageJavaScript.String(): {},
+	heartbeat.LanguageTypeScript.String(): {},
+	heartbeat.LanguageJSX.String():        {},
+	heartbeat.LanguageTSX.String():        {},
+	heartbeat.LanguageVueJS.String():      {},
+	heartbeat.LanguageSvelte.String():     {},
+}
+
+// packageJSON is the subset of a package.json file relevant for framework detection.
+type packageJSON struct {
+	Dependencies    map[string]string `json:"dependencies"`
+	DevDependencies map[string]string `json:"devDependencies"`
+}
+
+// cacheEntry stores the outcome of parsing a single package.json file, including a failed
+// attempt, so it's never parsed more than once per run.
+type cacheEntry struct {
+	pkg *packageJSON
+	err error
+}
+
+// cache memoizes parsed package.json files by absolute path, so heartbeats for files within
+// the same project only pay the cost of reading and parsing package.json once. It is safe for
+// concurrent use.
+type cache struct {
+	mu    sync.Mutex
+	items map[string]cacheEntry
+}
+
+func newCache() *cache {
+	return &cache{items: make(map[string]cacheEntry)}
+}
+
+// WithDetection initializes and returns a heartbeat handle option, which can be used in a
+// heartbeat processing pipeline to detect and add the JavaScript/TypeScript framework used by
+// a project to heartbeats of entity type 'file'.
+//
+// It relies on the heartbeat's already-detected language, so it must run after
+// language.WithDetection in the pipeline. If no framework is detected, the heartbeat is left
+// unchanged.
+func WithDetection() heartbeat.HandleOption {
+	c := newCache()
+
+	return func(next heartbeat.Handle) heartbeat.Handle {
+		return func(ctx context.Context, hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+			logger := log.Extract(ctx)
+
+			for n, h := range hh {
+				name, ok := detectFramework(ctx, c, h)
+				if !ok {
+					continue
+				}
+
+				logger.Debugf("detected framework %q for file %q", name, h.Entity)
+
+				hh[n].Framework = heartbeat.PointerTo(name)
+			}
+
+			return next(ctx, hh)
+		}
+	}
+}
+
+// detectFramework returns the framework name for a single heartbeat, or false if none applies
+// or none was detected. It never returns an error, so a missing, malformed, or unreadable
+// package.json simply results in no framework being set, leaving existing behavior unchanged.
+func detectFramework(ctx context.Context, c *cache, h heartbeat.Heartbeat) (string, bool) {
+	if h.Framework != nil || h.Language == nil {
+		return "", false
+	}
+
+	if _, ok := supportedLanguages[*h.Language]; !ok {
+		return "", false
+	}
+
+	fp := h.Entity
+	if h.LocalFile != "" {
+		fp = h.LocalFile
+	}
+
+	return detect(ctx, c, fp)
+}
+
+// detect searches upward from fp for the nearest package.json and returns the name of the
+// first known framework found among its dependencies and devDependencies.
+func detect(ctx context.Context, c *cache, fp string) (string, bool) {
+	pkgPath, found := file.Find(ctx, filepath.Dir(fp), packageJSONFilename)
+	if !found {
+		return "", false
+	}
+
+	pkg, err := loadPackageJSON(c, pkgPath)
+	if err != nil {
+		log.Extract(ctx).Debugf("failed to parse %q: %s", pkgPath, err)
+		return "", false
+	}
+
+	for _, fw := range frameworks {
+		if _, ok := pkg.Dependencies[fw.Dependency]; ok {
+			return fw.Name, true
+		}
+
+		if _, ok := pkg.DevDependencies[fw.Dependency]; ok {
+			return fw.Name, true
+		}
+	}
+
+	return "", false
+}
+
+// loadPackageJSON reads and parses the package.json file at path, using c to make sure it's
+// never read or parsed more than once per run, regardless of how many heartbeats share it.
+func loadPackageJSON(c *cache, path string) (*packageJSON, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if entry, ok := c.items[path]; ok {
+		return entry.pkg, entry.err
+	}
+
+	pkg, err := parsePackageJSON(path)
+
+	c.items[path] = cacheEntry{pkg: pkg, err: err}
+
+	return pkg, err
+}
+
+// parsePackageJSON reads and unmarshals a package.json file from disk.
+func parsePackageJSON(path string) (*packageJSON, error) {
+	data, err := os.ReadFile(path) // nolint:gosec
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file: %w", err)
+	}
+
+	var pkg packageJSON
+	if err := json.Unmarshal(data, &pkg); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal json: %w", err)
+	}
+
+	return &pkg, nil
+}

--- a/pkg/framework/framework_internal_test.go
+++ b/pkg/framework/framework_internal_test.go
@@ -1,0 +1,322 @@
+package framework
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writePackageJSON writes content to <dir>/package.json, creating dir if needed.
+func writePackageJSON(t *testing.T, dir string, content string) {
+	t.Helper()
+
+	require.NoError(t, os.MkdirAll(dir, 0750))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "package.json"), []byte(content), 0600))
+}
+
+// packageJSONWith builds a minimal package.json body from dependency and devDependency names.
+func packageJSONWith(deps []string, devDeps []string) string {
+	depsObj := "{"
+	for i, d := range deps {
+		if i > 0 {
+			depsObj += ","
+		}
+		depsObj += `"` + d + `": "^1.0.0"`
+	}
+	depsObj += "}"
+
+	devDepsObj := "{"
+	for i, d := range devDeps {
+		if i > 0 {
+			devDepsObj += ","
+		}
+		devDepsObj += `"` + d + `": "^1.0.0"`
+	}
+	devDepsObj += "}"
+
+	return `{"name": "fixture", "dependencies": ` + depsObj + `, "devDependencies": ` + devDepsObj + `}`
+}
+
+func TestDetect_Frameworks(t *testing.T) {
+	tests := map[string]struct {
+		Deps     []string
+		Expected string
+	}{
+		"React":     {Deps: []string{"react"}, Expected: "React"},
+		"Next.js":   {Deps: []string{"react", "next"}, Expected: "Next.js"},
+		"Vue":       {Deps: []string{"vue"}, Expected: "Vue"},
+		"Nuxt":      {Deps: []string{"vue", "nuxt"}, Expected: "Nuxt"},
+		"Angular":   {Deps: []string{"@angular/core"}, Expected: "Angular"},
+		"NestJS":    {Deps: []string{"@nestjs/core"}, Expected: "NestJS"},
+		"Svelte":    {Deps: []string{"svelte"}, Expected: "Svelte"},
+		"SvelteKit": {Deps: []string{"svelte", "@sveltejs/kit"}, Expected: "SvelteKit"},
+		"SolidJS":   {Deps: []string{"solid-js"}, Expected: "SolidJS"},
+		"Preact":    {Deps: []string{"preact"}, Expected: "Preact"},
+		"Qwik":      {Deps: []string{"@builder.io/qwik"}, Expected: "Qwik"},
+		"Remix":     {Deps: []string{"react", "@remix-run/react"}, Expected: "Remix"},
+		"Astro":     {Deps: []string{"astro"}, Expected: "Astro"},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			writePackageJSON(t, tmpDir, packageJSONWith(test.Deps, nil))
+
+			entity := filepath.Join(tmpDir, "src", "index.js")
+			require.NoError(t, os.MkdirAll(filepath.Dir(entity), 0750))
+
+			got, ok := detect(t.Context(), newCache(), entity)
+			require.True(t, ok)
+			assert.Equal(t, test.Expected, got)
+		})
+	}
+}
+
+func TestDetect_PlainJavaScriptNoFramework(t *testing.T) {
+	tmpDir := t.TempDir()
+	writePackageJSON(t, tmpDir, packageJSONWith([]string{"lodash", "axios"}, nil))
+
+	entity := filepath.Join(tmpDir, "index.js")
+
+	name, ok := detect(t.Context(), newCache(), entity)
+	assert.False(t, ok)
+	assert.Empty(t, name)
+}
+
+func TestDetect_PlainJSXNoDependencies(t *testing.T) {
+	tmpDir := t.TempDir()
+	writePackageJSON(t, tmpDir, packageJSONWith(nil, nil))
+
+	entity := filepath.Join(tmpDir, "index.jsx")
+
+	name, ok := detect(t.Context(), newCache(), entity)
+	assert.False(t, ok)
+	assert.Empty(t, name)
+}
+
+func TestDetect_NoPackageJSON(t *testing.T) {
+	tmpDir := t.TempDir()
+	entity := filepath.Join(tmpDir, "index.js")
+
+	name, ok := detect(t.Context(), newCache(), entity)
+	assert.False(t, ok)
+	assert.Empty(t, name)
+}
+
+func TestDetect_InvalidPackageJSON(t *testing.T) {
+	tmpDir := t.TempDir()
+	writePackageJSON(t, tmpDir, `{not valid json`)
+
+	entity := filepath.Join(tmpDir, "index.js")
+
+	name, ok := detect(t.Context(), newCache(), entity)
+	assert.False(t, ok)
+	assert.Empty(t, name)
+}
+
+func TestDetect_NestedPackageJSONLookup(t *testing.T) {
+	tmpDir := t.TempDir()
+	writePackageJSON(t, tmpDir, packageJSONWith([]string{"react"}, nil))
+
+	// entity lives several directories below the package.json.
+	entity := filepath.Join(tmpDir, "src", "components", "deeply", "nested", "Button.jsx")
+	require.NoError(t, os.MkdirAll(filepath.Dir(entity), 0750))
+
+	name, ok := detect(t.Context(), newCache(), entity)
+	require.True(t, ok)
+	assert.Equal(t, "React", name)
+}
+
+func TestDetect_DevDependencies(t *testing.T) {
+	tmpDir := t.TempDir()
+	writePackageJSON(t, tmpDir, packageJSONWith(nil, []string{"svelte"}))
+
+	entity := filepath.Join(tmpDir, "App.svelte")
+
+	name, ok := detect(t.Context(), newCache(), entity)
+	require.True(t, ok)
+	assert.Equal(t, "Svelte", name)
+}
+
+func TestDetect_UsesNearestPackageJSONNotFarthest(t *testing.T) {
+	root := t.TempDir()
+	writePackageJSON(t, root, packageJSONWith([]string{"vue"}, nil))
+
+	sub := filepath.Join(root, "packages", "app")
+	writePackageJSON(t, sub, packageJSONWith([]string{"react"}, nil))
+
+	entity := filepath.Join(sub, "src", "index.jsx")
+	require.NoError(t, os.MkdirAll(filepath.Dir(entity), 0750))
+
+	name, ok := detect(t.Context(), newCache(), entity)
+	require.True(t, ok)
+	assert.Equal(t, "React", name)
+}
+
+func TestLoadPackageJSON_CachesResult(t *testing.T) {
+	tmpDir := t.TempDir()
+	pkgPath := filepath.Join(tmpDir, "package.json")
+	require.NoError(t, os.WriteFile(pkgPath, []byte(packageJSONWith([]string{"react"}, nil)), 0600))
+
+	c := newCache()
+
+	pkg1, err := loadPackageJSON(c, pkgPath)
+	require.NoError(t, err)
+	require.NotNil(t, pkg1)
+
+	// Remove the file from disk. If loadPackageJSON reads from disk again instead of using
+	// the cache, this second call would fail.
+	require.NoError(t, os.Remove(pkgPath))
+
+	pkg2, err := loadPackageJSON(c, pkgPath)
+	require.NoError(t, err)
+	assert.Same(t, pkg1, pkg2)
+}
+
+func TestLoadPackageJSON_CachesFailure(t *testing.T) {
+	tmpDir := t.TempDir()
+	pkgPath := filepath.Join(tmpDir, "package.json")
+	require.NoError(t, os.WriteFile(pkgPath, []byte(`{not valid`), 0600))
+
+	c := newCache()
+
+	_, err1 := loadPackageJSON(c, pkgPath)
+	require.Error(t, err1)
+
+	// Fix the file on disk. A cache hit should still return the original (cached) error
+	// rather than re-reading, proving the failed parse was memoized too.
+	require.NoError(t, os.WriteFile(pkgPath, []byte(packageJSONWith([]string{"react"}, nil)), 0600))
+
+	_, err2 := loadPackageJSON(c, pkgPath)
+	require.Error(t, err2)
+	assert.Equal(t, err1, err2)
+}
+
+func TestDetectFramework_SkipsUnsupportedLanguage(t *testing.T) {
+	tmpDir := t.TempDir()
+	writePackageJSON(t, tmpDir, packageJSONWith([]string{"react"}, nil))
+
+	entity := filepath.Join(tmpDir, "main.py")
+
+	h := heartbeat.Heartbeat{
+		Entity:   entity,
+		Language: heartbeat.PointerTo(heartbeat.LanguagePython.String()),
+	}
+
+	name, ok := detectFramework(t.Context(), newCache(), h)
+	assert.False(t, ok)
+	assert.Empty(t, name)
+}
+
+func TestDetectFramework_SkipsNilLanguage(t *testing.T) {
+	tmpDir := t.TempDir()
+	writePackageJSON(t, tmpDir, packageJSONWith([]string{"react"}, nil))
+
+	entity := filepath.Join(tmpDir, "index.jsx")
+
+	h := heartbeat.Heartbeat{Entity: entity}
+
+	name, ok := detectFramework(t.Context(), newCache(), h)
+	assert.False(t, ok)
+	assert.Empty(t, name)
+}
+
+func TestDetectFramework_SkipsAlreadySetFramework(t *testing.T) {
+	tmpDir := t.TempDir()
+	writePackageJSON(t, tmpDir, packageJSONWith([]string{"vue"}, nil))
+
+	entity := filepath.Join(tmpDir, "index.jsx")
+
+	h := heartbeat.Heartbeat{
+		Entity:    entity,
+		Language:  heartbeat.PointerTo(heartbeat.LanguageJSX.String()),
+		Framework: heartbeat.PointerTo("React"),
+	}
+
+	name, ok := detectFramework(t.Context(), newCache(), h)
+	assert.False(t, ok)
+	assert.Empty(t, name)
+}
+
+func TestDetectFramework_PrefersLocalFileOverEntity(t *testing.T) {
+	tmpDir := t.TempDir()
+	writePackageJSON(t, tmpDir, packageJSONWith([]string{"react"}, nil))
+
+	entity := filepath.Join(t.TempDir(), "index.jsx") // unrelated tree, no package.json
+	localFile := filepath.Join(tmpDir, "index.jsx")
+
+	h := heartbeat.Heartbeat{
+		Entity:    entity,
+		LocalFile: localFile,
+		Language:  heartbeat.PointerTo(heartbeat.LanguageJSX.String()),
+	}
+
+	name, ok := detectFramework(t.Context(), newCache(), h)
+	require.True(t, ok)
+	assert.Equal(t, "React", name)
+}
+
+func TestWithDetection_SetsFrameworkOnHeartbeats(t *testing.T) {
+	tmpDir := t.TempDir()
+	writePackageJSON(t, tmpDir, packageJSONWith([]string{"next", "react"}, nil))
+
+	entity := filepath.Join(tmpDir, "pages", "index.tsx")
+	require.NoError(t, os.MkdirAll(filepath.Dir(entity), 0750))
+
+	var received []heartbeat.Heartbeat
+
+	next := func(_ context.Context, hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+		received = hh
+		return []heartbeat.Result{}, nil
+	}
+
+	handle := WithDetection()(next)
+
+	hh := []heartbeat.Heartbeat{
+		{
+			Entity:   entity,
+			Language: heartbeat.PointerTo(heartbeat.LanguageTSX.String()),
+		},
+	}
+
+	_, err := handle(t.Context(), hh)
+	require.NoError(t, err)
+
+	require.Len(t, received, 1)
+	require.NotNil(t, received[0].Framework)
+	assert.Equal(t, "Next.js", *received[0].Framework)
+}
+
+func TestWithDetection_LeavesHeartbeatUnchangedWhenNoFrameworkDetected(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	entity := filepath.Join(tmpDir, "main.py")
+
+	var received []heartbeat.Heartbeat
+
+	next := func(_ context.Context, hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
+		received = hh
+		return []heartbeat.Result{}, nil
+	}
+
+	handle := WithDetection()(next)
+
+	hh := []heartbeat.Heartbeat{
+		{
+			Entity:   entity,
+			Language: heartbeat.PointerTo(heartbeat.LanguagePython.String()),
+		},
+	}
+
+	_, err := handle(t.Context(), hh)
+	require.NoError(t, err)
+
+	require.Len(t, received, 1)
+	assert.Nil(t, received[0].Framework)
+}

--- a/pkg/heartbeat/heartbeat.go
+++ b/pkg/heartbeat/heartbeat.go
@@ -35,6 +35,7 @@ type Heartbeat struct {
 	Dependencies          []string   `json:"dependencies,omitempty"`
 	Entity                string     `json:"entity"`
 	EntityType            EntityType `json:"type"`
+	Framework             *string    `json:"framework,omitempty"`
 	HumanLineChanges      *int       `json:"human_line_changes,omitempty"`
 	IsUnsavedEntity       bool       `json:"-"`
 	IsWrite               *bool      `json:"is_write,omitempty"`


### PR DESCRIPTION
## Summary

Adds framework detection alongside the existing language detection. Given a heartbeat
for a JS/TS-family file, it walks up from the file to the nearest `package.json` and
checks `dependencies`/`devDependencies` against a small registry of known frameworks,
setting a new `framework` field on the heartbeat.

Detected frameworks: React, Next.js, Vue, Nuxt, Angular, NestJS, Svelte, SvelteKit,
SolidJS, Preact, Qwik, Remix, Astro.

## Why a new field instead of changing `language`

`Heartbeat.Language` is sent as-is to the API and drives existing language statistics.
Overwriting `JSX` → `React` would silently corrupt users' language stats. `framework`
is additive (`omitempty`), so behavior for every existing heartbeat is unchanged.

## Design

- `pkg/framework` — a small `Framework{Name, Dependency}` registry; adding support for
  another framework is a one-line addition, no new conditionals.
- Runs after `language.WithDetection` in the pipeline (needs `Heartbeat.Language`
  already set) — wired via a new `WithFrameworkDetection()` preprocessor.
- Reuses `pkg/file.Find` for the upward `package.json` search (the same helper
  `language`/`project` already use).
- `package.json` reads/parses are memoized per run, so multiple heartbeats for files in
  the same project only pay the parse cost once.
- Registry is ordered meta-framework-first (e.g. Next.js before React, Nuxt before Vue,
  SvelteKit before Svelte) so a project depending on both resolves to the more specific
  one.
- Missing/malformed/unreadable `package.json` → no framework detected, no error, no
  panic. Existing behavior is fully preserved when nothing is detected.

## Not included

Backend/API support for storing `framework` — that lives in a separate repo. This PR
is CLI-side groundwork only; the field is inert until the API recognizes it, similar to
how other newer heartbeat fields appear to have been introduced CLI-first.

## Testing

Table-driven tests in `pkg/framework/framework_internal_test.go` covering:
- All 13 supported frameworks
- Plain JS/JSX with no framework dependency
- Missing `package.json`
- Invalid/malformed `package.json`
- Nested `package.json` lookup (finds nearest, not farthest)
- Detection via `devDependencies`
- Cache correctness (memoizes both successful and failed parses)
- Language gating (skips non-JS/TS languages)
- `LocalFile` vs `Entity` precedence
- Full `WithDetection()` pipeline integration, including backward compatibility when no
  framework is detected

`go test ./...` passes for every package this change touches
(`pkg/framework`, `pkg/heartbeat`, `cmd/handler`, `cmd/heartbeat`).

## Known unrelated issue

`TestSyncOfflineActivity_MultipleApiKey` in `cmd/offlinesync` fails locally on Windows
due to a `bbolt` file handle still being open when `t.TempDir()` cleanup tries to
delete it — reproduces on a clean checkout without this change and is unrelated to
`pkg/framework`.