### PR TITLE
Add DeepSeek ai parser

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/go-viper/encoding/ini v0.1.1
 	github.com/juju/mutex v0.0.0-20180619145857-d21b13acf4bf
 	github.com/kevinburke/ssh_config v1.4.0
+	github.com/klauspost/compress v1.19.2
 	github.com/matishsiao/goInfo v0.0.0-20241216093258-66a9250504d6
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/sftp v1.13.10

--- a/go.sum
+++ b/go.sum
@@ -86,6 +86,8 @@ github.com/juju/version v0.0.0-20210303051006-2015802527a8/go.mod h1:YUOK6VK9+V4
 github.com/julienschmidt/httprouter v1.1.1-0.20151013225520-77a895ad01eb/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kevinburke/ssh_config v1.4.0 h1:6xxtP5bZ2E4NF5tuQulISpTO2z8XbtH8cg1PWkxoFkQ=
 github.com/kevinburke/ssh_config v1.4.0/go.mod h1:q2RIzfka+BXARoNexmF9gkxEX7DmvbW9P4hIVx2Kg4M=
+github.com/klauspost/compress v1.19.2 h1:hMRETovs/pu/dVWN7zIT1PGG8t509MwT6bO7XSi26R8=
+github.com/klauspost/compress v1.19.2/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=

--- a/pkg/ai/ai.go
+++ b/pkg/ai/ai.go
@@ -135,6 +135,8 @@ const (
 	ZedParser
 	// ZerostackParser is the parser ID for Zerostack.
 	ZerostackParser
+	// DeepSeekParser is the parser ID for DeepSeek Harness.
+	DeepSeekParser
 )
 
 type (
@@ -272,6 +274,11 @@ func parseAIHeartbeats(
 			FallbackUserAgent: config.Plugin,
 		},
 		Codex{
+			After:             after,
+			UserAgents:        userAgents,
+			FallbackUserAgent: config.Plugin,
+		},
+		DeepSeek{
 			After:             after,
 			UserAgents:        userAgents,
 			FallbackUserAgent: config.Plugin,

--- a/pkg/ai/deepseek.go
+++ b/pkg/ai/deepseek.go
@@ -1,0 +1,906 @@
+package ai
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/klauspost/compress/zstd"
+
+	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
+	"github.com/wakatime/wakatime-cli/pkg/ini"
+	"github.com/wakatime/wakatime-cli/pkg/log"
+)
+
+// DeepSeek contains parameters for detecting heartbeats from DeepSeek Harness session transcripts.
+type DeepSeek ParserConfig
+
+type (
+	dshSessionState struct {
+		cwd        string
+		id         string
+		seedLength int
+	}
+
+	dshParseState struct {
+		eventIndex              int
+		heartbeats              Heartbeats
+		model                   string
+		pendingPromptHeartbeats []int
+		pendingTools            map[string]dshToolCall
+		pendingUsage            *dshPendingUsage
+		tokens                  heartbeat.AITokens
+	}
+
+	dshSessionHeader struct {
+		Type       string `json:"type"`
+		ID         string `json:"id"`
+		Cwd        string `json:"cwd"`
+		SeedLength int    `json:"seedLength"`
+	}
+
+	dshMessageSource struct {
+		Kind     string `json:"kind"`
+		Provider string `json:"provider"`
+		Model    string `json:"model"`
+		CallID   string `json:"callId"`
+	}
+
+	dshContentBlock struct {
+		Type       string            `json:"type"`
+		Text       string            `json:"text"`
+		ToolCallID string            `json:"toolCallId"`
+		IsError    bool              `json:"isError"`
+		Content    []dshContentBlock `json:"content"`
+	}
+
+	dshMessage struct {
+		Role    string            `json:"role"`
+		Content []dshContentBlock `json:"content"`
+		Source  *dshMessageSource `json:"source"`
+	}
+
+	dshUsage struct {
+		InputTokens      *int64 `json:"inputTokens"`
+		OutputTokens     *int64 `json:"outputTokens"`
+		CacheReadTokens  *int64 `json:"cacheReadTokens"`
+		CacheWriteTokens *int64 `json:"cacheWriteTokens"`
+	}
+
+	dshChunk struct {
+		Type   string           `json:"type"`
+		Usage  *dshUsage        `json:"usage"`
+		Reason *dshFinishReason `json:"reason"`
+	}
+
+	dshFinishReason struct {
+		Kind string `json:"kind"`
+	}
+
+	dshRequestHeader struct {
+		Config *dshRequestConfig `json:"config"`
+	}
+
+	dshRequestConfig struct {
+		Provider string `json:"provider"`
+		Model    string `json:"model"`
+	}
+
+	dshEventError struct {
+		Name string `json:"name"`
+		Code string `json:"code"`
+	}
+
+	dshEventData struct {
+		Turn       int               `json:"turn"`
+		Step       int               `json:"step"`
+		Role       string            `json:"role"`
+		Content    []dshContentBlock `json:"content"`
+		Source     *dshMessageSource `json:"source"`
+		Provenance *dshMessageSource `json:"provenance"`
+		Message    *dshMessage       `json:"message"`
+		Usage      *dshUsage         `json:"usage"`
+		Chunk      *dshChunk         `json:"chunk"`
+		CallID     string            `json:"callId"`
+		Name       string            `json:"name"`
+		Arguments  json.RawMessage   `json:"arguments"`
+		IsError    bool              `json:"isError"`
+		Provider   string            `json:"provider"`
+		Model      string            `json:"model"`
+		Header     *dshRequestHeader `json:"header"`
+		Error      *dshEventError    `json:"error"`
+	}
+
+	dshLogLine struct {
+		Type string       `json:"type"`
+		Seq  *int         `json:"seq"`
+		Time int64        `json:"time"`
+		Data dshEventData `json:"data"`
+	}
+
+	dshToolCall struct {
+		arguments map[string]interface{}
+		name      string
+	}
+
+	dshPendingUsage struct {
+		turn      int
+		step      int
+		timestamp time.Time
+		usage     dshUsage
+	}
+
+	dshTranscriptReader struct {
+		closer io.Closer
+		reader io.Reader
+	}
+)
+
+// Parse parses DeepSeek Harness JSONL session transcripts for AI heartbeats.
+func (g DeepSeek) Parse(ctx context.Context) (Heartbeats, error) {
+	logger := log.Extract(ctx)
+
+	transcripts, err := g.transcriptPaths(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(transcripts) == 0 {
+		return Heartbeats{}, nil
+	}
+
+	logger.Debugf("Found %d transcript logs modified after %s for %s", len(transcripts), g.After, g.Name())
+
+	var heartbeats Heartbeats
+
+	for _, transcript := range transcripts {
+		parsed, err := g.parseTranscript(ctx, transcript)
+		if err != nil {
+			logger.Warnf("failed parsing deepseek harness transcript %q: %s", transcript, err)
+			continue
+		}
+
+		heartbeats = append(heartbeats, parsed...)
+	}
+
+	return heartbeats, nil
+}
+
+func (g DeepSeek) transcriptPaths(ctx context.Context) ([]string, error) {
+	sessionsDir, err := dshSessionsDir(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := os.Stat(sessionsDir); err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+
+		return nil, fmt.Errorf("failed to stat .dsh sessions directory: %s", err)
+	}
+
+	var transcripts []string
+
+	err = filepath.WalkDir(sessionsDir, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+
+		if entry.IsDir() || !dshTranscriptName(entry.Name()) {
+			return nil
+		}
+
+		info, err := entry.Info()
+		if err != nil || !timestampAtOrAfterCutoff(info.ModTime(), g.After) {
+			return nil
+		}
+
+		transcripts = append(transcripts, path)
+
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to walk .dsh sessions directory: %s", err)
+	}
+
+	return transcripts, nil
+}
+
+func dshSessionsDir(ctx context.Context) (string, error) {
+	root := strings.TrimSpace(os.Getenv("DSH_HOME"))
+	if root == "" {
+		home, err := ini.UserHomeDir(ctx)
+		if err != nil {
+			return "", fmt.Errorf("failed to find user home dir: %s", err)
+		}
+
+		root = filepath.Join(home, ".dsh")
+	}
+
+	sessionsDir, err := filepath.Abs(filepath.Join(root, "sessions"))
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve DSH_HOME: %s", err)
+	}
+
+	return sessionsDir, nil
+}
+
+func dshTranscriptName(name string) bool {
+	return name == "session.jsonl" || name == "session.jsonl.zstd"
+}
+
+func (g DeepSeek) parseTranscript(ctx context.Context, transcript string) (Heartbeats, error) {
+	logger := log.Extract(ctx)
+
+	stream, err := dshOpenTranscript(transcript)
+	if err != nil {
+		return nil, err
+	}
+	defer stream.closer.Close() // nolint:errcheck
+
+	scanner := bufio.NewScanner(stream.reader)
+	scanner.Buffer(make([]byte, 0, 64*1024), maxTranscriptLineSize)
+
+	session := dshSessionState{id: filepath.Base(filepath.Dir(transcript))}
+	if scanner.Scan() {
+		g.readSessionHeader(logger, transcript, scanner.Bytes(), &session)
+	}
+
+	state := dshParseState{pendingTools: make(map[string]dshToolCall)}
+
+	for scanner.Scan() {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
+		g.handleTranscriptLine(logger, transcript, scanner.Bytes(), session, &state)
+	}
+
+	// DSH appends independent zstd frames. A concurrent reader can reach an incomplete
+	// final frame after decoding all previously committed lines, which are still safe to use.
+	if err := scanner.Err(); err != nil &&
+		(!strings.HasSuffix(transcript, ".zstd") || !errors.Is(err, io.ErrUnexpectedEOF)) {
+		return nil, fmt.Errorf("failed reading deepseek harness transcript %q: %s", transcript, err)
+	}
+
+	g.commitPendingUsage(session, &state)
+
+	return state.heartbeats, nil
+}
+
+func dshOpenTranscript(transcript string) (dshTranscriptReader, error) {
+	//nolint:gosec
+	fh, err := os.Open(filepath.Clean(transcript))
+	if err != nil {
+		return dshTranscriptReader{}, fmt.Errorf("failed to open deepseek harness transcript %q: %s", transcript, err)
+	}
+
+	if !strings.HasSuffix(transcript, ".zstd") {
+		return dshTranscriptReader{closer: fh, reader: fh}, nil
+	}
+
+	decoder, err := zstd.NewReader(fh)
+	if err != nil {
+		fh.Close() // nolint:errcheck,gosec
+
+		return dshTranscriptReader{}, fmt.Errorf(
+			"failed to create zstd reader for deepseek harness transcript %q: %s", transcript, err,
+		)
+	}
+
+	return dshTranscriptReader{
+		closer: dshCombinedCloser{decoder: decoder, file: fh},
+		reader: decoder,
+	}, nil
+}
+
+type dshCombinedCloser struct {
+	decoder *zstd.Decoder
+	file    *os.File
+}
+
+func (c dshCombinedCloser) Close() error {
+	c.decoder.Close()
+
+	return c.file.Close()
+}
+
+func (DeepSeek) readSessionHeader(
+	logger *log.Logger,
+	transcript string,
+	line []byte,
+	session *dshSessionState,
+) {
+	if len(line) == 0 {
+		return
+	}
+
+	var header dshSessionHeader
+	if err := json.Unmarshal(line, &header); err != nil {
+		logger.Warnf("failed parsing deepseek harness session header from %q: %s", transcript, err)
+
+		return
+	}
+
+	if header.Type != "session" {
+		logger.Warnf("missing deepseek harness session header in %q", transcript)
+
+		return
+	}
+
+	if header.ID != "" {
+		session.id = header.ID
+	}
+
+	if header.Cwd != "" {
+		session.cwd = header.Cwd
+	}
+
+	if header.SeedLength > 0 {
+		session.seedLength = header.SeedLength
+	}
+}
+
+func (g DeepSeek) handleTranscriptLine(
+	logger *log.Logger,
+	transcript string,
+	line []byte,
+	session dshSessionState,
+	state *dshParseState,
+) {
+	if len(line) == 0 {
+		return
+	}
+
+	var logLine dshLogLine
+	if err := json.Unmarshal(line, &logLine); err != nil {
+		logger.Warnf("failed parsing deepseek harness transcript line from %q: %s", transcript, err)
+		logger.Debugf("failed parsing deepseek harness transcript line: %s", line)
+
+		return
+	}
+
+	eventIndex := state.eventIndex
+	state.eventIndex++
+
+	if dshSeedEvent(logLine.Seq, eventIndex, session.seedLength) {
+		return
+	}
+
+	timestamp := time.UnixMilli(logLine.Time).UTC()
+
+	switch logLine.Type {
+	case "request/header", "request/context":
+		g.trackModel(logLine, state)
+	case "user/message":
+		g.handleUserMessage(timestamp, logLine, session, state)
+	case "assistant/chunk":
+		g.handleAssistantChunk(timestamp, logLine, session, state)
+	case "assistant/message":
+		g.handleAssistantMessage(timestamp, logLine, session, state)
+	case "tool/call":
+		state.handleToolCall(logLine)
+	case "tool/result":
+		g.handleToolResult(timestamp, logLine, session, state)
+	case "compaction/summary":
+		g.commitUsage(logLine.Data.Usage, timestamp, session, state)
+	}
+}
+
+func dshSeedEvent(seq *int, eventIndex int, seedLength int) bool {
+	if seedLength <= 0 {
+		return false
+	}
+
+	if seq != nil {
+		return *seq < seedLength
+	}
+
+	return eventIndex < seedLength
+}
+
+func (g DeepSeek) trackModel(logLine dshLogLine, state *dshParseState) {
+	var model string
+
+	if logLine.Type == "request/header" && logLine.Data.Header != nil && logLine.Data.Header.Config != nil {
+		model = logLine.Data.Header.Config.Model
+	} else {
+		model = logLine.Data.Model
+	}
+
+	g.setModel(state, model)
+}
+
+func (g DeepSeek) setModel(state *dshParseState, model string) {
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return
+	}
+
+	state.model = model
+
+	for _, i := range state.pendingPromptHeartbeats {
+		if i < 0 || i >= len(state.heartbeats) {
+			continue
+		}
+
+		entity := state.heartbeats[i].Entity
+		state.heartbeats[i].UserAgent = aiUserAgentWithModel(
+			entity,
+			g.UserAgents,
+			g.FallbackUserAgent,
+			model,
+			"",
+		)
+	}
+
+	state.pendingPromptHeartbeats = nil
+}
+
+func (g DeepSeek) handleUserMessage(
+	timestamp time.Time,
+	logLine dshLogLine,
+	session dshSessionState,
+	state *dshParseState,
+) {
+	if logLine.Time <= 0 || !timestampAtOrAfterCutoff(timestamp, g.After) ||
+		logLine.Data.Source == nil || logLine.Data.Source.Kind != "user" {
+		return
+	}
+
+	var promptChars int
+
+	for _, block := range logLine.Data.Content {
+		if block.Type == "text" {
+			promptChars += promptLength(block.Text)
+		}
+	}
+
+	if promptChars == 0 {
+		return
+	}
+
+	h := g.appHeartbeat(timestamp, session, state)
+	h.AIPromptLength = promptChars
+	state.appendHeartbeat(h)
+	// The request header follows user/message, so update this heartbeat when that header arrives.
+	state.pendingPromptHeartbeats = append(state.pendingPromptHeartbeats, len(state.heartbeats)-1)
+}
+
+func (g DeepSeek) handleAssistantChunk(
+	timestamp time.Time,
+	logLine dshLogLine,
+	session dshSessionState,
+	state *dshParseState,
+) {
+	chunk := logLine.Data.Chunk
+	if chunk == nil {
+		return
+	}
+
+	switch chunk.Type {
+	case "usage":
+		if chunk.Usage == nil {
+			return
+		}
+
+		if state.pendingUsage != nil &&
+			(state.pendingUsage.turn != logLine.Data.Turn || state.pendingUsage.step != logLine.Data.Step) {
+			g.commitPendingUsage(session, state)
+		}
+
+		state.pendingUsage = &dshPendingUsage{
+			turn:      logLine.Data.Turn,
+			step:      logLine.Data.Step,
+			timestamp: timestamp,
+			usage:     *chunk.Usage,
+		}
+	case "finish":
+		if chunk.Reason != nil && (chunk.Reason.Kind == "error" || chunk.Reason.Kind == "aborted") {
+			g.commitPendingUsage(session, state)
+		}
+	}
+}
+
+func (g DeepSeek) handleAssistantMessage(
+	timestamp time.Time,
+	logLine dshLogLine,
+	session dshSessionState,
+	state *dshParseState,
+) {
+	message := logLine.Data.Message
+	if message == nil {
+		message = &dshMessage{Role: logLine.Data.Role, Content: logLine.Data.Content, Source: logLine.Data.Source}
+	}
+
+	modelSource := message.Source
+	if modelSource == nil {
+		modelSource = logLine.Data.Provenance
+	}
+
+	if modelSource != nil && modelSource.Model != "" {
+		g.setModel(state, modelSource.Model)
+	}
+
+	if logLine.Time > 0 && timestampAtOrAfterCutoff(timestamp, g.After) {
+		if h := g.assistantHeartbeat(timestamp, session, state, message); h != nil {
+			state.appendHeartbeat(*h)
+		}
+	}
+
+	usage := logLine.Data.Usage
+	usageTimestamp := timestamp
+
+	if state.pendingUsage != nil && state.pendingUsage.turn == logLine.Data.Turn &&
+		state.pendingUsage.step == logLine.Data.Step {
+		if usage == nil {
+			usage = &state.pendingUsage.usage
+			usageTimestamp = state.pendingUsage.timestamp
+		}
+
+		state.pendingUsage = nil
+	}
+
+	g.commitUsage(usage, usageTimestamp, session, state)
+}
+
+func (s *dshParseState) handleToolCall(logLine dshLogLine) {
+	if logLine.Data.CallID == "" || logLine.Data.Name == "" {
+		return
+	}
+
+	s.pendingTools[logLine.Data.CallID] = dshToolCall{
+		arguments: dshToolArguments(logLine.Data.Arguments),
+		name:      logLine.Data.Name,
+	}
+}
+
+func (g DeepSeek) handleToolResult(
+	timestamp time.Time,
+	logLine dshLogLine,
+	session dshSessionState,
+	state *dshParseState,
+) {
+	callID, failed := dshToolResult(logLine.Data)
+	if callID == "" {
+		return
+	}
+
+	call, ok := state.pendingTools[callID]
+	if !ok {
+		return
+	}
+
+	delete(state.pendingTools, callID)
+
+	if failed || logLine.Time <= 0 || !timestampAtOrAfterCutoff(timestamp, g.After) {
+		return
+	}
+
+	filePath, isWrite, lineChanges := dshToolHeartbeatInfo(call, session.cwd)
+	if filePath == "" || dshDirectoryViewResult(call, logLine.Data, filePath) {
+		return
+	}
+
+	h := heartbeat.NewWithAITokens(
+		heartbeat.PointerTo(lineChanges),
+		session.id,
+		state.tokens,
+		"",
+		heartbeat.AICodingCategory.String(),
+		nil,
+		filePath,
+		heartbeat.FileType,
+		nil,
+		false,
+		heartbeat.PointerTo(isWrite),
+		nil,
+		"",
+		nil,
+		nil,
+		"",
+		"",
+		false,
+		"",
+		"",
+		heartbeatTimestamp(timestamp),
+		aiUserAgentWithModel(filePath, g.UserAgents, g.FallbackUserAgent, state.model, ""),
+	)
+	state.appendHeartbeat(h)
+}
+
+func dshToolResult(data dshEventData) (string, bool) {
+	failed := data.Error != nil || data.IsError
+	callID := data.CallID
+
+	if data.Message == nil {
+		return callID, failed
+	}
+
+	if callID == "" && data.Message.Source != nil {
+		callID = data.Message.Source.CallID
+	}
+
+	for _, block := range data.Message.Content {
+		if block.Type != "tool-result" {
+			continue
+		}
+
+		if callID == "" {
+			callID = block.ToolCallID
+		}
+
+		failed = failed || block.IsError
+	}
+
+	return callID, failed
+}
+
+func dshDirectoryViewResult(call dshToolCall, data dshEventData, filePath string) bool {
+	if !strings.EqualFold(strings.TrimSpace(call.name), "str_replace_editor") ||
+		!strings.EqualFold(strings.TrimSpace(piStringValue(call.arguments, "command")), "view") {
+		return false
+	}
+
+	if dshContentHasDirectoryListing(data.Content) ||
+		(data.Message != nil && dshContentHasDirectoryListing(data.Message.Content)) {
+		return true
+	}
+
+	info, err := os.Stat(filepath.FromSlash(filePath))
+
+	return err == nil && info.IsDir()
+}
+
+func dshContentHasDirectoryListing(blocks []dshContentBlock) bool {
+	for _, block := range blocks {
+		if block.Type == "text" && strings.HasPrefix(
+			strings.TrimSpace(block.Text),
+			"Here're the files and directories up to 2 levels deep in ",
+		) {
+			return true
+		}
+
+		if dshContentHasDirectoryListing(block.Content) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (g DeepSeek) assistantHeartbeat(
+	timestamp time.Time,
+	session dshSessionState,
+	state *dshParseState,
+	message *dshMessage,
+) *heartbeat.Heartbeat {
+	if message == nil || message.Role != "assistant" {
+		return nil
+	}
+
+	var lineChanges int
+
+	for _, block := range message.Content {
+		if block.Type == "text" && strings.TrimSpace(block.Text) != "" {
+			lineChanges += countStringLines(block.Text)
+		}
+	}
+
+	if lineChanges == 0 {
+		return nil
+	}
+
+	h := g.appHeartbeat(timestamp, session, state)
+
+	return &h
+}
+
+func (g DeepSeek) appHeartbeat(
+	timestamp time.Time,
+	session dshSessionState,
+	state *dshParseState,
+) heartbeat.Heartbeat {
+	entity := g.Name()
+
+	return heartbeat.NewWithAITokens(
+		nil,
+		session.id,
+		state.tokens,
+		"",
+		heartbeat.AICodingCategory.String(),
+		nil,
+		entity,
+		heartbeat.AppType,
+		nil,
+		false,
+		heartbeat.PointerTo(false),
+		nil,
+		"",
+		nil,
+		nil,
+		"",
+		"",
+		false,
+		"",
+		session.cwd,
+		heartbeatTimestamp(timestamp),
+		aiUserAgentWithModel(entity, g.UserAgents, g.FallbackUserAgent, state.model, ""),
+	)
+}
+
+func (s *dshParseState) appendHeartbeat(h heartbeat.Heartbeat) {
+	s.heartbeats = append(s.heartbeats, h)
+	s.advanceTokens()
+}
+
+func (g DeepSeek) commitPendingUsage(session dshSessionState, state *dshParseState) {
+	if state.pendingUsage == nil {
+		return
+	}
+
+	pending := state.pendingUsage
+	state.pendingUsage = nil
+	g.commitUsage(&pending.usage, pending.timestamp, session, state)
+}
+
+func (g DeepSeek) commitUsage(
+	usage *dshUsage,
+	timestamp time.Time,
+	session dshSessionState,
+	state *dshParseState,
+) {
+	if usage != nil && !timestamp.IsZero() && timestampAtOrAfterCutoff(timestamp, g.After) &&
+		len(state.heartbeats) == 0 && dshUsageHasTokens(*usage) {
+		state.appendHeartbeat(g.appHeartbeat(timestamp, session, state))
+	}
+
+	state.commitUsage(usage, timestamp, g.After)
+}
+
+func (s *dshParseState) commitUsage(usage *dshUsage, timestamp time.Time, after time.Time) {
+	if usage == nil {
+		return
+	}
+
+	s.tokens.CurrentInput += dshTokenValue(usage.InputTokens) + dshTokenValue(usage.CacheWriteTokens)
+	s.tokens.CurrentCachedInput += dshTokenValue(usage.CacheReadTokens)
+	s.tokens.CurrentOutput += dshTokenValue(usage.OutputTokens)
+
+	if timestamp.IsZero() || !timestampAtOrAfterCutoff(timestamp, after) {
+		s.advanceTokens()
+
+		return
+	}
+
+	s.attachTokensToLastHeartbeat()
+}
+
+func dshTokenValue(value *int64) int64 {
+	if value == nil || *value < 0 {
+		return 0
+	}
+
+	return *value
+}
+
+func dshUsageHasTokens(usage dshUsage) bool {
+	return dshTokenValue(usage.InputTokens) > 0 || dshTokenValue(usage.OutputTokens) > 0 ||
+		dshTokenValue(usage.CacheReadTokens) > 0 || dshTokenValue(usage.CacheWriteTokens) > 0
+}
+
+func (s *dshParseState) attachTokensToLastHeartbeat() {
+	input := max(s.tokens.CurrentInput-s.tokens.LastInput, 0)
+	cachedInput := max(s.tokens.CurrentCachedInput-s.tokens.LastCachedInput, 0)
+	output := max(s.tokens.CurrentOutput-s.tokens.LastOutput, 0)
+
+	if len(s.heartbeats) > 0 {
+		i := len(s.heartbeats) - 1
+		s.heartbeats[i].AIInputTokens += input
+		s.heartbeats[i].AICachedInputTokens += cachedInput
+		s.heartbeats[i].AIOutputTokens += output
+	}
+
+	s.advanceTokens()
+}
+
+func (s *dshParseState) advanceTokens() {
+	s.tokens.LastInput = s.tokens.CurrentInput
+	s.tokens.LastCachedInput = s.tokens.CurrentCachedInput
+	s.tokens.LastOutput = s.tokens.CurrentOutput
+}
+
+func dshToolArguments(raw json.RawMessage) map[string]interface{} {
+	if len(raw) == 0 {
+		return nil
+	}
+
+	var arguments map[string]interface{}
+	if err := json.Unmarshal(raw, &arguments); err == nil {
+		return arguments
+	}
+
+	var encoded string
+	if err := json.Unmarshal(raw, &encoded); err != nil {
+		return nil
+	}
+
+	if err := json.Unmarshal([]byte(encoded), &arguments); err != nil {
+		return nil
+	}
+
+	return arguments
+}
+
+func dshToolHeartbeatInfo(call dshToolCall, cwd string) (string, bool, int) {
+	name := strings.ToLower(strings.TrimSpace(call.name))
+
+	switch name {
+	case "read", "read_image":
+		return dshToolPath(call.arguments, cwd, "file_path"), false, 0
+	case "write":
+		return dshToolPath(call.arguments, cwd, "file_path"), true,
+			dshTextLineCount(piStringValue(call.arguments, "content"))
+	case "edit":
+		return dshToolPath(call.arguments, cwd, "file_path"), true,
+			dshReplacementLineChanges(call.arguments, "old_string", "new_string")
+	case "str_replace_editor":
+		return dshStrReplaceEditorInfo(call.arguments, cwd)
+	default:
+		return "", false, 0
+	}
+}
+
+func dshStrReplaceEditorInfo(arguments map[string]interface{}, cwd string) (string, bool, int) {
+	path := dshToolPath(arguments, cwd, "path")
+
+	switch strings.ToLower(piStringValue(arguments, "command")) {
+	case "view":
+		return path, false, 0
+	case "create":
+		return path, true, dshTextLineCount(piStringValue(arguments, "file_text"))
+	case "insert":
+		return path, true, dshTextLineCount(piStringValue(arguments, "new_str"))
+	case "str_replace":
+		return path, true, dshReplacementLineChanges(arguments, "old_str", "new_str")
+	default:
+		return "", false, 0
+	}
+}
+
+func dshToolPath(arguments map[string]interface{}, cwd string, key string) string {
+	path := strings.TrimSpace(piStringValue(arguments, key))
+	if path == "" {
+		return ""
+	}
+
+	if !filepath.IsAbs(path) && cwd != "" {
+		path = filepath.Join(cwd, path)
+	}
+
+	return filepath.ToSlash(filepath.Clean(path))
+}
+
+func dshReplacementLineChanges(arguments map[string]interface{}, oldKey string, newKey string) int {
+	return dshTextLineCount(piStringValue(arguments, newKey)) -
+		dshTextLineCount(piStringValue(arguments, oldKey))
+}
+
+func dshTextLineCount(text string) int {
+	if text == "" {
+		return 0
+	}
+
+	return countStringLines(text)
+}
+
+// Name returns the parser name.
+func (DeepSeek) Name() string { return "DeepSeek Harness" }

--- a/pkg/ai/deepseek_test.go
+++ b/pkg/ai/deepseek_test.go
@@ -1,0 +1,475 @@
+package ai_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/klauspost/compress/zstd"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wakatime/wakatime-cli/pkg/ai"
+	"github.com/wakatime/wakatime-cli/pkg/heartbeat"
+)
+
+func TestDeepSeekParseCompressedTranscript(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("DSH_HOME", "")
+
+	projectDir := filepath.Join(home, "project")
+	readFile := filepath.ToSlash(filepath.Join(projectDir, "README.md"))
+	editFile := filepath.ToSlash(filepath.Join(projectDir, "main.go"))
+	transcript := filepath.Join(home, ".dsh", "sessions", "--project--", "session-abc", "session.jsonl.zstd")
+	start := time.Date(2026, 4, 19, 12, 0, 0, 0, time.UTC)
+
+	dshWriteCompressedTranscript(t, transcript, []interface{}{
+		map[string]interface{}{"type": "session", "id": "session-abc", "cwd": projectDir},
+		dshEvent("user/message", 0, start, map[string]interface{}{
+			"role": "user", "source": map[string]interface{}{"kind": "plugin"},
+			"content": []map[string]interface{}{{"type": "text", "text": "injected context"}},
+		}),
+		dshEvent("user/message", 1, start.Add(time.Second), map[string]interface{}{
+			"role": "user", "source": map[string]interface{}{"kind": "user"},
+			"content": []map[string]interface{}{{"type": "text", "text": "Fix main.go"}},
+		}),
+		dshEvent("request/header", 2, start.Add(2*time.Second), map[string]interface{}{
+			"header": map[string]interface{}{"config": map[string]interface{}{
+				"provider": "deepseek", "model": "deepseek-v4",
+			}},
+		}),
+		dshEvent("assistant/chunk", 3, start.Add(3*time.Second), map[string]interface{}{
+			"turn": 1, "step": 1,
+			"chunk": map[string]interface{}{"type": "usage", "usage": map[string]interface{}{
+				"inputTokens": 10, "cacheReadTokens": 3, "cacheWriteTokens": 2, "outputTokens": 5,
+			}},
+		}),
+		dshEvent("assistant/chunk", 4, start.Add(4*time.Second), map[string]interface{}{
+			"turn": 1, "step": 1,
+			"chunk": map[string]interface{}{"type": "finish", "reason": map[string]interface{}{"kind": "error"}},
+		}),
+		dshEvent("assistant/chunk", 5, start.Add(5*time.Second), map[string]interface{}{
+			"turn": 1, "step": 1,
+			"chunk": map[string]interface{}{"type": "usage", "usage": map[string]interface{}{
+				"inputTokens": 20, "cacheReadTokens": 7, "cacheWriteTokens": 1, "outputTokens": 8,
+			}},
+		}),
+		dshEvent("assistant/chunk", 6, start.Add(6*time.Second), map[string]interface{}{
+			"turn": 1, "step": 1,
+			"chunk": map[string]interface{}{"type": "finish", "reason": map[string]interface{}{"kind": "stop"}},
+		}),
+		dshEvent("assistant/message", 7, start.Add(7*time.Second), map[string]interface{}{
+			"turn": 1, "step": 1,
+			"usage": map[string]interface{}{
+				"inputTokens": 20, "cacheReadTokens": 7, "cacheWriteTokens": 1, "outputTokens": 8,
+			},
+			"message": map[string]interface{}{
+				"role": "assistant", "source": map[string]interface{}{
+					"kind": "model", "provider": "deepseek", "model": "deepseek-v4",
+				},
+				"content": []map[string]interface{}{{"type": "text", "text": "I will update it."}},
+			},
+		}),
+		dshEvent("tool/call", 8, start.Add(8*time.Second), map[string]interface{}{
+			"callId": "read-1", "name": "read", "arguments": `{"file_path":"README.md"}`,
+		}),
+		dshToolResultEvent(9, start.Add(9*time.Second), "read-1", false),
+		dshEvent("tool/call", 10, start.Add(10*time.Second), map[string]interface{}{
+			"callId": "edit-1", "name": "edit",
+			"arguments": `{"file_path":"main.go","old_string":"old\n","new_string":"new\nmore\n"}`,
+		}),
+		dshToolResultEvent(11, start.Add(11*time.Second), "edit-1", false),
+		dshEvent("tool/call", 12, start.Add(12*time.Second), map[string]interface{}{
+			"callId": "write-failed", "name": "write",
+			"arguments": `{"file_path":"failed.go","content":"package failed\n"}`,
+		}),
+		dshToolResultEvent(13, start.Add(13*time.Second), "write-failed", true),
+		dshEvent("tool/call", 14, start.Add(14*time.Second), map[string]interface{}{
+			"callId": "grep-1", "name": "grep", "arguments": `{"path":".","pattern":"TODO"}`,
+		}),
+		dshToolResultEvent(15, start.Add(15*time.Second), "grep-1", false),
+		dshEvent("tool/call", 16, start.Add(16*time.Second), map[string]interface{}{
+			"callId": "create-1", "name": "str_replace_editor",
+			"arguments": `{"command":"create","path":"created.go","file_text":"package created\n"}`,
+		}),
+		dshToolResultEvent(17, start.Add(17*time.Second), "create-1", false),
+		dshEvent("tool/call", 18, start.Add(18*time.Second), map[string]interface{}{
+			"callId": "view-dir", "name": "str_replace_editor",
+			"arguments": `{"command":"view","path":"project"}`,
+		}),
+		dshToolResultEventWithText(
+			19,
+			start.Add(19*time.Second),
+			"view-dir",
+			false,
+			"Here're the files and directories up to 2 levels deep in project, excluding hidden items",
+		),
+	})
+
+	parser := ai.DeepSeek{
+		After:             start.Add(-time.Minute),
+		FallbackUserAgent: "plugin/0.0.1",
+		UserAgents: map[string]string{
+			editFile: heartbeat.UserAgent(ctx, "editor/1.2.3"),
+		},
+	}
+
+	got, err := parser.Parse(ctx)
+	require.NoError(t, err)
+	require.Len(t, got, 5)
+
+	assert.Equal(t, "DeepSeek Harness", got[0].Entity)
+	assert.Equal(t, heartbeat.AppType, got[0].EntityType)
+	assert.Equal(t, "session-abc", got[0].AISession)
+	assert.Equal(t, len([]rune("Fix main.go")), got[0].AIPromptLength)
+	assert.Equal(t, projectDir, got[0].ProjectPathOverride)
+	assert.Equal(t, int64(12), got[0].AIInputTokens)
+	assert.Equal(t, int64(3), got[0].AICachedInputTokens)
+	assert.Equal(t, int64(5), got[0].AIOutputTokens)
+	assert.Contains(t, got[0].UserAgent, "deepseek/4")
+
+	assert.Equal(t, "DeepSeek Harness", got[1].Entity)
+	assert.Equal(t, int64(21), got[1].AIInputTokens)
+	assert.Equal(t, int64(7), got[1].AICachedInputTokens)
+	assert.Equal(t, int64(8), got[1].AIOutputTokens)
+	assert.Contains(t, got[1].UserAgent, "deepseek/4")
+
+	assert.Equal(t, readFile, got[2].Entity)
+	assert.Equal(t, heartbeat.FileType, got[2].EntityType)
+	require.NotNil(t, got[2].IsWrite)
+	assert.False(t, *got[2].IsWrite)
+
+	assert.Equal(t, editFile, got[3].Entity)
+	require.NotNil(t, got[3].AILineChanges)
+	assert.Equal(t, 1, *got[3].AILineChanges)
+	require.NotNil(t, got[3].IsWrite)
+	assert.True(t, *got[3].IsWrite)
+	assert.Contains(t, got[3].UserAgent, "editor/1.2.3")
+
+	assert.Equal(t, filepath.ToSlash(filepath.Join(projectDir, "created.go")), got[4].Entity)
+	require.NotNil(t, got[4].AILineChanges)
+	assert.Equal(t, 2, *got[4].AILineChanges)
+	require.NotNil(t, got[4].IsWrite)
+	assert.True(t, *got[4].IsWrite)
+}
+
+func TestDeepSeekParseUncompressedTranscriptFromConfiguredHome(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	dshHome := filepath.Join(home, "configured-dsh")
+	t.Setenv("HOME", filepath.Join(home, "unused-home"))
+	t.Setenv("USERPROFILE", filepath.Join(home, "unused-home"))
+	t.Setenv("DSH_HOME", dshHome)
+
+	start := time.Date(2026, 4, 19, 12, 0, 0, 0, time.UTC)
+	transcript := filepath.Join(dshHome, "sessions", "--project--", "session-raw", "session.jsonl")
+	dshWriteRawTranscript(t, transcript, []interface{}{
+		map[string]interface{}{"type": "session", "id": "session-raw", "cwd": home},
+		dshEvent("user/message", 0, start, map[string]interface{}{
+			"role": "user", "source": map[string]interface{}{"kind": "user"},
+			"content": []map[string]interface{}{{"type": "text", "text": "Raw transcript prompt"}},
+		}),
+		dshEvent("assistant/message", 1, start.Add(time.Second), map[string]interface{}{
+			"turn": 1, "step": 1,
+			"usage": map[string]interface{}{
+				"inputTokens": 4, "cacheReadTokens": 2, "cacheWriteTokens": 1, "outputTokens": 3,
+			},
+			"message": map[string]interface{}{
+				"role": "assistant", "source": map[string]interface{}{
+					"kind": "model", "provider": "deepseek", "model": "deepseek-v4",
+				},
+				"content": []map[string]interface{}{{"type": "text", "text": "Raw response"}},
+			},
+		}),
+	})
+
+	got, err := (ai.DeepSeek{After: start.Add(-time.Second)}).Parse(ctx)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.Equal(t, "session-raw", got[0].AISession)
+	assert.Equal(t, len([]rune("Raw transcript prompt")), got[0].AIPromptLength)
+	assert.Equal(t, int64(5), got[1].AIInputTokens)
+	assert.Equal(t, int64(2), got[1].AICachedInputTokens)
+	assert.Equal(t, int64(3), got[1].AIOutputTokens)
+}
+
+func TestDeepSeekParseCompressedTranscriptWithIncompleteTail(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	t.Setenv("DSH_HOME", home)
+
+	start := time.Date(2026, 4, 19, 12, 0, 0, 0, time.UTC)
+	transcript := filepath.Join(home, "sessions", "--project--", "session-truncated", "session.jsonl.zstd")
+	dshWriteCompressedTranscript(t, transcript, []interface{}{
+		map[string]interface{}{"type": "session", "id": "session-truncated", "cwd": home},
+		dshEvent("user/message", 0, start, map[string]interface{}{
+			"role": "user", "source": map[string]interface{}{"kind": "user"},
+			"content": []map[string]interface{}{{"type": "text", "text": "Complete prompt"}},
+		}),
+		dshEvent("user/message", 1, start.Add(time.Second), map[string]interface{}{
+			"role": "user", "source": map[string]interface{}{"kind": "user"},
+			"content": []map[string]interface{}{{"type": "text", "text": "Incomplete prompt"}},
+		}),
+	})
+
+	info, err := os.Stat(transcript)
+	require.NoError(t, err)
+	require.NoError(t, os.Truncate(transcript, info.Size()-5))
+
+	got, err := (ai.DeepSeek{After: start.Add(-time.Second)}).Parse(ctx)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, len([]rune("Complete prompt")), got[0].AIPromptLength)
+}
+
+func TestDeepSeekParseSkipsForkSeedPrefix(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("DSH_HOME", "")
+
+	start := time.Date(2026, 4, 19, 12, 0, 0, 0, time.UTC)
+	transcript := filepath.Join(home, ".dsh", "sessions", "--project--", "session-child", "session.jsonl.zstd")
+	dshWriteCompressedTranscript(t, transcript, []interface{}{
+		map[string]interface{}{
+			"type": "session", "id": "session-child", "cwd": home,
+			"parentSession": "session-parent", "seedLength": 3,
+		},
+		dshEvent("user/message", 0, start, map[string]interface{}{
+			"role": "user", "source": map[string]interface{}{"kind": "user"},
+			"content": []map[string]interface{}{{"type": "text", "text": "Inherited parent prompt"}},
+		}),
+		dshEvent("tool/call", 1, start.Add(time.Second), map[string]interface{}{
+			"callId": "inherited-read", "name": "read", "arguments": `{"file_path":"parent.go"}`,
+		}),
+		dshToolResultEvent(2, start.Add(2*time.Second), "inherited-read", false),
+		dshEvent("user/message", 3, start.Add(3*time.Second), map[string]interface{}{
+			"role": "user", "source": map[string]interface{}{"kind": "user"},
+			"content": []map[string]interface{}{{"type": "text", "text": "Child prompt"}},
+		}),
+	})
+
+	got, err := (ai.DeepSeek{After: start.Add(-time.Second)}).Parse(ctx)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "session-child", got[0].AISession)
+	assert.Equal(t, len([]rune("Child prompt")), got[0].AIPromptLength)
+}
+
+func TestDeepSeekParseSkipsOldTranscript(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("DSH_HOME", "")
+
+	start := time.Date(2026, 4, 19, 12, 0, 0, 0, time.UTC)
+	transcript := filepath.Join(home, ".dsh", "sessions", "--project--", "session-old", "session.jsonl")
+	dshWriteRawTranscript(t, transcript, []interface{}{
+		map[string]interface{}{"type": "session", "id": "session-old", "cwd": home},
+		dshEvent("user/message", 0, start, map[string]interface{}{
+			"role": "user", "source": map[string]interface{}{"kind": "user"},
+			"content": []map[string]interface{}{{"type": "text", "text": "Old prompt"}},
+		}),
+	})
+	require.NoError(t, os.Chtimes(transcript, start, start))
+
+	got, err := (ai.DeepSeek{After: start.Add(time.Minute)}).Parse(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestDeepSeekParseUsageOnlyAssistantMessage(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	t.Setenv("DSH_HOME", home)
+
+	start := time.Date(2026, 4, 19, 12, 0, 0, 0, time.UTC)
+	transcript := filepath.Join(home, "sessions", "--project--", "session-usage-only", "session.jsonl")
+	dshWriteRawTranscript(t, transcript, []interface{}{
+		map[string]interface{}{"type": "session", "id": "session-usage-only", "cwd": home},
+		dshEvent("user/message", 0, start.Add(-time.Second), map[string]interface{}{
+			"role": "user", "source": map[string]interface{}{"kind": "user"},
+			"content": []map[string]interface{}{{"type": "text", "text": "Old prompt"}},
+		}),
+		dshEvent("assistant/message", 1, start.Add(time.Second), map[string]interface{}{
+			"turn": 1, "step": 1,
+			"usage": map[string]interface{}{
+				"inputTokens": 11, "cacheReadTokens": 7, "cacheWriteTokens": 3, "outputTokens": 5,
+			},
+			"message": map[string]interface{}{
+				"role": "assistant", "content": []interface{}{},
+				"source": map[string]interface{}{
+					"kind": "model", "provider": "deepseek", "model": "deepseek-v4",
+				},
+			},
+		}),
+	})
+
+	got, err := (ai.DeepSeek{After: start}).Parse(ctx)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, heartbeat.AppType, got[0].EntityType)
+	assert.Equal(t, int64(14), got[0].AIInputTokens)
+	assert.Equal(t, int64(7), got[0].AICachedInputTokens)
+	assert.Equal(t, int64(5), got[0].AIOutputTokens)
+	assert.Contains(t, got[0].UserAgent, "deepseek/4")
+}
+
+func TestDeepSeekParseLegacyToolResultShapes(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	t.Setenv("DSH_HOME", home)
+
+	projectDir := filepath.Join(home, "project")
+	readFile := filepath.ToSlash(filepath.Join(projectDir, "README.md"))
+	start := time.Date(2026, 4, 19, 12, 0, 0, 0, time.UTC)
+	transcript := filepath.Join(home, "sessions", "--project--", "session-legacy-tools", "session.jsonl")
+	dshWriteRawTranscript(t, transcript, []interface{}{
+		map[string]interface{}{"type": "session", "id": "session-legacy-tools", "cwd": projectDir},
+		dshEvent("tool/call", 0, start, map[string]interface{}{
+			"callId": "failed-write", "name": "write",
+			"arguments": `{"file_path":"failed.go","content":"package failed\n"}`,
+		}),
+		dshEvent("tool/result", 1, start.Add(time.Second), map[string]interface{}{
+			"callId": "failed-write", "isError": true,
+			"content": []map[string]interface{}{{"type": "text", "text": "write failed"}},
+		}),
+		dshEvent("tool/call", 2, start.Add(2*time.Second), map[string]interface{}{
+			"callId": "directory-view", "name": "str_replace_editor",
+			"arguments": `{"command":"view","path":"virtual-directory"}`,
+		}),
+		dshEvent("tool/result", 3, start.Add(3*time.Second), map[string]interface{}{
+			"callId": "directory-view", "isError": false,
+			"content": []map[string]interface{}{{
+				"type": "text",
+				"text": "Here're the files and directories up to 2 levels deep in virtual-directory",
+			}},
+		}),
+		dshEvent("tool/call", 4, start.Add(4*time.Second), map[string]interface{}{
+			"callId": "successful-read", "name": "read", "arguments": `{"file_path":"README.md"}`,
+		}),
+		dshEvent("tool/result", 5, start.Add(5*time.Second), map[string]interface{}{
+			"callId": "successful-read", "isError": false,
+			"content": []map[string]interface{}{{"type": "text", "text": "contents"}},
+		}),
+	})
+
+	got, err := (ai.DeepSeek{After: start}).Parse(ctx)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, readFile, got[0].Entity)
+	require.NotNil(t, got[0].IsWrite)
+	assert.False(t, *got[0].IsWrite)
+}
+
+func TestDeepSeekParseAssistantProvenanceModel(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	t.Setenv("DSH_HOME", home)
+
+	start := time.Date(2026, 4, 19, 12, 0, 0, 0, time.UTC)
+	transcript := filepath.Join(home, "sessions", "--project--", "session-provenance", "session.jsonl")
+	dshWriteRawTranscript(t, transcript, []interface{}{
+		map[string]interface{}{"type": "session", "id": "session-provenance", "cwd": home},
+		dshEvent("user/message", 0, start, map[string]interface{}{
+			"role": "user", "source": map[string]interface{}{"kind": "user"},
+			"content": []map[string]interface{}{{"type": "text", "text": "Use the configured model"}},
+		}),
+		dshEvent("assistant/message", 1, start.Add(time.Second), map[string]interface{}{
+			"turn": 1, "step": 1, "role": "assistant",
+			"provenance": map[string]interface{}{
+				"kind": "model", "provider": "deepseek", "model": "deepseek-v4",
+			},
+			"content": []map[string]interface{}{{"type": "text", "text": "Done"}},
+		}),
+	})
+
+	got, err := (ai.DeepSeek{After: start}).Parse(ctx)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.Contains(t, got[0].UserAgent, "deepseek/4")
+	assert.Contains(t, got[1].UserAgent, "deepseek/4")
+}
+
+func dshEvent(eventType string, seq int, timestamp time.Time, data map[string]interface{}) map[string]interface{} {
+	return map[string]interface{}{
+		"type": eventType,
+		"seq":  seq,
+		"time": timestamp.UnixMilli(),
+		"data": data,
+	}
+}
+
+func dshToolResultEvent(seq int, timestamp time.Time, callID string, failed bool) map[string]interface{} {
+	return dshToolResultEventWithText(seq, timestamp, callID, failed, "result")
+}
+
+func dshToolResultEventWithText(
+	seq int,
+	timestamp time.Time,
+	callID string,
+	failed bool,
+	text string,
+) map[string]interface{} {
+	data := map[string]interface{}{
+		"message": map[string]interface{}{
+			"role": "user", "source": map[string]interface{}{"kind": "tool", "callId": callID},
+			"content": []map[string]interface{}{{
+				"type": "tool-result", "toolCallId": callID, "isError": failed,
+				"content": []map[string]interface{}{{"type": "text", "text": text}},
+			}},
+		},
+	}
+	if failed {
+		data["error"] = map[string]interface{}{"name": "ToolError", "code": "FAILED"}
+	}
+
+	return dshEvent("tool/result", seq, timestamp, data)
+}
+
+func dshWriteCompressedTranscript(t *testing.T, destination string, rows []interface{}) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(destination), 0o755))
+
+	var compressed bytes.Buffer
+	for _, row := range rows {
+		writer, err := zstd.NewWriter(&compressed)
+		require.NoError(t, err)
+
+		_, err = writer.Write(append(dshJSON(t, row), '\n'))
+		require.NoError(t, err)
+		require.NoError(t, writer.Close())
+	}
+
+	require.NoError(t, os.WriteFile(destination, compressed.Bytes(), 0o644))
+}
+
+func dshWriteRawTranscript(t *testing.T, destination string, rows []interface{}) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(destination), 0o755))
+
+	var raw bytes.Buffer
+	for _, row := range rows {
+		raw.Write(dshJSON(t, row))
+		raw.WriteByte('\n')
+	}
+
+	require.NoError(t, os.WriteFile(destination, raw.Bytes(), 0o644))
+}
+
+func dshJSON(t *testing.T, value interface{}) []byte {
+	t.Helper()
+
+	raw, err := json.Marshal(value)
+	require.NoError(t, err)
+
+	return raw
+}

--- a/pkg/ai/helpers_internal_test.go
+++ b/pkg/ai/helpers_internal_test.go
@@ -28,6 +28,7 @@ func TestParserIDStringAndPlugins(t *testing.T) {
 	assert.Equal(t, "Claude/1.2.3", aiPlugin(Claude{}, "1.2.3"))
 	assert.Equal(t, "Codex", aiPlugin(Codex{}, ""))
 	assert.Equal(t, "Codex/1.2.3", aiPlugin(Codex{}, "1.2.3"))
+	assert.Equal(t, "DeepSeek Harness", aiPlugin(DeepSeek{}, ""))
 	assert.Equal(t, "Grok Build", aiPlugin(GrokBuild{}, ""))
 	assert.Equal(t, "Grok Build/1.2.3", aiPlugin(GrokBuild{}, "1.2.3"))
 	assert.Equal(t, "opus/4.1-medium", aiModelUserAgentToken("claude-opus-4.1", "medium"))

--- a/pkg/ai/parser_empty_home_internal_test.go
+++ b/pkg/ai/parser_empty_home_internal_test.go
@@ -13,6 +13,7 @@ func TestParsersEmptyHome(t *testing.T) {
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
 	t.Setenv("CODEX_HOME", "")
+	t.Setenv("DSH_HOME", "")
 	t.Setenv("GROK_HOME", "")
 
 	after := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
@@ -32,6 +33,7 @@ func TestParsersEmptyHome(t *testing.T) {
 		CursorAgent{After: after},
 		Devin{After: after},
 		Droid{After: after},
+		DeepSeek{After: after},
 		Forge{After: after},
 		Gemini{After: after},
 		Goose{After: after},


### PR DESCRIPTION
Implemented a new DeepSeek Harness parser based on Codex’s architecture.

- Reads concatenated zstd frames and uncompressed session.jsonl.
- Honors DSH_HOME.
- Counts usage chunks, retries, message fallbacks, cache reads, and cache writes without double-counting.
- Skips inherited fork events using seedLength.
- Counts only source.kind == "user" as prompts.
- Emits file heartbeats only after successful tool results.
- Supports DSH filesystem tools and str_replace_editor.
- Normalizes file entities to forward slashes for Windows compatibility.

Closes #1538.