### PR TITLE
DeepSeek Harness AI parser

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/go-viper/encoding/ini v0.1.1
 	github.com/juju/mutex v0.0.0-20180619145857-d21b13acf4bf
 	github.com/kevinburke/ssh_config v1.4.0
+	github.com/klauspost/compress v1.19.2
 	github.com/matishsiao/goInfo v0.0.0-20241216093258-66a9250504d6
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/sftp v1.13.10

--- a/go.sum
+++ b/go.sum
@@ -86,6 +86,8 @@ github.com/juju/version v0.0.0-20210303051006-2015802527a8/go.mod h1:YUOK6VK9+V4
 github.com/julienschmidt/httprouter v1.1.1-0.20151013225520-77a895ad01eb/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kevinburke/ssh_config v1.4.0 h1:6xxtP5bZ2E4NF5tuQulISpTO2z8XbtH8cg1PWkxoFkQ=
 github.com/kevinburke/ssh_config v1.4.0/go.mod h1:q2RIzfka+BXARoNexmF9gkxEX7DmvbW9P4hIVx2Kg4M=
+github.com/klauspost/compress v1.19.2 h1:hMRETovs/pu/dVWN7zIT1PGG8t509MwT6bO7XSi26R8=
+github.com/klauspost/compress v1.19.2/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=

--- a/pkg/ai/ai.go
+++ b/pkg/ai/ai.go
@@ -101,6 +101,8 @@ const (
 	DevinParser
 	// DroidParser is the parser ID for Droid.
 	DroidParser
+	// DshParser is the parser ID for DeepSeek Harness.
+	DshParser
 	// ForgeParser is the parser ID for Forge.
 	ForgeParser
 	// HermesParser is the parser ID for Hermes Agent.
@@ -387,6 +389,11 @@ func parseAIHeartbeats(
 			FallbackUserAgent: config.Plugin,
 		},
 		Droid{
+			After:             after,
+			UserAgents:        userAgents,
+			FallbackUserAgent: config.Plugin,
+		},
+		Dsh{
 			After:             after,
 			UserAgents:        userAgents,
 			FallbackUserAgent: config.Plugin,

--- a/pkg/ai/dsh.go
+++ b/pkg/ai/dsh.go
@@ -1,0 +1,542 @@
+package ai
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/klauspost/compress/zstd"
+
+	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
+	"github.com/wakatime/wakatime-cli/pkg/ini"
+	"github.com/wakatime/wakatime-cli/pkg/log"
+)
+
+// Dsh contains parameters for detecting heartbeats from DeepSeek Harness session logs.
+type Dsh ParserConfig
+
+type (
+	dshSessionState struct {
+		cwd string
+		id  string
+	}
+
+	dshParseState struct {
+		heartbeats Heartbeats
+		tokens     heartbeat.AITokens
+		model      string
+		toolCalls  map[string]dshToolCall
+	}
+
+	dshContentBlock struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+
+	dshMessageSource struct {
+		Kind     string `json:"kind"`
+		Provider string `json:"provider"`
+		Model    string `json:"model"`
+	}
+
+	dshHeader struct {
+		Config *dshMessageSource `json:"config"`
+	}
+
+	dshMessage struct {
+		Role    string            `json:"role"`
+		Content []dshContentBlock `json:"content"`
+		Source  *dshMessageSource `json:"source"`
+	}
+
+	dshUsage struct {
+		InputTokens     *int64 `json:"inputTokens"`
+		OutputTokens    *int64 `json:"outputTokens"`
+		CacheReadTokens *int64 `json:"cacheReadTokens"`
+	}
+
+	dshEventData struct {
+		Role      string            `json:"role"`
+		Content   []dshContentBlock `json:"content"`
+		Message   *dshMessage       `json:"message"`
+		Usage     *dshUsage         `json:"usage"`
+		CallID    string            `json:"callId"`
+		Name      string            `json:"name"`
+		Arguments json.RawMessage   `json:"arguments"`
+		Provider  string            `json:"provider"`
+		Model     string            `json:"model"`
+		Header    *dshHeader        `json:"header"`
+		ID        string            `json:"id"`
+		Cwd       string            `json:"cwd"`
+	}
+
+	dshLogLine struct {
+		Type string       `json:"type"`
+		Time int64        `json:"time"` // epoch milliseconds.
+		Data dshEventData `json:"data"`
+		ID   string       `json:"id"`
+		Cwd  string       `json:"cwd"`
+	}
+
+	dshToolCall struct {
+		Name      string
+		Arguments map[string]interface{}
+	}
+)
+
+// Parse parses the DeepSeek Harness session logs for ai heartbeats.
+func (g Dsh) Parse(ctx context.Context) (Heartbeats, error) {
+	logger := log.Extract(ctx)
+
+	transcripts, err := g.transcriptPaths(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(transcripts) == 0 {
+		return Heartbeats{}, nil
+	}
+
+	logger.Debugf("Found %d transcript logs modified after %s for %s", len(transcripts), g.After, g.Name())
+
+	var heartbeats Heartbeats
+
+	for _, transcript := range transcripts {
+		parsed, err := g.parseTranscript(ctx, transcript)
+		if err != nil {
+			logger.Warnf("failed parsing deepseek harness transcript %q: %s", transcript, err)
+			continue
+		}
+
+		heartbeats = append(heartbeats, parsed...)
+	}
+
+	return heartbeats, nil
+}
+
+// Name returns its id.
+func (Dsh) Name() string { return "DeepSeek Harness" }
+
+func (g Dsh) transcriptPaths(ctx context.Context) ([]string, error) {
+	home, err := ini.UserHomeDir(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find user home dir: %s", err)
+	}
+
+	sessionsDir := filepath.Join(envOrDefault("DSH_HOME", filepath.Join(home, ".dsh")), "sessions")
+	if _, err := os.Stat(sessionsDir); err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+
+		return nil, fmt.Errorf("failed to stat .dsh sessions directory: %s", err)
+	}
+
+	var transcripts []string
+
+	err = filepath.WalkDir(sessionsDir, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".jsonl.zstd") {
+			return nil
+		}
+
+		info, err := entry.Info()
+		if err != nil || !timestampAtOrAfterCutoff(info.ModTime(), g.After) {
+			return nil
+		}
+
+		transcripts = append(transcripts, path)
+
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to walk .dsh sessions directory: %s", err)
+	}
+
+	return transcripts, nil
+}
+
+func (g Dsh) parseTranscript(ctx context.Context, transcript string) (Heartbeats, error) {
+	logger := log.Extract(ctx)
+
+	//nolint:gosec
+	fh, err := os.Open(filepath.Clean(transcript))
+	if err != nil {
+		return nil, fmt.Errorf("failed to open deepseek harness transcript %q: %s", transcript, err)
+	}
+	defer fh.Close() // nolint:errcheck,gosec
+
+	decoder, err := zstd.NewReader(fh)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create zstd reader for deepseek harness transcript %q: %s", transcript, err)
+	}
+	defer decoder.Close()
+
+	session := dshSessionState{id: dshSessionIDFromPath(transcript)}
+	state := dshParseState{toolCalls: make(map[string]dshToolCall)}
+
+	scanner := bufio.NewScanner(decoder)
+	scanner.Buffer(make([]byte, 0, 64*1024), maxTranscriptLineSize)
+
+	for scanner.Scan() {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+
+		g.handleTranscriptLine(logger, transcript, line, &session, &state)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("failed reading deepseek harness transcript %q: %s", transcript, err)
+	}
+
+	return state.heartbeats, nil
+}
+
+func (g Dsh) handleTranscriptLine(
+	logger *log.Logger,
+	transcript string,
+	line []byte,
+	session *dshSessionState,
+	state *dshParseState,
+) {
+	if len(line) == 0 {
+		return
+	}
+
+	var logLine dshLogLine
+	if err := json.Unmarshal(line, &logLine); err != nil {
+		logger.Warnf("failed parsing deepseek harness transcript line from %q: %s", transcript, err)
+		logger.Debugf("failed parsing deepseek harness transcript line: %s", line)
+
+		return
+	}
+
+	timestamp := time.UnixMilli(logLine.Time).UTC()
+
+	switch logLine.Type {
+	case "session":
+		if id := firstNonEmptyString(logLine.ID, logLine.Data.ID); id != "" {
+			session.id = strings.TrimPrefix(id, "session-")
+		}
+
+		if cwd := firstNonEmptyString(logLine.Cwd, logLine.Data.Cwd); cwd != "" {
+			session.cwd = cwd
+		}
+	case "request/header":
+		if header := logLine.Data.Header; header != nil && header.Config != nil && header.Config.Model != "" {
+			state.model = header.Config.Model
+		}
+	case "request/context":
+		if logLine.Data.Model != "" {
+			state.model = logLine.Data.Model
+		}
+	case "user/message":
+		if logLine.Time <= 0 || !timestampAtOrAfterCutoff(timestamp, g.After) {
+			return
+		}
+
+		g.userMessageHeartbeat(timestamp, *session, state, logLine.Data)
+	case "assistant/message":
+		msg := logLine.Data.Message
+		if msg == nil {
+			msg = &dshMessage{Role: logLine.Data.Role, Content: logLine.Data.Content}
+		}
+
+		if msg.Source != nil && msg.Source.Model != "" {
+			state.model = msg.Source.Model
+		}
+
+		state.tokens = g.tokenCounts(logLine.Data.Usage, state.tokens, timestamp, g.After)
+
+		if logLine.Time <= 0 || !timestampAtOrAfterCutoff(timestamp, g.After) {
+			return
+		}
+
+		g.assistantMessageHeartbeat(timestamp, *session, state, msg)
+	case "tool/call":
+		if logLine.Time <= 0 || !timestampAtOrAfterCutoff(timestamp, g.After) {
+			return
+		}
+
+		g.toolCallHeartbeat(timestamp, *session, state, logLine.Data)
+	}
+}
+
+func (g Dsh) userMessageHeartbeat(
+	timestamp time.Time,
+	session dshSessionState,
+	state *dshParseState,
+	data dshEventData,
+) {
+	var (
+		lineChanges int
+		promptChars int
+	)
+
+	for _, block := range data.Content {
+		if block.Type != "text" || strings.TrimSpace(block.Text) == "" {
+			continue
+		}
+
+		lineChanges += countStringLines(block.Text)
+		promptChars += promptLength(block.Text)
+	}
+
+	if lineChanges == 0 {
+		return
+	}
+
+	entity := g.Name()
+
+	h := heartbeat.NewWithAITokens(
+		nil,
+		session.id,
+		state.tokens,
+		"",
+		heartbeat.AICodingCategory.String(),
+		nil,
+		entity,
+		heartbeat.AppType,
+		nil,
+		false,
+		heartbeat.PointerTo(false),
+		nil,
+		"",
+		nil,
+		nil,
+		"",
+		"",
+		false,
+		"",
+		session.cwd,
+		heartbeatTimestamp(timestamp),
+		aiUserAgentWithModel(entity, g.UserAgents, g.FallbackUserAgent, state.model, ""),
+	)
+
+	if promptChars > 0 {
+		h.AIPromptLength = promptChars
+	}
+
+	state.heartbeats = append(state.heartbeats, h)
+}
+
+func (g Dsh) assistantMessageHeartbeat(
+	timestamp time.Time,
+	session dshSessionState,
+	state *dshParseState,
+	msg *dshMessage,
+) {
+	if msg == nil {
+		return
+	}
+
+	var lineChanges int
+
+	for _, block := range msg.Content {
+		if block.Type != "text" || strings.TrimSpace(block.Text) == "" {
+			continue
+		}
+
+		lineChanges += countStringLines(block.Text)
+	}
+
+	if lineChanges == 0 {
+		return
+	}
+
+	entity := g.Name()
+
+	h := heartbeat.NewWithAITokens(
+		nil,
+		session.id,
+		state.tokens,
+		"",
+		heartbeat.AICodingCategory.String(),
+		nil,
+		entity,
+		heartbeat.AppType,
+		nil,
+		false,
+		heartbeat.PointerTo(false),
+		nil,
+		"",
+		nil,
+		nil,
+		"",
+		"",
+		false,
+		"",
+		session.cwd,
+		heartbeatTimestamp(timestamp),
+		aiUserAgentWithModel(entity, g.UserAgents, g.FallbackUserAgent, state.model, ""),
+	)
+
+	state.tokens.LastInput = state.tokens.CurrentInput
+	state.tokens.LastCachedInput = state.tokens.CurrentCachedInput
+	state.tokens.LastOutput = state.tokens.CurrentOutput
+
+	state.heartbeats = append(state.heartbeats, h)
+}
+
+func (g Dsh) toolCallHeartbeat(
+	timestamp time.Time,
+	session dshSessionState,
+	state *dshParseState,
+	data dshEventData,
+) {
+	args := dshToolArguments(data.Arguments)
+
+	if data.CallID != "" && data.Name != "" {
+		state.toolCalls[data.CallID] = dshToolCall{Name: data.Name, Arguments: args}
+	}
+
+	filePath := dshToolPath(args, session.cwd)
+	if filePath == "" {
+		return
+	}
+
+	isWrite := dshIsWriteTool(data.Name)
+
+	lineChanges := 0
+	if isWrite {
+		lineChanges = dshWriteLineChanges(args)
+	}
+
+	entity := filePath
+
+	h := heartbeat.NewWithAITokens(
+		heartbeat.PointerTo(lineChanges),
+		session.id,
+		state.tokens,
+		"",
+		heartbeat.AICodingCategory.String(),
+		nil,
+		entity,
+		heartbeat.FileType,
+		nil,
+		false,
+		heartbeat.PointerTo(isWrite),
+		nil,
+		"",
+		nil,
+		nil,
+		"",
+		"",
+		false,
+		"",
+		"",
+		heartbeatTimestamp(timestamp),
+		aiUserAgentWithModel(entity, g.UserAgents, g.FallbackUserAgent, state.model, ""),
+	)
+
+	state.heartbeats = append(state.heartbeats, h)
+}
+
+func (Dsh) tokenCounts(usage *dshUsage, tokens heartbeat.AITokens, timestamp time.Time, after time.Time) heartbeat.AITokens {
+	if usage == nil {
+		return tokens
+	}
+
+	inputTokens := int64(0)
+	if usage.InputTokens != nil {
+		inputTokens = *usage.InputTokens
+	}
+
+	cachedInputTokens := int64(0)
+	if usage.CacheReadTokens != nil {
+		cachedInputTokens = max(*usage.CacheReadTokens, 0)
+	}
+
+	outputTokens := int64(0)
+	if usage.OutputTokens != nil {
+		outputTokens = *usage.OutputTokens
+	}
+
+	tokens.CurrentInput = tokens.LastInput + inputTokens
+	tokens.CurrentCachedInput = tokens.LastCachedInput + cachedInputTokens
+	tokens.CurrentOutput = tokens.LastOutput + outputTokens
+
+	if !timestampAtOrAfterCutoff(timestamp, after) {
+		tokens.LastInput = tokens.CurrentInput
+		tokens.LastCachedInput = tokens.CurrentCachedInput
+		tokens.LastOutput = tokens.CurrentOutput
+	}
+
+	return tokens
+}
+
+// dshToolArguments decodes tool call arguments, which may be a JSON object or a
+// JSON-encoded string wrapping one.
+func dshToolArguments(raw json.RawMessage) map[string]interface{} {
+	if len(raw) == 0 {
+		return nil
+	}
+
+	var obj map[string]interface{}
+	if err := json.Unmarshal(raw, &obj); err == nil {
+		return obj
+	}
+
+	var encoded string
+	if err := json.Unmarshal(raw, &encoded); err != nil {
+		return nil
+	}
+
+	var inner map[string]interface{}
+	if err := json.Unmarshal([]byte(encoded), &inner); err != nil {
+		return nil
+	}
+
+	return inner
+}
+
+func dshToolPath(args map[string]interface{}, cwd string) string {
+	// Note that file operations use "file_path"; the generic "path" key
+	// belongs to search tools like grep and glob and holds a directory.
+	for _, key := range []string{"file_path", "filePath"} {
+		if value := piStringValue(args, key); value != "" {
+			return piAbsPath(value, cwd)
+		}
+	}
+
+	return ""
+}
+
+func dshIsWriteTool(name string) bool {
+	switch strings.ToLower(name) {
+	case "edit", "write", "multiedit", "patch", "apply_patch":
+		return true
+	default:
+		return false
+	}
+}
+
+func dshWriteLineChanges(args map[string]interface{}) int {
+	for _, key := range []string{"content", "new_string", "newString", "text"} {
+		if value := piStringValue(args, key); value != "" {
+			return countStringLines(value)
+		}
+	}
+
+	return 0
+}
+
+func dshSessionIDFromPath(path string) string {
+	id := filepath.Base(filepath.Dir(path))
+
+	return strings.TrimPrefix(id, "session-")
+}

--- a/pkg/ai/dsh_test.go
+++ b/pkg/ai/dsh_test.go
@@ -1,0 +1,268 @@
+package ai_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/klauspost/compress/zstd"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wakatime/wakatime-cli/pkg/ai"
+	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
+)
+
+func dshJSONLine(t *testing.T, v interface{}) string {
+	t.Helper()
+
+	raw, err := json.Marshal(v)
+	require.NoError(t, err)
+
+	return string(raw)
+}
+
+func dshCompressTranscript(t *testing.T, dest string, lines []string) {
+	t.Helper()
+
+	require.NoError(t, os.MkdirAll(filepath.Dir(dest), 0o755))
+
+	var buf bytes.Buffer
+
+	writer, err := zstd.NewWriter(&buf)
+	require.NoError(t, err)
+
+	for _, line := range lines {
+		_, err := writer.Write([]byte(line + "\n"))
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, writer.Close())
+	require.NoError(t, os.WriteFile(dest, buf.Bytes(), 0o644))
+}
+
+func TestDshParse(t *testing.T) {
+	ctx := context.Background()
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	projectDir := filepath.Join(home, "project")
+	readFile := filepath.Join(projectDir, "README.md")
+	editFile := filepath.Join(projectDir, "main.go")
+
+	transcriptPath := filepath.Join(
+		home, ".dsh", "sessions",
+		"--tmp-project--",
+		"session-abc123",
+		"session.jsonl.zstd",
+	)
+
+	// An out-of-window request whose usage must not leak into emitted heartbeats.
+	outOfWindow := time.Date(2026, 4, 19, 11, 0, 0, 0, time.UTC)
+
+	dshCompressTranscript(t, transcriptPath, []string{
+		dshJSONLine(t, map[string]interface{}{
+			"type":      "session",
+			"version":   0,
+			"id":        "session-abc123",
+			"createdAt": 1776598800000,
+			"cwd":       projectDir,
+		}),
+		dshJSONLine(t, map[string]interface{}{
+			"type": "request/header",
+			"time": outOfWindow.UnixMilli(),
+			"data": map[string]interface{}{
+				"header": map[string]interface{}{
+					"config": map[string]interface{}{
+						"provider": "deepseek",
+						"model":    "deepseek-v4",
+					},
+				},
+			},
+		}),
+		dshJSONLine(t, map[string]interface{}{
+			"type": "assistant/message",
+			"time": outOfWindow.UnixMilli(),
+			"data": map[string]interface{}{
+				"usage": map[string]interface{}{"inputTokens": 999999, "outputTokens": 888888, "cacheReadTokens": 777777},
+				"message": map[string]interface{}{
+					"role": "assistant",
+					"content": []map[string]interface{}{
+						{"type": "text", "text": "old summary"},
+					},
+					"source": map[string]interface{}{"kind": "model", "provider": "deepseek", "model": "deepseek-v4"},
+				},
+			},
+		}),
+		dshJSONLine(t, map[string]interface{}{
+			"type": "assistant/chunk",
+			"time": 1776600000000,
+			"data": map[string]interface{}{
+				"chunk": map[string]interface{}{
+					"type":  "usage",
+					"usage": map[string]interface{}{"inputTokens": 1, "outputTokens": 2},
+				},
+			},
+		}),
+		dshJSONLine(t, map[string]interface{}{
+			"type": "user/message",
+			"time": 1776600001000,
+			"data": map[string]interface{}{
+				"role": "user",
+				"content": []map[string]interface{}{
+					{"type": "text", "text": "Inspect the project and fix main.go"},
+				},
+			},
+		}),
+		dshJSONLine(t, map[string]interface{}{
+			"type": "tool/call",
+			"time": 1776600002000,
+			"data": map[string]interface{}{
+				"name":      "read",
+				"arguments": `{"file_path":"` + readFile + `"}`,
+			},
+		}),
+		dshJSONLine(t, map[string]interface{}{
+			"type": "tool/call",
+			"time": 1776600003000,
+			"data": map[string]interface{}{
+				"name":      "edit",
+				"arguments": `{"file_path":"` + editFile + `","old_string":"old\nline\n","new_string":"new\nlines\nhere\n"}`,
+			},
+		}),
+		dshJSONLine(t, map[string]interface{}{
+			"type": "tool/call",
+			"time": 1776600003500,
+			"data": map[string]interface{}{
+				"name":      "bash",
+				"arguments": `{"command":"go test ./..."}`,
+			},
+		}),
+		dshJSONLine(t, map[string]interface{}{
+			"type": "tool/call",
+			"time": 1776600003600,
+			"data": map[string]interface{}{
+				"name":      "grep",
+				"arguments": `{"pattern":"TODO","path":"` + projectDir + `"}`,
+			},
+		}),
+		dshJSONLine(t, map[string]interface{}{
+			"type": "assistant/message",
+			"time": 1776600004000,
+			"data": map[string]interface{}{
+				"usage": map[string]interface{}{"inputTokens": 100, "outputTokens": 50, "cacheReadTokens": 200},
+				"message": map[string]interface{}{
+					"role": "assistant",
+					"content": []map[string]interface{}{
+						{"type": "reasoning", "text": "thinking"},
+						{"type": "text", "text": "Fixed the parser.\nAll tests pass."},
+					},
+					"source": map[string]interface{}{"kind": "model", "provider": "deepseek", "model": "deepseek-v4"},
+				},
+			},
+		}),
+	})
+
+	parser := ai.Dsh{
+		After:             time.Date(2026, 4, 19, 11, 59, 0, 0, time.UTC),
+		FallbackUserAgent: "plugin/0.0.1",
+	}
+
+	got, err := parser.Parse(ctx)
+	require.NoError(t, err)
+	require.Len(t, got, 4)
+
+	assert.Equal(t, "DeepSeek Harness", got[0].Entity)
+	assert.Equal(t, heartbeat.AppType, got[0].EntityType)
+	assert.Equal(t, "abc123", got[0].AISession)
+	assert.Equal(t, len([]rune("Inspect the project and fix main.go")), got[0].AIPromptLength)
+	assert.Equal(t, heartbeat.AICodingCategory.String(), got[0].Category)
+	assert.Equal(t, projectDir, got[0].ProjectPathOverride)
+	require.NotNil(t, got[0].IsWrite)
+	assert.False(t, *got[0].IsWrite)
+	assert.Equal(t, float64(1776600001), got[0].Time)
+
+	assert.Equal(t, readFile, got[1].Entity)
+	assert.Equal(t, heartbeat.FileType, got[1].EntityType)
+	assert.Equal(t, "abc123", got[1].AISession)
+	require.NotNil(t, got[1].AILineChanges)
+	assert.Zero(t, *got[1].AILineChanges)
+	require.NotNil(t, got[1].IsWrite)
+	assert.False(t, *got[1].IsWrite)
+
+	assert.Equal(t, editFile, got[2].Entity)
+	assert.Equal(t, heartbeat.FileType, got[2].EntityType)
+	require.NotNil(t, got[2].AILineChanges)
+	assert.Equal(t, 4, *got[2].AILineChanges)
+	require.NotNil(t, got[2].IsWrite)
+	assert.True(t, *got[2].IsWrite)
+
+	// usage from the out-of-window assistant/message must be excluded
+	assert.Equal(t, int64(100), got[3].AIInputTokens)
+	assert.Equal(t, int64(200), got[3].AICachedInputTokens)
+	assert.Equal(t, int64(50), got[3].AIOutputTokens)
+	assert.Contains(t, got[3].UserAgent, "deepseek/")
+	assert.True(t, strings.Index(got[3].UserAgent, "deepseek/") <
+		strings.Index(got[3].UserAgent, "plugin/0.0.1"))
+}
+
+func TestDshParseSkipsOldTranscripts(t *testing.T) {
+	ctx := context.Background()
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	transcriptPath := filepath.Join(
+		home, ".dsh", "sessions",
+		"--tmp-project--",
+		"session-old456",
+		"session.jsonl.zstd",
+	)
+
+	dshCompressTranscript(t, transcriptPath, []string{
+		dshJSONLine(t, map[string]interface{}{
+			"type": "session",
+			"id":   "session-old456",
+			"cwd":  home,
+		}),
+		dshJSONLine(t, map[string]interface{}{
+			"type": "user/message",
+			"time": 1776600001000,
+			"data": map[string]interface{}{
+				"role":    "user",
+				"content": []map[string]interface{}{{"type": "text", "text": "old activity"}},
+			},
+		}),
+	})
+
+	old := time.Date(2026, 4, 19, 11, 0, 0, 0, time.UTC)
+	require.NoError(t, os.Chtimes(transcriptPath, old, old))
+
+	parser := ai.Dsh{After: time.Date(2026, 4, 19, 12, 0, 0, 0, time.UTC)}
+
+	got, err := parser.Parse(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestDshParseMissingDirectory(t *testing.T) {
+	ctx := context.Background()
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	parser := ai.Dsh{After: time.Now().Add(-time.Minute)}
+
+	got, err := parser.Parse(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}


### PR DESCRIPTION
Reads zstd-compressed session transcripts:

  - `~/.dsh/sessions/**/session-*/session.jsonl.zstd` — session ID, project cwd, user prompts, model metadata, token usage with cache reads, and `edit`/`write` tool calls for per-file heartbeats.
  - Sub-agent sessions are parsed too, since file edits made by sub-agents only appear there.
  - Search tools (`grep`, `glob`) are skipped because their `path` argument is a directory root, not a file.

Adds `github.com/klauspost/compress` for streaming zstd decompression.

`DSH_HOME` overrides the default `~/.dsh`.
