### PR TITLE
Grok Build AI parser

### DIFF
--- a/pkg/ai/ai.go
+++ b/pkg/ai/ai.go
@@ -85,6 +85,8 @@ const (
 	GooseParser
 	// AmpParser is the parser ID for Amp.
 	AmpParser
+	// GrokBuildParser is the parser ID for Grok Build.
+	GrokBuildParser
 )
 
 type (
@@ -222,6 +224,11 @@ func parseAIHeartbeats(
 			FallbackUserAgent: config.Plugin,
 		},
 		Codex{
+			After:             after,
+			UserAgents:        userAgents,
+			FallbackUserAgent: config.Plugin,
+		},
+		GrokBuild{
 			After:             after,
 			UserAgents:        userAgents,
 			FallbackUserAgent: config.Plugin,

--- a/pkg/ai/grok_build.go
+++ b/pkg/ai/grok_build.go
@@ -1,0 +1,1129 @@
+package ai
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
+	"github.com/wakatime/wakatime-cli/pkg/ini"
+	"github.com/wakatime/wakatime-cli/pkg/log"
+)
+
+const grokBuildXAIUpdateMethod = "_x.ai/session/update"
+
+// GrokBuild contains params for detecting heartbeats from Grok Build sessions.
+type GrokBuild ParserConfig
+
+type (
+	grokBuildSummaryInfo struct {
+		ID  string `json:"id"`
+		Cwd string `json:"cwd"`
+	}
+
+	grokBuildSummary struct {
+		Info           grokBuildSummaryInfo `json:"info"`
+		CurrentModelID string               `json:"current_model_id"`
+		GitRootDir     string               `json:"git_root_dir"`
+	}
+
+	grokBuildVersion struct {
+		Version       string `json:"version"`
+		StableVersion string `json:"stable_version"`
+	}
+
+	grokBuildSession struct {
+		cwd     string
+		id      string
+		model   string
+		version string
+	}
+
+	grokBuildUpdateEnvelope struct {
+		Timestamp int64           `json:"timestamp"`
+		Method    string          `json:"method"`
+		Params    json.RawMessage `json:"params"`
+	}
+
+	grokBuildUpdateParams struct {
+		SessionID string               `json:"sessionId"`
+		Update    grokBuildUpdate      `json:"update"`
+		Meta      *grokBuildUpdateMeta `json:"_meta"`
+	}
+
+	grokBuildUpdate struct {
+		SessionUpdate     string                  `json:"sessionUpdate"`
+		Content           *grokBuildUpdateContent `json:"content"`
+		Usage             *grokBuildUsage         `json:"usage"`
+		Meta              *grokBuildUpdateMeta    `json:"_meta"`
+		TargetPromptIndex *int                    `json:"target_prompt_index"`
+	}
+
+	grokBuildUpdateContent struct {
+		Type *string               `json:"type"`
+		Text *string               `json:"text"`
+		Meta *grokBuildContentMeta `json:"_meta"`
+	}
+
+	grokBuildContentMeta struct {
+		BashCommand *string `json:"bash_command"`
+	}
+
+	grokBuildUpdateMeta struct {
+		ModelID          string `json:"modelId"`
+		PromptIndex      *int   `json:"promptIndex"`
+		AgentTimestampMS int64  `json:"agentTimestampMs"`
+		HostTurn         *bool  `json:"hostTurn"`
+	}
+
+	grokBuildUsage struct {
+		InputTokens  *int64 `json:"inputTokens"`
+		OutputTokens *int64 `json:"outputTokens"`
+	}
+
+	grokBuildUpdateEvent struct {
+		timestamp int64
+		isXAI     bool
+		params    grokBuildUpdateParams
+	}
+
+	grokBuildPendingPrompt struct {
+		text        string
+		promptIndex *int
+		timestamp   time.Time
+		model       string
+		counts      bool
+	}
+
+	grokBuildPrompt struct {
+		length       int
+		timestamp    time.Time
+		model        string
+		inputTokens  int64
+		outputTokens int64
+	}
+
+	grokBuildModelSnapshot struct {
+		timestamp time.Time
+		model     string
+	}
+
+	grokBuildHunk struct {
+		HunkID        string    `json:"hunkId"`
+		FilePath      string    `json:"filePath"`
+		LinesAdded    int       `json:"linesAdded"`
+		LinesRemoved  int       `json:"linesRemoved"`
+		AuthorType    string    `json:"authorType"`
+		EventType     string    `json:"eventType"`
+		RemovalReason string    `json:"removalReason"`
+		PromptIndex   *int      `json:"promptIndex"`
+		Timestamp     time.Time `json:"timestamp"`
+	}
+
+	grokBuildParseState struct {
+		prompts        []grokBuildPrompt
+		hunkHeartbeats Heartbeats
+		tokens         heartbeat.AITokens
+		model          string
+		// Prompt indexes can be reused after a rewind, so retain model history.
+		modelsByPromptIndex map[int][]grokBuildModelSnapshot
+		// Removal records omit author and model while negating the whole mixed-author hunk.
+		hunkAIContributions map[string]map[string]int
+		pending             *grokBuildPendingPrompt
+		seenPromptIndex     bool
+	}
+)
+
+// Parse parses Grok Build session transcripts for AI heartbeats.
+func (g GrokBuild) Parse(ctx context.Context) (Heartbeats, error) {
+	logger := log.Extract(ctx)
+
+	grokHome, err := grokBuildHomeDir(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	sessionDirs, err := g.sessionDirs(ctx, grokHome)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(sessionDirs) == 0 {
+		return Heartbeats{}, nil
+	}
+
+	logger.Debugf("Found %d Grok Build sessions modified after %s", len(sessionDirs), g.After)
+	version := grokBuildCLIVersion(logger, grokHome)
+
+	var heartbeats Heartbeats
+
+	for _, sessionDir := range sessionDirs {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
+		parsed, parseErr := g.parseSession(ctx, logger, grokHome, sessionDir, version)
+		if parseErr != nil {
+			if errors.Is(parseErr, context.Canceled) || errors.Is(parseErr, context.DeadlineExceeded) {
+				return nil, parseErr
+			}
+
+			logger.Warnf("failed parsing Grok Build session %q: %s", sessionDir, parseErr)
+
+			continue
+		}
+
+		heartbeats = append(heartbeats, parsed...)
+	}
+
+	sort.SliceStable(heartbeats, func(i, j int) bool {
+		return heartbeats[i].Time < heartbeats[j].Time
+	})
+
+	return heartbeats, nil
+}
+
+func (g GrokBuild) sessionDirs(ctx context.Context, grokHome string) ([]string, error) {
+	sessionsRoot := filepath.Join(grokHome, "sessions")
+	if _, err := os.Stat(sessionsRoot); err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+
+		return nil, fmt.Errorf("failed to stat Grok Build sessions directory: %s", err)
+	}
+
+	var sessionDirs []string
+
+	err := filepath.WalkDir(sessionsRoot, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		if entry.IsDir() || entry.Name() != "summary.json" {
+			return nil
+		}
+
+		sessionDir := filepath.Dir(path)
+
+		modified, modifiedErr := grokBuildSessionModifiedAtOrAfter(sessionDir, g.After)
+		if modifiedErr != nil {
+			return modifiedErr
+		}
+
+		if modified {
+			sessionDirs = append(sessionDirs, sessionDir)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to walk Grok Build sessions directory: %s", err)
+	}
+
+	sort.Strings(sessionDirs)
+
+	return sessionDirs, nil
+}
+
+func grokBuildSessionModifiedAtOrAfter(sessionDir string, after time.Time) (bool, error) {
+	for _, name := range []string{"summary.json", "updates.jsonl", "hunk_records.jsonl"} {
+		path := filepath.Join(sessionDir, name)
+
+		info, err := os.Stat(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+
+			return false, fmt.Errorf("failed to stat Grok Build session file %q: %s", path, err)
+		}
+
+		if timestampAtOrAfterCutoff(info.ModTime(), after) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func (g GrokBuild) parseSession(
+	ctx context.Context,
+	logger *log.Logger,
+	grokHome string,
+	sessionDir string,
+	version string,
+) (Heartbeats, error) {
+	session, err := grokBuildReadSession(sessionDir, version)
+	if err != nil {
+		return nil, err
+	}
+
+	state := grokBuildParseState{
+		model:               session.model,
+		modelsByPromptIndex: make(map[int][]grokBuildModelSnapshot),
+		hunkAIContributions: make(map[string]map[string]int),
+	}
+
+	if err := g.parseUpdates(ctx, logger, sessionDir, session, &state); err != nil {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
+		logger.Warnf("failed parsing Grok Build updates for session %q: %s", sessionDir, err)
+	}
+
+	if err := g.parseHunks(ctx, logger, grokHome, sessionDir, session, &state); err != nil {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
+		logger.Warnf("failed parsing Grok Build hunks for session %q: %s", sessionDir, err)
+	}
+
+	heartbeats := append(g.promptHeartbeats(session, state.prompts), state.hunkHeartbeats...)
+	sort.SliceStable(heartbeats, func(i, j int) bool {
+		return heartbeats[i].Time < heartbeats[j].Time
+	})
+
+	return heartbeats, nil
+}
+
+func grokBuildReadSession(sessionDir string, version string) (grokBuildSession, error) {
+	path := filepath.Join(sessionDir, "summary.json")
+
+	data, err := os.ReadFile(filepath.Clean(path)) //nolint:gosec
+	if err != nil {
+		return grokBuildSession{}, fmt.Errorf("failed to read Grok Build summary %q: %s", path, err)
+	}
+
+	var summary grokBuildSummary
+	if err := json.Unmarshal(data, &summary); err != nil {
+		return grokBuildSession{}, fmt.Errorf("failed to parse Grok Build summary %q: %s", path, err)
+	}
+
+	sessionID := strings.TrimSpace(summary.Info.ID)
+	if sessionID == "" {
+		sessionID = filepath.Base(sessionDir)
+	}
+
+	cwd := firstNonEmptyString(strings.TrimSpace(summary.GitRootDir), strings.TrimSpace(summary.Info.Cwd))
+	if cwd != "" {
+		cwd = filepath.Clean(filepath.FromSlash(cwd))
+	}
+
+	return grokBuildSession{
+		cwd:     cwd,
+		id:      sessionID,
+		model:   strings.TrimSpace(summary.CurrentModelID),
+		version: version,
+	}, nil
+}
+
+func (g GrokBuild) parseUpdates(
+	ctx context.Context,
+	logger *log.Logger,
+	sessionDir string,
+	session grokBuildSession,
+	state *grokBuildParseState,
+) error {
+	defer grokBuildFlushPrompt(session, state)
+
+	path := filepath.Join(sessionDir, "updates.jsonl")
+
+	return grokBuildWalkJSONL(
+		ctx,
+		logger,
+		path,
+		"updates",
+		func(line []byte) error {
+			event, err := grokBuildDecodeUpdate(line)
+			if err != nil {
+				return err
+			}
+
+			g.handleUpdate(event, session, state)
+
+			return nil
+		},
+		func() {
+			grokBuildFlushPrompt(session, state)
+		},
+	)
+}
+
+func (g GrokBuild) handleUpdate(
+	event grokBuildUpdateEvent,
+	session grokBuildSession,
+	state *grokBuildParseState,
+) {
+	update := event.params.Update
+	timestamp := grokBuildEventTime(event)
+	g.trackUpdateModel(timestamp, update, session, state)
+
+	switch {
+	case !event.isXAI && update.SessionUpdate == "user_message_chunk":
+		grokBuildHandleUserMessage(timestamp, update, session, state)
+	case event.isXAI && update.SessionUpdate == "rewind_marker":
+		grokBuildFlushPrompt(session, state)
+	default:
+		grokBuildFlushPrompt(session, state)
+
+		if update.SessionUpdate == "turn_completed" {
+			g.handleTurnCompleted(timestamp, update, state)
+		}
+	}
+}
+
+func (GrokBuild) trackUpdateModel(
+	timestamp time.Time,
+	update grokBuildUpdate,
+	session grokBuildSession,
+	state *grokBuildParseState,
+) {
+	if update.Meta == nil {
+		return
+	}
+
+	model := strings.TrimSpace(update.Meta.ModelID)
+	if model != "" {
+		state.model = model
+	}
+
+	if update.Meta.PromptIndex == nil {
+		return
+	}
+
+	model = firstNonEmptyString(model, state.model, session.model)
+	if model != "" {
+		promptIndex := *update.Meta.PromptIndex
+
+		history := state.modelsByPromptIndex[promptIndex]
+		if len(history) == 0 || history[len(history)-1].model != model {
+			state.modelsByPromptIndex[promptIndex] = append(history, grokBuildModelSnapshot{
+				timestamp: timestamp,
+				model:     model,
+			})
+		}
+	}
+}
+
+func grokBuildHandleUserMessage(
+	timestamp time.Time,
+	update grokBuildUpdate,
+	session grokBuildSession,
+	state *grokBuildParseState,
+) {
+	if !grokBuildIsPromptText(update) {
+		grokBuildFlushPrompt(session, state)
+		return
+	}
+
+	var promptIndex *int
+	if update.Meta != nil {
+		promptIndex = update.Meta.PromptIndex
+	}
+
+	if promptIndex != nil {
+		state.seenPromptIndex = true
+	}
+
+	counts := !state.seenPromptIndex || promptIndex != nil
+
+	newRun := state.pending == nil
+	if state.pending != nil && (state.seenPromptIndex || promptIndex != nil) {
+		newRun = !grokBuildSamePromptIndex(state.pending.promptIndex, promptIndex)
+	}
+
+	if newRun {
+		grokBuildFlushPrompt(session, state)
+		state.pending = &grokBuildPendingPrompt{
+			promptIndex: promptIndex,
+			timestamp:   timestamp,
+			model:       firstNonEmptyString(state.model, session.model),
+			counts:      counts,
+		}
+	}
+
+	state.pending.text += *update.Content.Text
+
+	if state.pending.timestamp.IsZero() && !timestamp.IsZero() {
+		state.pending.timestamp = timestamp
+	}
+
+	if state.model != "" {
+		state.pending.model = state.model
+	}
+
+	if state.pending.promptIndex == nil && promptIndex != nil {
+		state.pending.promptIndex = promptIndex
+		state.pending.counts = true
+	}
+}
+
+func grokBuildIsPromptText(update grokBuildUpdate) bool {
+	if update.Meta != nil && update.Meta.HostTurn != nil && *update.Meta.HostTurn {
+		return false
+	}
+
+	if update.Content == nil || update.Content.Type == nil || update.Content.Text == nil {
+		return false
+	}
+
+	if *update.Content.Type != "text" {
+		return false
+	}
+
+	return update.Content.Meta == nil || update.Content.Meta.BashCommand == nil
+}
+
+func grokBuildFlushPrompt(session grokBuildSession, state *grokBuildParseState) {
+	if state.pending == nil {
+		return
+	}
+
+	pending := state.pending
+	state.pending = nil
+
+	if !pending.counts {
+		return
+	}
+
+	text := strings.TrimSpace(pending.text)
+	if text == "" {
+		return
+	}
+
+	model := pending.model
+	if pending.promptIndex != nil {
+		model = firstNonEmptyString(
+			grokBuildModelAtPromptIndex(*pending.promptIndex, pending.timestamp, state),
+			model,
+		)
+	}
+
+	state.prompts = append(state.prompts, grokBuildPrompt{
+		length:    promptLength(text),
+		timestamp: pending.timestamp,
+		model:     firstNonEmptyString(model, state.model, session.model),
+	})
+}
+
+func (g GrokBuild) handleTurnCompleted(
+	timestamp time.Time,
+	update grokBuildUpdate,
+	state *grokBuildParseState,
+) {
+	if update.Usage == nil {
+		return
+	}
+
+	inputTokens := grokBuildNonNegativeTokenCount(update.Usage.InputTokens)
+	outputTokens := grokBuildNonNegativeTokenCount(update.Usage.OutputTokens)
+	// Turn usage is incremental. Convert it to Codex-style cumulative state so
+	// the heartbeat receives only the delta since the previous token event.
+	state.tokens.CurrentInput = state.tokens.LastInput + inputTokens
+	state.tokens.CurrentOutput = state.tokens.LastOutput + outputTokens
+
+	inputDelta := state.tokens.CurrentInput - state.tokens.LastInput
+	outputDelta := state.tokens.CurrentOutput - state.tokens.LastOutput
+
+	if !timestamp.IsZero() && timestampAtOrAfterCutoff(timestamp, g.After) && len(state.prompts) > 0 {
+		prompt := &state.prompts[len(state.prompts)-1]
+		if timestampAtOrAfterCutoff(prompt.timestamp, g.After) {
+			prompt.inputTokens += inputDelta
+			prompt.outputTokens += outputDelta
+		}
+	}
+
+	state.tokens.LastInput = state.tokens.CurrentInput
+	state.tokens.LastOutput = state.tokens.CurrentOutput
+}
+
+func grokBuildNonNegativeTokenCount(value *int64) int64 {
+	if value == nil || *value < 0 {
+		return 0
+	}
+
+	return *value
+}
+
+func (g GrokBuild) promptHeartbeats(session grokBuildSession, prompts []grokBuildPrompt) Heartbeats {
+	heartbeats := make(Heartbeats, 0, len(prompts))
+	entity := appHeartbeatEntity(g.Name(), session.id)
+
+	for _, prompt := range prompts {
+		if prompt.timestamp.IsZero() || !timestampAtOrAfterCutoff(prompt.timestamp, g.After) {
+			continue
+		}
+
+		h := heartbeat.NewWithAITokens(
+			nil,
+			session.id,
+			heartbeat.AITokens{
+				CurrentInput:  prompt.inputTokens,
+				CurrentOutput: prompt.outputTokens,
+			},
+			"",
+			heartbeat.AICodingCategory.String(),
+			nil,
+			entity,
+			heartbeat.AppType,
+			nil,
+			false,
+			heartbeat.PointerTo(false),
+			nil,
+			"",
+			nil,
+			nil,
+			"",
+			"",
+			false,
+			"",
+			session.cwd,
+			heartbeatTimestamp(prompt.timestamp),
+			g.userAgent(entity, prompt.model, session.version),
+		)
+		h.AIPromptLength = prompt.length
+		heartbeats = append(heartbeats, h)
+	}
+
+	return heartbeats
+}
+
+func (g GrokBuild) parseHunks(
+	ctx context.Context,
+	logger *log.Logger,
+	grokHome string,
+	sessionDir string,
+	session grokBuildSession,
+	state *grokBuildParseState,
+) error {
+	path := filepath.Join(sessionDir, "hunk_records.jsonl")
+
+	return grokBuildWalkJSONL(
+		ctx,
+		logger,
+		path,
+		"hunks",
+		func(line []byte) error {
+			var hunk grokBuildHunk
+			if err := json.Unmarshal(line, &hunk); err != nil {
+				return err
+			}
+
+			g.handleHunk(hunk, grokHome, session, state)
+
+			return nil
+		},
+		nil,
+	)
+}
+
+func (g GrokBuild) handleHunk(
+	hunk grokBuildHunk,
+	grokHome string,
+	session grokBuildSession,
+	state *grokBuildParseState,
+) {
+	eventType := strings.ToLower(strings.TrimSpace(hunk.EventType))
+	if eventType == "removed" {
+		g.handleRemovedHunk(hunk, grokHome, session, state)
+		return
+	}
+
+	if eventType != "added" && eventType != "updated" {
+		return
+	}
+
+	if !strings.EqualFold(strings.TrimSpace(hunk.AuthorType), "agent") {
+		return
+	}
+
+	filePath := grokBuildNativePath(hunk.FilePath)
+	if filePath == "" || grokBuildShouldSkipPath(filePath, grokHome) || hunk.Timestamp.IsZero() {
+		return
+	}
+
+	lineChanges := hunk.LinesAdded - hunk.LinesRemoved
+	model := grokBuildHunkModel(hunk, session, state)
+	hunkID := strings.TrimSpace(hunk.HunkID)
+
+	if hunkID != "" {
+		contributions := state.hunkAIContributions[hunkID]
+		if contributions == nil {
+			contributions = make(map[string]int)
+			state.hunkAIContributions[hunkID] = contributions
+		}
+
+		contributions[model] += lineChanges
+	}
+
+	if timestampAtOrAfterCutoff(hunk.Timestamp, g.After) {
+		state.hunkHeartbeats = append(
+			state.hunkHeartbeats,
+			g.hunkHeartbeat(filePath, lineChanges, hunk.Timestamp, model, session),
+		)
+	}
+}
+
+func (g GrokBuild) handleRemovedHunk(
+	hunk grokBuildHunk,
+	grokHome string,
+	session grokBuildSession,
+	state *grokBuildParseState,
+) {
+	hunkID := strings.TrimSpace(hunk.HunkID)
+	contributions := state.hunkAIContributions[hunkID]
+	delete(state.hunkAIContributions, hunkID)
+
+	if strings.EqualFold(strings.TrimSpace(hunk.RemovalReason), "accepted") {
+		return
+	}
+
+	if len(contributions) == 0 || hunk.Timestamp.IsZero() || !timestampAtOrAfterCutoff(hunk.Timestamp, g.After) {
+		return
+	}
+
+	filePath := grokBuildNativePath(hunk.FilePath)
+	if filePath == "" || grokBuildShouldSkipPath(filePath, grokHome) {
+		return
+	}
+
+	models := make([]string, 0, len(contributions))
+	for model, lineChanges := range contributions {
+		if lineChanges != 0 {
+			models = append(models, model)
+		}
+	}
+
+	sort.Strings(models)
+
+	for _, model := range models {
+		state.hunkHeartbeats = append(
+			state.hunkHeartbeats,
+			g.hunkHeartbeat(filePath, -contributions[model], hunk.Timestamp, model, session),
+		)
+	}
+}
+
+func grokBuildHunkModel(
+	hunk grokBuildHunk,
+	session grokBuildSession,
+	state *grokBuildParseState,
+) string {
+	if hunk.PromptIndex != nil {
+		// Updated records retain the hunk's creation timestamp, so it cannot
+		// identify which generation produced the update after a rewind reuses a
+		// prompt index. Prefer the latest known generation for updated records.
+		if strings.EqualFold(strings.TrimSpace(hunk.EventType), "updated") {
+			if model := grokBuildLatestModelAtPromptIndex(*hunk.PromptIndex, state); model != "" {
+				return model
+			}
+		}
+
+		if model := grokBuildModelAtPromptIndex(*hunk.PromptIndex, hunk.Timestamp, state); model != "" {
+			return model
+		}
+	}
+
+	return firstNonEmptyString(state.model, session.model)
+}
+
+func grokBuildLatestModelAtPromptIndex(promptIndex int, state *grokBuildParseState) string {
+	history := state.modelsByPromptIndex[promptIndex]
+	for i := len(history) - 1; i >= 0; i-- {
+		if history[i].model != "" {
+			return history[i].model
+		}
+	}
+
+	return ""
+}
+
+func grokBuildModelAtPromptIndex(
+	promptIndex int,
+	timestamp time.Time,
+	state *grokBuildParseState,
+) string {
+	history := state.modelsByPromptIndex[promptIndex]
+	if len(history) == 0 {
+		return ""
+	}
+
+	model := ""
+
+	var matchedAt time.Time
+
+	for _, snapshot := range history {
+		if snapshot.timestamp.IsZero() {
+			if model == "" {
+				model = snapshot.model
+			}
+
+			continue
+		}
+
+		if !timestamp.IsZero() && snapshot.timestamp.After(timestamp) {
+			continue
+		}
+
+		if matchedAt.IsZero() || snapshot.timestamp.After(matchedAt) || snapshot.timestamp.Equal(matchedAt) {
+			model = snapshot.model
+			matchedAt = snapshot.timestamp
+		}
+	}
+
+	if model == "" {
+		return history[0].model
+	}
+
+	return model
+}
+
+func (g GrokBuild) hunkHeartbeat(
+	filePath string,
+	lineChanges int,
+	timestamp time.Time,
+	model string,
+	session grokBuildSession,
+) heartbeat.Heartbeat {
+	return heartbeat.NewWithAITokens(
+		heartbeat.PointerTo(lineChanges),
+		session.id,
+		heartbeat.AITokens{},
+		"",
+		heartbeat.AICodingCategory.String(),
+		nil,
+		filePath,
+		heartbeat.FileType,
+		nil,
+		false,
+		heartbeat.PointerTo(true),
+		nil,
+		"",
+		nil,
+		nil,
+		"",
+		"",
+		false,
+		"",
+		session.cwd,
+		heartbeatTimestamp(timestamp),
+		g.userAgent(filePath, model, session.version),
+	)
+}
+
+func (g GrokBuild) userAgent(entity string, model string, version string) string {
+	return aiUserAgentWithModelAndEditor(
+		entity,
+		g.UserAgents,
+		g.FallbackUserAgent,
+		model,
+		"",
+		grokBuildUserAgentProduct(version),
+	)
+}
+
+func grokBuildUserAgentProduct(version string) string {
+	version = strings.TrimSpace(version)
+	if version == "" {
+		version = "unknown"
+	}
+
+	return "grok-build/" + version
+}
+
+func grokBuildDecodeUpdate(line []byte) (grokBuildUpdateEvent, error) {
+	var envelope grokBuildUpdateEnvelope
+	if err := json.Unmarshal(line, &envelope); err != nil {
+		return grokBuildUpdateEvent{}, err
+	}
+
+	var params grokBuildUpdateParams
+	if len(envelope.Params) > 0 && string(envelope.Params) != "null" {
+		if err := json.Unmarshal(envelope.Params, &params); err != nil {
+			return grokBuildUpdateEvent{}, err
+		}
+
+		if strings.TrimSpace(params.Update.SessionUpdate) == "" {
+			return grokBuildUpdateEvent{}, errors.New("missing Grok Build session update type")
+		}
+
+		return grokBuildUpdateEvent{
+			timestamp: envelope.Timestamp,
+			isXAI:     envelope.Method == grokBuildXAIUpdateMethod,
+			params:    params,
+		}, nil
+	}
+
+	if err := json.Unmarshal(line, &params); err != nil {
+		return grokBuildUpdateEvent{}, err
+	}
+
+	if strings.TrimSpace(params.Update.SessionUpdate) == "" {
+		return grokBuildUpdateEvent{}, errors.New("missing Grok Build session update type")
+	}
+
+	return grokBuildUpdateEvent{params: params}, nil
+}
+
+func grokBuildEventTime(event grokBuildUpdateEvent) time.Time {
+	meta := event.params.Meta
+	if meta == nil {
+		meta = event.params.Update.Meta
+	}
+
+	if meta != nil && meta.AgentTimestampMS > 0 {
+		return time.UnixMilli(meta.AgentTimestampMS).UTC()
+	}
+
+	if event.timestamp > 1_000_000_000_000 {
+		return time.UnixMilli(event.timestamp).UTC()
+	}
+
+	if event.timestamp > 0 {
+		return time.Unix(event.timestamp, 0).UTC()
+	}
+
+	return time.Time{}
+}
+
+func grokBuildSamePromptIndex(a *int, b *int) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+
+	return *a == *b
+}
+
+func grokBuildNativePath(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return ""
+	}
+
+	return filepath.Clean(filepath.FromSlash(path))
+}
+
+func grokBuildShouldSkipPath(path string, grokHome string) bool {
+	cleanPath := filepath.Clean(path)
+	cleanHome := filepath.Clean(grokHome)
+
+	relative, err := filepath.Rel(cleanHome, cleanPath)
+	if err == nil && relative != ".." && !strings.HasPrefix(relative, ".."+string(os.PathSeparator)) {
+		return true
+	}
+
+	return strings.Contains(filepath.ToSlash(cleanPath), "/.grok/")
+}
+
+func grokBuildHomeDir(ctx context.Context) (string, error) {
+	configured := strings.TrimSpace(os.Getenv("GROK_HOME"))
+	if configured == "" {
+		home, err := ini.UserHomeDir(ctx)
+		if err != nil {
+			return "", fmt.Errorf("failed to find user home dir: %s", err)
+		}
+
+		return filepath.Join(home, ".grok"), nil
+	}
+
+	if filepath.IsAbs(configured) {
+		return filepath.Clean(configured), nil
+	}
+
+	if configured == "~" || strings.HasPrefix(configured, "~/") || strings.HasPrefix(configured, `~\`) {
+		home, err := ini.UserHomeDir(ctx)
+		if err != nil {
+			return "", fmt.Errorf("failed to expand GROK_HOME: %s", err)
+		}
+
+		if configured == "~" {
+			return home, nil
+		}
+
+		configured = filepath.Join(home, configured[2:])
+	}
+
+	resolved, err := filepath.Abs(configured)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve GROK_HOME %q: %s", configured, err)
+	}
+
+	return resolved, nil
+}
+
+func grokBuildCLIVersion(logger *log.Logger, grokHome string) string {
+	path := filepath.Join(grokHome, "version.json")
+
+	data, err := os.ReadFile(filepath.Clean(path)) //nolint:gosec
+	if err != nil {
+		if !os.IsNotExist(err) {
+			logger.Debugf("failed to read Grok Build version file %q: %s", path, err)
+		}
+
+		return ""
+	}
+
+	var version grokBuildVersion
+	if err := json.Unmarshal(data, &version); err != nil {
+		logger.Debugf("failed to parse Grok Build version file %q: %s", path, err)
+		return ""
+	}
+
+	return firstNonEmptyString(strings.TrimSpace(version.Version), strings.TrimSpace(version.StableVersion))
+}
+
+func grokBuildWalkJSONL(
+	ctx context.Context,
+	logger *log.Logger,
+	path string,
+	kind string,
+	handle func([]byte) error,
+	handleSkipped func(),
+) error {
+	//nolint:gosec
+	fh, err := os.Open(filepath.Clean(path))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+
+		return fmt.Errorf("failed to open Grok Build %s %q: %s", kind, path, err)
+	}
+	defer fh.Close() //nolint:errcheck,gosec
+
+	reader := bufio.NewReader(fh)
+
+	for {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		line, readErr := grokBuildReadJSONLLine(reader, maxTranscriptLineSize)
+		if errors.Is(readErr, errGrokBuildLineTooLong) {
+			logger.Warnf("skipping oversized Grok Build %s line in %q", kind, path)
+
+			if handleSkipped != nil {
+				handleSkipped()
+			}
+
+			continue
+		}
+
+		if errors.Is(readErr, io.EOF) && len(line) == 0 {
+			break
+		}
+
+		if readErr != nil && !errors.Is(readErr, io.EOF) {
+			return fmt.Errorf("failed reading Grok Build %s %q: %s", kind, path, readErr)
+		}
+
+		if len(bytes.TrimSpace(line)) > 0 {
+			if err := handle(line); err != nil {
+				logger.Warnf("failed parsing Grok Build %s line from %q: %s", kind, path, err)
+
+				if handleSkipped != nil {
+					handleSkipped()
+				}
+			}
+		}
+
+		if errors.Is(readErr, io.EOF) {
+			break
+		}
+	}
+
+	return nil
+}
+
+var errGrokBuildLineTooLong = errors.New("grok build JSONL line exceeds size limit")
+
+func grokBuildReadJSONLLine(reader *bufio.Reader, maxSize int) ([]byte, error) {
+	var line []byte
+
+	for {
+		fragment, err := reader.ReadSlice('\n')
+		hasNewline := len(fragment) > 0 && fragment[len(fragment)-1] == '\n'
+
+		content := fragment
+		if hasNewline {
+			content = fragment[:len(fragment)-1]
+		}
+
+		if len(line)+len(content) > maxSize {
+			if !hasNewline {
+				if discardErr := grokBuildDiscardJSONLLine(reader); discardErr != nil && !errors.Is(discardErr, io.EOF) {
+					return nil, discardErr
+				}
+			}
+
+			return nil, errGrokBuildLineTooLong
+		}
+
+		line = append(line, content...)
+		if hasNewline {
+			return bytesTrimSuffix(line, '\r'), nil
+		}
+
+		if errors.Is(err, io.EOF) {
+			if len(line) == 0 {
+				return nil, io.EOF
+			}
+
+			return bytesTrimSuffix(line, '\r'), io.EOF
+		}
+
+		if errors.Is(err, bufio.ErrBufferFull) {
+			continue
+		}
+
+		if err != nil {
+			return nil, err
+		}
+	}
+}
+
+func grokBuildDiscardJSONLLine(reader *bufio.Reader) error {
+	for {
+		_, err := reader.ReadSlice('\n')
+		if err == nil {
+			return nil
+		}
+
+		if errors.Is(err, io.EOF) {
+			return io.EOF
+		}
+
+		if !errors.Is(err, bufio.ErrBufferFull) {
+			return err
+		}
+	}
+}
+
+func bytesTrimSuffix(value []byte, suffix byte) []byte {
+	if len(value) > 0 && value[len(value)-1] == suffix {
+		return value[:len(value)-1]
+	}
+
+	return value
+}
+
+// Name returns its id.
+func (GrokBuild) Name() string {
+	return "Grok Build"
+}

--- a/pkg/ai/grok_build_internal_test.go
+++ b/pkg/ai/grok_build_internal_test.go
@@ -1,0 +1,174 @@
+package ai
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"io"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGrokBuildReadJSONLLineContinuesAfterOversizedRecord(t *testing.T) {
+	contents := "one\r\n" + strings.Repeat("x", 32) + "\ntwo"
+	reader := bufio.NewReaderSize(strings.NewReader(contents), 16)
+
+	line, err := grokBuildReadJSONLLine(reader, 4)
+	require.NoError(t, err)
+	assert.Equal(t, "one", string(line))
+
+	line, err = grokBuildReadJSONLLine(reader, 4)
+	assert.Nil(t, line)
+	assert.ErrorIs(t, err, errGrokBuildLineTooLong)
+
+	line, err = grokBuildReadJSONLLine(reader, 4)
+	assert.Equal(t, "two", string(line))
+	assert.ErrorIs(t, err, io.EOF)
+
+	line, err = grokBuildReadJSONLLine(reader, 4)
+	assert.Nil(t, line)
+	assert.True(t, errors.Is(err, io.EOF))
+}
+
+func TestGrokBuildUserAgentProduct(t *testing.T) {
+	assert.Equal(t, "grok-build/unknown", grokBuildUserAgentProduct(""))
+	assert.Equal(t, "grok-build/1.2.3", grokBuildUserAgentProduct(" 1.2.3 "))
+}
+
+func TestGrokBuildDecodeUpdate(t *testing.T) {
+	t.Run("envelope", func(t *testing.T) {
+		event, err := grokBuildDecodeUpdate([]byte(`{
+			"timestamp": 123,
+			"method": "_x.ai/session/update",
+			"params": {"sessionId": "session", "update": {"sessionUpdate": "turn_completed"}}
+		}`))
+		require.NoError(t, err)
+		assert.EqualValues(t, 123, event.timestamp)
+		assert.True(t, event.isXAI)
+		assert.Equal(t, "session", event.params.SessionID)
+	})
+
+	t.Run("raw params", func(t *testing.T) {
+		event, err := grokBuildDecodeUpdate([]byte(
+			`{"sessionId":"session","update":{"sessionUpdate":"user_message_chunk"}}`,
+		))
+		require.NoError(t, err)
+		assert.False(t, event.isXAI)
+		assert.Equal(t, "user_message_chunk", event.params.Update.SessionUpdate)
+	})
+
+	for name, input := range map[string]string{
+		"malformed envelope": `{`,
+		"malformed params":   `{"params":{"update":`,
+		"missing type":       `{"params":{"sessionId":"session","update":{}}}`,
+		"raw missing type":   `{"sessionId":"session","update":{}}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := grokBuildDecodeUpdate([]byte(input))
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestGrokBuildEventTime(t *testing.T) {
+	metaTime := time.Date(2026, 7, 24, 1, 2, 3, 4_000_000, time.UTC)
+	secondsTime := time.Date(2026, 7, 24, 1, 2, 3, 0, time.UTC)
+
+	tests := []struct {
+		name  string
+		event grokBuildUpdateEvent
+		want  time.Time
+	}{
+		{
+			name: "params metadata takes precedence",
+			event: grokBuildUpdateEvent{timestamp: secondsTime.Unix(), params: grokBuildUpdateParams{
+				Meta: &grokBuildUpdateMeta{AgentTimestampMS: metaTime.UnixMilli()},
+			}},
+			want: metaTime,
+		},
+		{
+			name: "update metadata fallback",
+			event: grokBuildUpdateEvent{params: grokBuildUpdateParams{Update: grokBuildUpdate{
+				Meta: &grokBuildUpdateMeta{AgentTimestampMS: metaTime.UnixMilli()},
+			}}},
+			want: metaTime,
+		},
+		{name: "milliseconds", event: grokBuildUpdateEvent{timestamp: metaTime.UnixMilli()}, want: metaTime},
+		{name: "seconds", event: grokBuildUpdateEvent{timestamp: secondsTime.Unix()}, want: secondsTime},
+		{name: "missing", event: grokBuildUpdateEvent{}, want: time.Time{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, grokBuildEventTime(tt.event))
+		})
+	}
+}
+
+func TestGrokBuildSmallHelpers(t *testing.T) {
+	zero, one, anotherOne := 0, 1, 1
+
+	assert.True(t, grokBuildSamePromptIndex(nil, nil))
+	assert.False(t, grokBuildSamePromptIndex(nil, &zero))
+	assert.False(t, grokBuildSamePromptIndex(&zero, &one))
+	assert.True(t, grokBuildSamePromptIndex(&one, &anotherOne))
+
+	negative, positive := int64(-1), int64(7)
+
+	assert.Zero(t, grokBuildNonNegativeTokenCount(nil))
+	assert.Zero(t, grokBuildNonNegativeTokenCount(&negative))
+	assert.EqualValues(t, 7, grokBuildNonNegativeTokenCount(&positive))
+
+	assert.Empty(t, grokBuildNativePath("  "))
+
+	wantPath := filepath.Join("project", "file.go")
+	assert.Equal(t, wantPath, grokBuildNativePath(" project/file.go "))
+}
+
+func TestGrokBuildHomeDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	t.Run("absolute", func(t *testing.T) {
+		configured := filepath.Join(home, "custom", "..", "grok")
+		t.Setenv("GROK_HOME", configured)
+
+		got, err := grokBuildHomeDir(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, filepath.Clean(configured), got)
+	})
+
+	t.Run("home", func(t *testing.T) {
+		t.Setenv("GROK_HOME", "~")
+
+		got, err := grokBuildHomeDir(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, home, got)
+	})
+
+	t.Run("home child", func(t *testing.T) {
+		t.Setenv("GROK_HOME", "~/.custom-grok")
+
+		got, err := grokBuildHomeDir(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, filepath.Join(home, ".custom-grok"), got)
+	})
+
+	t.Run("relative", func(t *testing.T) {
+		t.Setenv("GROK_HOME", filepath.Join("testdata", "grok"))
+
+		got, err := grokBuildHomeDir(context.Background())
+		require.NoError(t, err)
+		assert.True(t, filepath.IsAbs(got))
+		assert.Equal(t, filepath.Join("testdata", "grok"), filepath.Join(
+			filepath.Base(filepath.Dir(got)),
+			filepath.Base(got),
+		))
+	})
+}

--- a/pkg/ai/grok_build_test.go
+++ b/pkg/ai/grok_build_test.go
@@ -1,0 +1,573 @@
+package ai_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wakatime/wakatime-cli/pkg/ai"
+	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
+)
+
+type grokBuildTestSession struct {
+	grokHome   string
+	dir        string
+	id         string
+	projectDir string
+}
+
+func TestGrokBuildParse(t *testing.T) {
+	ctx := context.Background()
+	session := setupGrokBuildTestSession(t, false)
+	base := time.Date(2026, 7, 23, 22, 0, 0, 0, time.UTC)
+	firstPrompt := 0
+	secondPrompt := 1
+
+	session.writeUpdates(t, []string{
+		grokBuildTestEnvelope(t, session.id, "session/update", base.Add(time.Second),
+			grokBuildTestUserUpdate("fix ", "grok-3", &firstPrompt)),
+		grokBuildTestEnvelope(t, session.id, "session/update", base.Add(2*time.Second),
+			grokBuildTestUserUpdate("main.go", "grok-3", &firstPrompt)),
+		grokBuildTestEnvelope(t, session.id, "session/update", base.Add(3*time.Second),
+			map[string]any{"sessionUpdate": "agent_message_chunk"}),
+		grokBuildTestEnvelope(t, session.id, "_x.ai/session/update", base.Add(4*time.Second),
+			grokBuildTestTurnCompleted(100, 40)),
+		grokBuildTestRawUpdate(t, session.id, base.Add(5*time.Second),
+			grokBuildTestUserUpdate("commit", "grok-4.5", &secondPrompt)),
+		grokBuildTestEnvelope(t, session.id, "_x.ai/session/update", base.Add(6*time.Second),
+			grokBuildTestTurnCompleted(20, 5)),
+	})
+
+	editFile := filepath.Join(session.projectDir, "main.go")
+	skipFile := filepath.Join(session.grokHome, "sessions", "plan.md")
+	session.writeHunks(t, []string{
+		grokBuildTestHunk(t, session.id, "agent-hunk", editFile, base.Add(10*time.Second),
+			"added", "agent", &firstPrompt, 3, 1),
+		grokBuildTestHunk(t, session.id, "mixed-hunk", editFile, base.Add(11*time.Second),
+			"added", "human", nil, 5, 0),
+		grokBuildTestHunk(t, session.id, "mixed-hunk", editFile, base.Add(12*time.Second),
+			"updated", "agent", &secondPrompt, 1, 0),
+		grokBuildTestHunk(t, session.id, "mixed-hunk", editFile, base.Add(13*time.Second),
+			"removed", "", nil, -6, 0),
+		grokBuildTestHunk(t, session.id, "agent-hunk", editFile, base.Add(14*time.Second),
+			"removed", "", nil, -3, -1),
+		grokBuildTestHunk(t, session.id, "skip-hunk", skipFile, base.Add(15*time.Second),
+			"added", "agent", &secondPrompt, 10, 0),
+	})
+
+	parser := ai.GrokBuild{
+		After:             base,
+		FallbackUserAgent: "plugin/0.0.1",
+		UserAgents: map[string]string{
+			editFile: heartbeat.UserAgent(ctx, "editor/1.2.3"),
+		},
+	}
+
+	got, err := parser.Parse(ctx)
+	require.NoError(t, err)
+	require.Len(t, got, 6)
+
+	assert.Equal(t, "Grok Build "+session.id, got[0].Entity)
+	assert.Equal(t, heartbeat.AppType, got[0].EntityType)
+	assert.Equal(t, len([]rune("fix main.go")), got[0].AIPromptLength)
+	assert.EqualValues(t, 100, got[0].AIInputTokens)
+	assert.EqualValues(t, 40, got[0].AIOutputTokens)
+	assert.Equal(t, session.projectDir, got[0].ProjectPathOverride)
+	assert.Contains(t, got[0].UserAgent, "grok/3")
+	assert.Contains(t, got[0].UserAgent, "grok-build/0.2.111")
+
+	assert.Equal(t, len([]rune("commit")), got[1].AIPromptLength)
+	assert.EqualValues(t, 20, got[1].AIInputTokens)
+	assert.EqualValues(t, 5, got[1].AIOutputTokens)
+	assert.Contains(t, got[1].UserAgent, "grok/4.5")
+
+	assertGrokBuildFileHeartbeat(t, got[2], editFile, 2, "grok/3")
+	assertGrokBuildFileHeartbeat(t, got[3], editFile, 1, "grok/4.5")
+	assertGrokBuildFileHeartbeat(t, got[4], editFile, -1, "grok/4.5")
+	assertGrokBuildFileHeartbeat(t, got[5], editFile, -2, "grok/3")
+	assert.Contains(t, got[2].UserAgent, "editor/1.2.3")
+}
+
+func TestGrokBuildParse_PromptShapesAndRewind(t *testing.T) {
+	session := setupGrokBuildTestSession(t, false)
+	base := time.Date(2026, 7, 23, 22, 0, 0, 0, time.UTC)
+	firstPrompt := 0
+	secondPrompt := 1
+
+	bashUpdate := grokBuildTestUserUpdate("ignored bash", "grok-4.5", &firstPrompt)
+	bashUpdate["content"].(map[string]any)["_meta"] = map[string]any{"bash_command": ""}
+
+	hostUpdate := grokBuildTestUserUpdate("ignored host", "grok-4.5", &firstPrompt)
+	hostUpdate["_meta"].(map[string]any)["hostTurn"] = true
+
+	session.writeUpdates(t, []string{
+		grokBuildTestRawUpdate(t, session.id, base.Add(time.Second),
+			grokBuildTestUserUpdate("old ", "grok-4.5", nil)),
+		grokBuildTestRawUpdate(t, session.id, base.Add(2*time.Second),
+			grokBuildTestUserUpdate("format", "grok-4.5", nil)),
+		grokBuildTestEnvelope(t, session.id, "session/update", base.Add(3*time.Second),
+			map[string]any{"sessionUpdate": "agent_message_chunk"}),
+		grokBuildTestEnvelope(t, session.id, "session/update", base.Add(4*time.Second),
+			grokBuildTestUserUpdate("first ", "grok-4.5", &firstPrompt)),
+		grokBuildTestEnvelope(t, session.id, "session/update", base.Add(5*time.Second), bashUpdate),
+		grokBuildTestEnvelope(t, session.id, "session/update", base.Add(6*time.Second),
+			grokBuildTestUserUpdate("second", "grok-4.5", &firstPrompt)),
+		grokBuildTestEnvelope(t, session.id, "session/update", base.Add(7*time.Second), hostUpdate),
+		grokBuildTestEnvelope(t, session.id, "session/update", base.Add(8*time.Second),
+			grokBuildTestUserUpdate("left", "grok-4.5", &firstPrompt)),
+		`{"malformed":`,
+		grokBuildTestEnvelope(t, session.id, "session/update", base.Add(9*time.Second),
+			grokBuildTestUserUpdate("right", "grok-4.5", &firstPrompt)),
+		grokBuildTestEnvelope(t, session.id, "session/update", base.Add(10*time.Second),
+			map[string]any{"sessionUpdate": "agent_message_chunk"}),
+		grokBuildTestEnvelope(t, session.id, "session/update", base.Add(11*time.Second),
+			grokBuildTestUserUpdate("phantom", "grok-4.5", nil)),
+		grokBuildTestEnvelope(t, session.id, "session/update", base.Add(12*time.Second),
+			map[string]any{"sessionUpdate": "agent_message_chunk"}),
+		grokBuildTestEnvelope(t, session.id, "session/update", base.Add(13*time.Second),
+			grokBuildTestUserUpdate("discarded", "grok-4.5", &secondPrompt)),
+		grokBuildTestEnvelope(t, session.id, "session/update", base.Add(14*time.Second),
+			map[string]any{"sessionUpdate": "agent_message_chunk"}),
+		grokBuildTestEnvelope(t, session.id, "_x.ai/session/update", base.Add(15*time.Second),
+			map[string]any{"sessionUpdate": "rewind_marker", "target_prompt_index": 5}),
+		grokBuildTestEnvelope(t, session.id, "unexpected/update", base.Add(16*time.Second),
+			grokBuildTestUserUpdate("after rewind", "grok-4.5", &secondPrompt)),
+		grokBuildTestEnvelope(t, session.id, "_x.ai/session/update", base.Add(17*time.Second),
+			grokBuildTestTurnCompleted(7, 2)),
+	})
+	session.writeHunks(t, nil)
+
+	got, err := (ai.GrokBuild{After: base}).Parse(context.Background())
+	require.NoError(t, err)
+	require.Len(t, got, 7)
+
+	lengths := make([]int, 0, len(got))
+	for _, h := range got {
+		lengths = append(lengths, h.AIPromptLength)
+	}
+
+	assert.Equal(t, []int{10, 5, 6, 4, 5, 9, 12}, lengths)
+	assert.EqualValues(t, 7, got[6].AIInputTokens)
+	assert.EqualValues(t, 2, got[6].AIOutputTokens)
+}
+
+func TestGrokBuildParse_RemovalReversesPriorModelContributions(t *testing.T) {
+	session := setupGrokBuildTestSession(t, false)
+	base := time.Date(2026, 7, 23, 22, 0, 0, 0, time.UTC)
+	firstPrompt := 0
+	secondPrompt := 1
+
+	session.writeUpdates(t, []string{
+		grokBuildTestEnvelope(t, session.id, "session/update", base.Add(time.Second),
+			grokBuildTestUserUpdate("first", "grok-3", &firstPrompt)),
+		grokBuildTestEnvelope(t, session.id, "session/update", base.Add(2*time.Second),
+			map[string]any{"sessionUpdate": "agent_message_chunk"}),
+		grokBuildTestEnvelope(t, session.id, "session/update", base.Add(3*time.Second),
+			grokBuildTestUserUpdate("second", "grok-4.5", &secondPrompt)),
+		grokBuildTestEnvelope(t, session.id, "session/update", base.Add(4*time.Second),
+			map[string]any{"sessionUpdate": "agent_message_chunk"}),
+	})
+
+	editFile := filepath.Join(session.projectDir, "mixed.go")
+	session.writeHunks(t, []string{
+		grokBuildTestHunk(t, session.id, "mixed", editFile, base.Add(5*time.Second),
+			"added", "human", nil, 5, 0),
+		grokBuildTestHunk(t, session.id, "mixed", editFile, base.Add(6*time.Second),
+			"updated", "agent", &firstPrompt, 1, 0),
+		grokBuildTestHunk(t, session.id, "mixed", editFile, base.Add(7*time.Second),
+			"updated", "agent", &secondPrompt, 2, 0),
+		grokBuildTestHunk(t, session.id, "mixed", editFile, base.Add(20*time.Second),
+			"removed", "", nil, -8, 0),
+	})
+
+	got, err := (ai.GrokBuild{After: base.Add(10 * time.Second)}).Parse(context.Background())
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assertGrokBuildFileHeartbeat(t, got[0], editFile, -1, "grok/3")
+	assertGrokBuildFileHeartbeat(t, got[1], editFile, -2, "grok/4.5")
+}
+
+func TestGrokBuildParse_FileHeartbeatUsesSessionProjectForOutOfTreeFile(t *testing.T) {
+	session := setupGrokBuildTestSession(t, false)
+	base := time.Date(2026, 7, 23, 22, 0, 0, 0, time.UTC)
+	promptIndex := 0
+
+	session.writeUpdates(t, nil)
+
+	outOfTreeFile := filepath.Join(t.TempDir(), "plan.md")
+	session.writeHunks(t, []string{
+		grokBuildTestHunk(t, session.id, "out-of-tree", outOfTreeFile, base.Add(time.Second),
+			"added", "agent", &promptIndex, 1, 0),
+	})
+
+	got, err := (ai.GrokBuild{After: base}).Parse(context.Background())
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assertGrokBuildFileHeartbeat(t, got[0], outOfTreeFile, 1, "grok/4.5")
+	assert.Equal(t, session.projectDir, got[0].ProjectPathOverride)
+}
+
+func TestGrokBuildParse_ReusedPromptIndexUsesModelAtHunkTime(t *testing.T) {
+	session := setupGrokBuildTestSession(t, false)
+	base := time.Date(2026, 7, 23, 22, 0, 0, 0, time.UTC)
+	promptIndex := 0
+
+	session.writeUpdates(t, []string{
+		grokBuildTestEnvelope(t, session.id, "session/update", base.Add(time.Second),
+			grokBuildTestUserUpdate("old branch", "grok-3", &promptIndex)),
+		grokBuildTestEnvelope(t, session.id, "session/update", base.Add(1200*time.Millisecond),
+			map[string]any{"sessionUpdate": "agent_message_chunk"}),
+		grokBuildTestEnvelope(t, session.id, "_x.ai/session/update", base.Add(2*time.Second),
+			map[string]any{"sessionUpdate": "rewind_marker", "target_prompt_index": 0}),
+		grokBuildTestEnvelope(t, session.id, "session/update", base.Add(3*time.Second),
+			grokBuildTestUserUpdate("new branch", "grok-4.5", &promptIndex)),
+		grokBuildTestEnvelope(t, session.id, "session/update", base.Add(3200*time.Millisecond),
+			map[string]any{"sessionUpdate": "agent_message_chunk"}),
+	})
+
+	oldFile := filepath.Join(session.projectDir, "old.go")
+	newFile := filepath.Join(session.projectDir, "new.go")
+	session.writeHunks(t, []string{
+		grokBuildTestHunk(t, session.id, "old", oldFile, base.Add(1500*time.Millisecond),
+			"added", "agent", &promptIndex, 1, 0),
+		grokBuildTestHunk(t, session.id, "new", newFile, base.Add(4*time.Second),
+			"added", "agent", &promptIndex, 1, 0),
+	})
+
+	got, err := (ai.GrokBuild{After: base}).Parse(context.Background())
+	require.NoError(t, err)
+
+	var fileHeartbeats []heartbeat.Heartbeat
+
+	for _, h := range got {
+		if h.EntityType == heartbeat.FileType {
+			fileHeartbeats = append(fileHeartbeats, h)
+		}
+	}
+
+	require.Len(t, fileHeartbeats, 2)
+	assertGrokBuildFileHeartbeat(t, fileHeartbeats[0], oldFile, 1, "grok/3")
+	assertGrokBuildFileHeartbeat(t, fileHeartbeats[1], newFile, 1, "grok/4.5")
+}
+
+func TestGrokBuildParse_RewindKeepsHistoricalPromptsAndTokens(t *testing.T) {
+	session := setupGrokBuildTestSession(t, false)
+	base := time.Date(2026, 7, 23, 22, 0, 0, 0, time.UTC)
+	promptIndex := 0
+
+	session.writeUpdates(t, []string{
+		grokBuildTestEnvelope(t, session.id, "session/update", base.Add(time.Second),
+			grokBuildTestUserUpdate("old branch", "grok-3", &promptIndex)),
+		grokBuildTestEnvelope(t, session.id, "session/update", base.Add(2*time.Second),
+			map[string]any{"sessionUpdate": "agent_message_chunk"}),
+		grokBuildTestEnvelope(t, session.id, "_x.ai/session/update", base.Add(3*time.Second),
+			grokBuildTestTurnCompleted(10, 2)),
+		grokBuildTestEnvelope(t, session.id, "_x.ai/session/update", base.Add(4*time.Second),
+			map[string]any{"sessionUpdate": "rewind_marker", "target_prompt_index": 0}),
+		grokBuildTestEnvelope(t, session.id, "session/update", base.Add(5*time.Second),
+			grokBuildTestUserUpdate("new branch", "grok-4.5", &promptIndex)),
+		grokBuildTestEnvelope(t, session.id, "session/update", base.Add(6*time.Second),
+			map[string]any{"sessionUpdate": "agent_message_chunk"}),
+		grokBuildTestEnvelope(t, session.id, "_x.ai/session/update", base.Add(7*time.Second),
+			grokBuildTestTurnCompleted(4, 1)),
+	})
+	session.writeHunks(t, nil)
+
+	got, err := (ai.GrokBuild{After: base}).Parse(context.Background())
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.Equal(t, len([]rune("old branch")), got[0].AIPromptLength)
+	assert.EqualValues(t, 10, got[0].AIInputTokens)
+	assert.EqualValues(t, 2, got[0].AIOutputTokens)
+	assert.Equal(t, len([]rune("new branch")), got[1].AIPromptLength)
+	assert.EqualValues(t, 4, got[1].AIInputTokens)
+	assert.EqualValues(t, 1, got[1].AIOutputTokens)
+}
+
+func TestGrokBuildParse_ReusedPromptIndexUsesCurrentGenerationForUpdatedHunk(t *testing.T) {
+	session := setupGrokBuildTestSession(t, false)
+	base := time.Date(2026, 7, 23, 22, 0, 0, 0, time.UTC)
+	promptIndex := 0
+
+	session.writeUpdates(t, []string{
+		grokBuildTestEnvelope(t, session.id, "session/update", base.Add(time.Second),
+			grokBuildTestUserUpdate("old branch", "grok-3", &promptIndex)),
+		grokBuildTestEnvelope(t, session.id, "session/update", base.Add(1200*time.Millisecond),
+			map[string]any{"sessionUpdate": "agent_message_chunk"}),
+		grokBuildTestEnvelope(t, session.id, "_x.ai/session/update", base.Add(2*time.Second),
+			map[string]any{"sessionUpdate": "rewind_marker", "target_prompt_index": 0}),
+		grokBuildTestEnvelope(t, session.id, "session/update", base.Add(3*time.Second),
+			grokBuildTestUserUpdate("new branch", "grok-4.5", &promptIndex)),
+		grokBuildTestEnvelope(t, session.id, "session/update", base.Add(3200*time.Millisecond),
+			map[string]any{"sessionUpdate": "agent_message_chunk"}),
+	})
+
+	editFile := filepath.Join(session.projectDir, "main.go")
+	createdAt := base.Add(1500 * time.Millisecond)
+	session.writeHunks(t, []string{
+		grokBuildTestHunk(t, session.id, "reused", editFile, createdAt,
+			"added", "agent", &promptIndex, 1, 0),
+		// Grok persists hunk.created_at for updated records, so this timestamp
+		// intentionally remains older than the rewound prompt generation.
+		grokBuildTestHunk(t, session.id, "reused", editFile, createdAt,
+			"updated", "agent", &promptIndex, 2, 0),
+	})
+
+	got, err := (ai.GrokBuild{After: base}).Parse(context.Background())
+	require.NoError(t, err)
+
+	var fileHeartbeats []heartbeat.Heartbeat
+
+	for _, h := range got {
+		if h.EntityType == heartbeat.FileType {
+			fileHeartbeats = append(fileHeartbeats, h)
+		}
+	}
+
+	require.Len(t, fileHeartbeats, 2)
+	assertGrokBuildFileHeartbeat(t, fileHeartbeats[0], editFile, 1, "grok/3")
+	assertGrokBuildFileHeartbeat(t, fileHeartbeats[1], editFile, 2, "grok/4.5")
+}
+
+func TestGrokBuildParse_OversizedRecordsDoNotBlockFollowingLines(t *testing.T) {
+	session := setupGrokBuildTestSession(t, false)
+	base := time.Date(2026, 7, 23, 22, 0, 0, 0, time.UTC)
+	promptIndex := 0
+	oversized := strings.Repeat("x", 10*1024*1024+1)
+
+	session.writeUpdates(t, []string{
+		`{"padding":"` + oversized + `"}`,
+		grokBuildTestEnvelope(t, session.id, "session/update", base.Add(time.Second),
+			grokBuildTestUserUpdate("still parsed", "grok-4.5", &promptIndex)),
+		grokBuildTestEnvelope(t, session.id, "_x.ai/session/update", base.Add(2*time.Second),
+			grokBuildTestTurnCompleted(3, 1)),
+	})
+
+	editFile := filepath.Join(session.projectDir, "main.go")
+	session.writeHunks(t, []string{
+		`{"padding":"` + oversized + `"}`,
+		grokBuildTestHunk(t, session.id, "valid", editFile, base.Add(3*time.Second),
+			"added", "agent", &promptIndex, 1, 0),
+	})
+
+	got, err := (ai.GrokBuild{After: base}).Parse(context.Background())
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.Equal(t, len([]rune("still parsed")), got[0].AIPromptLength)
+	assert.EqualValues(t, 3, got[0].AIInputTokens)
+	assertGrokBuildFileHeartbeat(t, got[1], editFile, 1, "grok/4.5")
+}
+
+func TestGrokBuildParse_CustomHomeAndNativePaths(t *testing.T) {
+	session := setupGrokBuildTestSession(t, true)
+	base := time.Date(2026, 7, 23, 22, 0, 0, 0, time.UTC)
+	promptIndex := 0
+
+	session.writeUpdates(t, []string{
+		grokBuildTestEnvelope(t, session.id, "session/update", base.Add(time.Second),
+			grokBuildTestUserUpdate("custom home", "grok-4.5", &promptIndex)),
+	})
+
+	editFile := filepath.Join(session.projectDir, "main.go")
+	session.writeHunks(t, []string{
+		grokBuildTestHunk(t, session.id, "valid", editFile, base.Add(2*time.Second),
+			"added", "agent", &promptIndex, 1, 0),
+	})
+
+	badSessionDir := filepath.Join(session.grokHome, "sessions", "bad", "bad-session")
+	require.NoError(t, os.MkdirAll(badSessionDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(badSessionDir, "summary.json"),
+		[]byte(`{"invalid":`),
+		0o644,
+	))
+
+	got, err := (ai.GrokBuild{After: base}).Parse(context.Background())
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.Equal(t, session.projectDir, got[0].ProjectPathOverride)
+	assert.Equal(t, editFile, got[1].Entity)
+	assert.Contains(t, got[0].UserAgent, "grok-build/0.2.111")
+}
+
+func assertGrokBuildFileHeartbeat(
+	t *testing.T,
+	h heartbeat.Heartbeat,
+	entity string,
+	lineChanges int,
+	model string,
+) {
+	t.Helper()
+	assert.Equal(t, heartbeat.FileType, h.EntityType)
+	assert.Equal(t, entity, h.Entity)
+	require.NotNil(t, h.AILineChanges)
+	assert.Equal(t, lineChanges, *h.AILineChanges)
+	require.NotNil(t, h.IsWrite)
+	assert.True(t, *h.IsWrite)
+	assert.Contains(t, h.UserAgent, model)
+}
+
+func setupGrokBuildTestSession(t *testing.T, customHome bool) grokBuildTestSession {
+	t.Helper()
+
+	home := t.TempDir()
+
+	grokHome := filepath.Join(home, ".grok")
+	if customHome {
+		grokHome = t.TempDir()
+	}
+
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	if customHome {
+		t.Setenv("GROK_HOME", grokHome)
+	} else {
+		t.Setenv("GROK_HOME", "")
+	}
+
+	projectDir := filepath.Join(home, "project")
+	require.NoError(t, os.MkdirAll(projectDir, 0o755))
+
+	sessionID := "019f90c0-6137-79c2-b26e-ef83b2cecfd1"
+	sessionDir := filepath.Join(grokHome, "sessions", "project", sessionID)
+	require.NoError(t, os.MkdirAll(sessionDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(grokHome, "version.json"),
+		[]byte(`{"version":"0.2.111"}`),
+		0o644,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(sessionDir, "summary.json"),
+		[]byte(`{
+  "info": {"id": "`+sessionID+`", "cwd": "`+filepath.ToSlash(projectDir)+`"},
+  "current_model_id": "grok-4.5",
+  "git_root_dir": "`+filepath.ToSlash(projectDir)+`/"
+}`),
+		0o644,
+	))
+
+	return grokBuildTestSession{
+		grokHome:   grokHome,
+		dir:        sessionDir,
+		id:         sessionID,
+		projectDir: projectDir,
+	}
+}
+
+func (s grokBuildTestSession) writeUpdates(t *testing.T, lines []string) {
+	t.Helper()
+	writeGrokBuildJSONL(t, filepath.Join(s.dir, "updates.jsonl"), lines)
+}
+
+func (s grokBuildTestSession) writeHunks(t *testing.T, lines []string) {
+	t.Helper()
+	writeGrokBuildJSONL(t, filepath.Join(s.dir, "hunk_records.jsonl"), lines)
+}
+
+func writeGrokBuildJSONL(t *testing.T, path string, lines []string) {
+	t.Helper()
+
+	contents := ""
+	if len(lines) > 0 {
+		contents = strings.Join(lines, "\n") + "\n"
+	}
+
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o644))
+}
+
+func grokBuildTestEnvelope(
+	t *testing.T,
+	sessionID string,
+	method string,
+	timestamp time.Time,
+	update map[string]any,
+) string {
+	t.Helper()
+
+	return mustJSONLine(t, map[string]any{
+		"timestamp": timestamp.Unix(),
+		"method":    method,
+		"params":    grokBuildTestParams(sessionID, timestamp, update),
+	})
+}
+
+func grokBuildTestRawUpdate(
+	t *testing.T,
+	sessionID string,
+	timestamp time.Time,
+	update map[string]any,
+) string {
+	t.Helper()
+	return mustJSONLine(t, grokBuildTestParams(sessionID, timestamp, update))
+}
+
+func grokBuildTestParams(sessionID string, timestamp time.Time, update map[string]any) map[string]any {
+	return map[string]any{
+		"sessionId": sessionID,
+		"update":    update,
+		"_meta":     map[string]any{"agentTimestampMs": timestamp.UnixMilli()},
+	}
+}
+
+func grokBuildTestUserUpdate(text string, model string, promptIndex *int) map[string]any {
+	meta := map[string]any{"modelId": model}
+	if promptIndex != nil {
+		meta["promptIndex"] = *promptIndex
+	}
+
+	return map[string]any{
+		"sessionUpdate": "user_message_chunk",
+		"content":       map[string]any{"type": "text", "text": text},
+		"_meta":         meta,
+	}
+}
+
+func grokBuildTestTurnCompleted(input int64, output int64) map[string]any {
+	return map[string]any{
+		"sessionUpdate": "turn_completed",
+		"usage": map[string]any{
+			"inputTokens":  input,
+			"outputTokens": output,
+		},
+	}
+}
+
+func grokBuildTestHunk(
+	t *testing.T,
+	sessionID string,
+	hunkID string,
+	filePath string,
+	timestamp time.Time,
+	eventType string,
+	authorType string,
+	promptIndex *int,
+	linesAdded int,
+	linesRemoved int,
+) string {
+	t.Helper()
+
+	hunk := map[string]any{
+		"hunkId":       hunkID,
+		"filePath":     filepath.ToSlash(filePath),
+		"linesAdded":   linesAdded,
+		"linesRemoved": linesRemoved,
+		"eventType":    eventType,
+		"sessionId":    sessionID,
+		"timestamp":    timestamp,
+	}
+	if authorType != "" {
+		hunk["authorType"] = authorType
+	}
+
+	if promptIndex != nil {
+		hunk["promptIndex"] = *promptIndex
+	}
+
+	return mustJSONLine(t, hunk)
+}

--- a/pkg/ai/helpers_internal_test.go
+++ b/pkg/ai/helpers_internal_test.go
@@ -28,6 +28,8 @@ func TestParserIDStringAndPlugins(t *testing.T) {
 	assert.Equal(t, "Claude/1.2.3", aiPlugin(Claude{}, "1.2.3"))
 	assert.Equal(t, "Codex", aiPlugin(Codex{}, ""))
 	assert.Equal(t, "Codex/1.2.3", aiPlugin(Codex{}, "1.2.3"))
+	assert.Equal(t, "Grok Build", aiPlugin(GrokBuild{}, ""))
+	assert.Equal(t, "Grok Build/1.2.3", aiPlugin(GrokBuild{}, "1.2.3"))
 	assert.Equal(t, "opus/4.1-medium", aiModelUserAgentToken("claude-opus-4.1", "medium"))
 	assert.Equal(t, "fable/5", aiModelUserAgentToken("claude-fable-5", ""))
 	assert.Equal(t, "fable/5-high", aiModelUserAgentToken("claude-fable-5", "high"))

--- a/pkg/ai/parser_empty_home_internal_test.go
+++ b/pkg/ai/parser_empty_home_internal_test.go
@@ -12,6 +12,7 @@ func TestParsersEmptyHome(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
+	t.Setenv("GROK_HOME", "")
 
 	after := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
 	parsers := []Parser{
@@ -25,6 +26,7 @@ func TestParsersEmptyHome(t *testing.T) {
 		Cursor{After: after},
 		Gemini{After: after},
 		Goose{After: after},
+		GrokBuild{After: after},
 		Kiro{After: after},
 		OpenCode{After: after},
 		Pi{After: after},


### PR DESCRIPTION
Reads JSON files:

  - `$GROK_HOME/sessions/**/summary.json` — discovers sessions and reads session ID, project path, and fallback model.
  - Same directory’s `updates.jsonl` — prompts, model metadata, token usage, and rewind events.
  - Same directory’s `hunk_records.jsonl` — per-file AI line changes and removals.
  - `$GROK_HOME/version.json` — Grok Build CLI version for the user agent.

  `$GROK_HOME` defaults to `~/.grok`.