### PR TITLE
Default to IPv4 when local IP family detection fails

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -105,8 +105,10 @@ func isLocalIPv6(ctx context.Context) bool {
 
 	conn, err := net.Dial("udp", fmt.Sprintf("%s:80", BaseIPAddrv4))
 	if err != nil {
-		logger.Debugf("failed dialing to detect default local ip address: %s", err)
-		return true
+		// IPv4 is far more likely to be reachable than our hardcoded IPv6 address, so
+		// fall back to IPv4 when we can't determine the local address family.
+		logger.Debugf("failed dialing to detect default local ip address, falling back to ipv4: %s", err)
+		return false
 	}
 
 	defer func() {


### PR DESCRIPTION
**Describe the pull request**

This PR fixes `isLocalIPv6()` in `pkg/api/api.go` defaulting to IPv6 when it can't determine the local address family.

When a heartbeat request fails with a DNS error, wakatime-cli retries once against a hardcoded IP literal (`BaseIPAddrv4` or `BaseIPAddrv6`), choosing between them via `isLocalIPv6()`. That function probes the local address family by dialing UDP to the hardcoded IPv4 address; if that probe itself errors, it currently assumes IPv6 (`return true`).

On networks where the probe fails (e.g. a momentary missing IPv4 route, sleep/wake or VPN transitions), the hardcoded IPv6 literal is frequently unreachable too, so the retry also fails and the heartbeat is pushed into the offline queue instead of being sent - even though IPv4 to the same host is reachable. This exact failure signature (probe fails -> retries IPv6 -> `no route to host`) is visible in the log excerpt from #773, which only fixed error message preservation, not this underlying default.

Since IPv4 is far more broadly reachable than a single hardcoded IPv6 address, this PR flips the fallback default to IPv4 when detection fails. No behavior change when the local address family can be determined normally.

**Real-world impact**

I traced this from heartbeats piling up unsent in `~/.wakatime/offline_heartbeats.bdb` (one incident had 300+ queued) and found this exact failure signature in `wakatime.log`. I've hit the same pattern across several unrelated macOS machines and networks (personal laptop, a work laptop on a different organization's network), so this doesn't look specific to one network's quirks - it reproduces anywhere the local-IP-family probe is flaky, which seems fairly common in practice (network switches, sleep/wake, VPN transitions).

Confirmed with `golangci-lint run ./pkg/api/...` and `go test -race ./pkg/api/...`.
