### PR TITLE
Respect CODEX_HOME env

### DIFF
--- a/pkg/ai/codex.go
+++ b/pkg/ai/codex.go
@@ -146,12 +146,11 @@ func (g Codex) Parse(ctx context.Context) (Heartbeats, error) {
 }
 
 func (g Codex) transcriptPaths(ctx context.Context) ([]string, error) {
-	home, err := ini.UserHomeDir(ctx)
+	sessionsDir, err := codexSessionsDir(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find user home dir: %s", err)
+		return nil, err
 	}
 
-	sessionsDir := filepath.Join(home, ".codex", "sessions")
 	if _, err := os.Stat(sessionsDir); err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
@@ -185,6 +184,23 @@ func (g Codex) transcriptPaths(ctx context.Context) ([]string, error) {
 	}
 
 	return transcripts, nil
+}
+
+func codexSessionsDir(ctx context.Context) (string, error) {
+	home, err := ini.UserHomeDir(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to find user home dir: %s", err)
+	}
+
+	sessionsDir := filepath.Join(home, ".codex", "sessions")
+	if configuredHome := strings.TrimSpace(os.Getenv("CODEX_HOME")); configuredHome != "" {
+		sessionsDir, err = filepath.Abs(filepath.Join(configuredHome, "sessions"))
+		if err != nil {
+			return "", fmt.Errorf("failed to resolve CODEX_HOME: %s", err)
+		}
+	}
+
+	return sessionsDir, nil
 }
 
 func (g Codex) parseTranscript(ctx context.Context, transcript string) (Heartbeats, error) {


### PR DESCRIPTION
Use CODEX_HOME for Codex sessions while preserving the default path when
it is unset.

Even when `CODEX_HOME` is set, the Codex parser still scans the hardcoded
`$HOME/.codex/sessions` path and misses sessions stored under
`$CODEX_HOME/sessions`. This PR makes the parser use `CODEX_HOME`
while keeping the default path when the environment variable is unset.