### PR TITLE
feat: add Codex source override

### DIFF
--- a/cmd/heartbeat/heartbeat.go
+++ b/cmd/heartbeat/heartbeat.go
@@ -228,6 +228,7 @@ func applyAIParsing(
 	heartbeats []heartbeat.Heartbeat,
 ) ([]heartbeat.Heartbeat, error) {
 	handle := ai.WithAISync(ai.Config{
+		CodexSource:  params.AI.CodexSource,
 		SyncDisabled: params.AI.SyncDisabled,
 		Plugin:       params.API.Plugin,
 		Project:      params.Heartbeat.Project,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -215,6 +215,7 @@ func setFlags(cmd *cobra.Command, v *viper.Viper) {
 		"",
 		"Format output. Can be \"text\", \"json\" or \"raw-json\". Defaults to \"text\".",
 	)
+	flags.String("codex-source", "", "(internal) Override the Codex transcript source used for AI activity.")
 	flags.String("plugin", "", "Optional text editor plugin name and version for User-Agent header.")
 	flags.Int("print-offline-heartbeats", offline.PrintMaxDefault, "Prints offline heartbeats to stdout.")
 	flags.String("project", "", "Override auto-detected project."+
@@ -310,6 +311,7 @@ func setFlags(cmd *cobra.Command, v *viper.Viper) {
 	// hide internal flags
 	_ = flags.MarkHidden("offline-queue-file")
 	_ = flags.MarkHidden("offline-queue-file-legacy")
+	_ = flags.MarkHidden("codex-source")
 	_ = flags.MarkHidden("user-agent")
 
 	err := v.BindPFlags(flags)

--- a/cmd/root_internal_test.go
+++ b/cmd/root_internal_test.go
@@ -37,3 +37,16 @@ func TestSyncAIHeartbeatsFlagHidden(t *testing.T) {
 	require.NotNil(t, flag)
 	assert.True(t, flag.Hidden)
 }
+
+func TestCodexSourceFlag(t *testing.T) {
+	v := vipertools.MustNew()
+	command := &cobra.Command{}
+	setFlags(command, v)
+
+	flag := command.Flags().Lookup("codex-source")
+	require.NotNil(t, flag)
+	assert.True(t, flag.Hidden)
+
+	require.NoError(t, command.ParseFlags([]string{"--codex-source", "kandev"}))
+	assert.Equal(t, "kandev", v.GetString("codex-source"))
+}

--- a/pkg/ai/ai.go
+++ b/pkg/ai/ai.go
@@ -24,6 +24,7 @@ import (
 
 // Config contains filtering configurations.
 type Config struct {
+	CodexSource  string
 	SyncDisabled bool
 	Plugin       string
 	Project      params.ProjectParams
@@ -41,6 +42,7 @@ type ProjectInfo struct {
 // ParserConfig contains the arguments for each Parser implementation.
 type ParserConfig struct {
 	After             time.Time
+	CodexSource       string
 	FallbackUserAgent string
 	UserAgents        map[string]string
 	ProjectInfo       ProjectInfo
@@ -273,6 +275,7 @@ func parseAIHeartbeats(
 		},
 		Codex{
 			After:             after,
+			CodexSource:       config.CodexSource,
 			UserAgents:        userAgents,
 			FallbackUserAgent: config.Plugin,
 		},

--- a/pkg/ai/ai_test.go
+++ b/pkg/ai/ai_test.go
@@ -950,8 +950,9 @@ func TestWithAISync_ProducesExpectedHeartbeats(t *testing.T) {
 	v.Set("internal.ai_logs_last_parsed_at", after.Format(ini.DateFormat))
 
 	handle := ai.WithAISync(ai.Config{
-		Plugin: "plugin/0.0.1",
-		V:      v,
+		CodexSource: "kandev",
+		Plugin:      "plugin/0.0.1",
+		V:           v,
 	})(func(_ context.Context, hh []heartbeat.Heartbeat) ([]heartbeat.Result, error) {
 		results := make([]heartbeat.Result, len(hh))
 		for i := range hh {
@@ -980,6 +981,7 @@ func TestWithAISync_ProducesExpectedHeartbeats(t *testing.T) {
 	assert.Equal(t, "/Users/user/git/wakatime-cli", h.ProjectPathOverride)
 	assert.Equal(t, "019d9353-333c-7c41-a909-26f5c6221a5a", h.AISession)
 	assert.Equal(t, "plus", h.AISubscriptionPlan)
+	assert.Contains(t, h.UserAgent, "codex-kandev/0.119.0-alpha.28")
 
 	h = heartbeats[1].Heartbeat
 	assert.Equal(t, float64(1776297784039)/1000, h.Time)
@@ -995,6 +997,7 @@ func TestWithAISync_ProducesExpectedHeartbeats(t *testing.T) {
 	assert.Equal(t, "/Users/user/git/wakatime-cli", h.ProjectPathOverride)
 	assert.Equal(t, "019d9353-333c-7c41-a909-26f5c6221a5a", h.AISession)
 	assert.Equal(t, "plus", h.AISubscriptionPlan)
+	assert.Contains(t, h.UserAgent, "codex-kandev/0.119.0-alpha.28")
 
 	h = heartbeats[2].Heartbeat
 	assert.Equal(t, float64(1776297789438)/1000, h.Time)
@@ -1010,6 +1013,7 @@ func TestWithAISync_ProducesExpectedHeartbeats(t *testing.T) {
 	assert.Equal(t, "/Users/user/git/wakatime-cli", h.ProjectPathOverride)
 	assert.Equal(t, "019d9353-333c-7c41-a909-26f5c6221a5a", h.AISession)
 	assert.Equal(t, "plus", h.AISubscriptionPlan)
+	assert.Contains(t, h.UserAgent, "codex-kandev/0.119.0-alpha.28")
 }
 
 func TestWithAISync_PreservesCopilotTokensAfterMergingAppHeartbeat(t *testing.T) {

--- a/pkg/ai/codex.go
+++ b/pkg/ai/codex.go
@@ -1203,7 +1203,7 @@ func codexMoveFilePath(cwd string, line string) string {
 	return filepath.Join(cwd, file)
 }
 
-func (Codex) userAgent(
+func (g Codex) userAgent(
 	entity string,
 	agentVersion string,
 	version string,
@@ -1211,6 +1211,10 @@ func (Codex) userAgent(
 	userAgents map[string]string,
 	fallbackUserAgent string,
 ) string {
+	if override := strings.TrimSpace(g.CodexSource); override != "" {
+		source = override
+	}
+
 	return aiUserAgentWithModelAndEditor(
 		entity,
 		userAgents,

--- a/pkg/params/params.go
+++ b/pkg/params/params.go
@@ -901,8 +901,13 @@ func loadProjectMapPatterns(ctx context.Context, v *viper.Viper, prefix string) 
 
 // LoadAIParams loads ai sync params from viper.Viper instance.
 func LoadAIParams(_ context.Context, v *viper.Viper, _ FlagReadOrder) (AIParams, error) {
+	codexSource := vipertools.GetString(v, "codex-source")
+	if codexSource == "" {
+		codexSource = os.Getenv("WAKATIME_CODEX_SOURCE")
+	}
+
 	return AIParams{
-		CodexSource: vipertools.GetString(v, "codex-source"),
+		CodexSource: codexSource,
 		SyncDisabled: v.GetBool("sync-ai-disable") ||
 			v.GetBool("sync-ai-disabled") ||
 			v.GetBool("settings.sync_ai_disabled"),

--- a/pkg/params/params.go
+++ b/pkg/params/params.go
@@ -250,6 +250,7 @@ type (
 
 	// AIParams contains AI sync command parameters.
 	AIParams struct {
+		CodexSource  string
 		SyncDisabled bool
 	}
 
@@ -901,6 +902,7 @@ func loadProjectMapPatterns(ctx context.Context, v *viper.Viper, prefix string) 
 // LoadAIParams loads ai sync params from viper.Viper instance.
 func LoadAIParams(_ context.Context, v *viper.Viper, _ FlagReadOrder) (AIParams, error) {
 	return AIParams{
+		CodexSource: vipertools.GetString(v, "codex-source"),
 		SyncDisabled: v.GetBool("sync-ai-disable") ||
 			v.GetBool("sync-ai-disabled") ||
 			v.GetBool("settings.sync_ai_disabled"),

--- a/pkg/params/params_test.go
+++ b/pkg/params/params_test.go
@@ -66,6 +66,15 @@ func TestLoadHeartbeatParams_FlagTakesPrecedence(t *testing.T) {
 	assert.True(t, params.GuessLanguage)
 }
 
+func TestLoadAIParams_CodexSource(t *testing.T) {
+	v := vipertools.MustNew()
+	v.Set("codex-source", "kandev")
+
+	params, err := paramspkg.LoadAIParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
+	require.NoError(t, err)
+	assert.Equal(t, "kandev", params.CodexSource)
+}
+
 func TestLoadHeartbeatParams_ProjectConfigTakesPrecedence(t *testing.T) {
 	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")

--- a/pkg/params/params_test.go
+++ b/pkg/params/params_test.go
@@ -75,6 +75,27 @@ func TestLoadAIParams_CodexSource(t *testing.T) {
 	assert.Equal(t, "kandev", params.CodexSource)
 }
 
+func TestLoadAIParams_CodexSourceFromEnvironment(t *testing.T) {
+	t.Setenv("WAKATIME_CODEX_SOURCE", "kandev")
+
+	v := vipertools.MustNew()
+
+	params, err := paramspkg.LoadAIParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
+	require.NoError(t, err)
+	assert.Equal(t, "kandev", params.CodexSource)
+}
+
+func TestLoadAIParams_CodexSourceFlagTakesPrecedenceOverEnvironment(t *testing.T) {
+	t.Setenv("WAKATIME_CODEX_SOURCE", "environment")
+
+	v := vipertools.MustNew()
+	v.Set("codex-source", "flag")
+
+	params, err := paramspkg.LoadAIParams(t.Context(), v, paramspkg.FlagReadOrderFlagPrecedence)
+	require.NoError(t, err)
+	assert.Equal(t, "flag", params.CodexSource)
+}
+
 func TestLoadHeartbeatParams_ProjectConfigTakesPrecedence(t *testing.T) {
 	v := vipertools.MustNew()
 	v.Set("entity", "/path/to/file")


### PR DESCRIPTION
**Describe the pull request**

This PR adds an opt-in `--codex-source` flag and `WAKATIME_CODEX_SOURCE` environment variable for AI heartbeat sync. When either is set, the Codex parser uses the supplied source for editor attribution instead of the source recorded in the transcript. The explicit flag takes precedence over the environment variable. If neither is set, the existing transcript-source behavior is unchanged.

When an application runs `codex-acp`, and `codex-acp` starts Codex app-server, the transcript source is currently hardcoded to `vscode`. WakaTime uses that source for editor attribution, so it reports the session as `Codex VSCode` even when another application, such as Kandev, is the tool actually invoking Codex.

The better long-term fix is for upstream `codex-acp` and Codex to support a dynamic source supplied by the application that starts them. This underlying Codex issue is already tracked in [openai/codex#23442](https://github.com/openai/codex/issues/23442). This WakaTime override is temporary support while we wait for a maintainer fix upstream. Once that support is available, integrations such as `codex-acp` can pass the correct source directly. Until then, this override lets the invoking application identify itself so WakaTime can report `codex-kandev/<version>` correctly without changing Codex transcripts.

For the current Kandev ACP workaround, configure the environment inherited by the WakaTime plugin and CLI:

```sh
WAKATIME_CODEX_SOURCE=kandev
```

The WakaTime Codex plugin already forwards its environment to `wakatime-cli`.

**Testing**

- `make test`
- `make test-integration`
- `make test-ip`
- `go test ./pkg/ai ./pkg/params ./cmd ./cmd/heartbeat -count=1`
- `golangci-lint run ./pkg/ai ./pkg/params ./cmd ./cmd/heartbeat`
- Shell tests were not run because `bats` is not installed in the environment.

The full `make test-all` target is also blocked by two existing `gosec` findings in `pkg/api/heartbeat.go`.
